### PR TITLE
Add correct placeholder for project description

### DIFF
--- a/frontend/components/Project/ProjectModal.tsx
+++ b/frontend/components/Project/ProjectModal.tsx
@@ -403,7 +403,7 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                                                     onChange={handleChange}
                                                     className="block w-full h-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm p-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 transition duration-150 ease-in-out resize-none"
                                                     placeholder={t(
-                                                        'forms.areaDescriptionPlaceholder',
+                                                        'forms.projectDescriptionPlaceholder',
                                                         'Enter project description (optional)'
                                                     )}
                                                     style={{

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -380,7 +380,8 @@
     "tagNamePlaceholder": "Enter tag name",
     "tagInputPlaceholder": "Type to add a tag",
     "createTagOption": "+ Create \"{{tagName}}\"",
-    "removeTagAriaLabel": "Remove tag {{tagName}}"
+    "removeTagAriaLabel": "Remove tag {{tagName}}",
+    "projectDescriptionPlaceholder": "Enter project description"
   },
   "auth": {
     "login": "Login",


### PR DESCRIPTION
Hello !
First, thank you for this project :)

In this pull request I changed the placeholder of the description in the project creation modal from "Enter area description" to "Enter project description"

I added forms.projectDescriptionPlaceholder in the english locale
Note that I did not add anything to the other locales

Before
<img width="672" height="502" alt="image" src="https://github.com/user-attachments/assets/75898c23-b04f-41cc-84e4-62b94f733af9" />

After
<img width="672" height="502" alt="image" src="https://github.com/user-attachments/assets/cb9ffebe-a392-42db-aca6-3dd573968a8d" />
