### PR TITLE
Feat: add configurable option for upload path

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -86,7 +86,7 @@ if (config.production) {
 }
 
 // Serve uploaded files
-app.use('/api/uploads', express.static(path.join(__dirname, 'uploads')));
+app.use('/api/uploads', express.static(config.uploadLocation));
 
 // Authentication middleware
 const { requireAuth } = require('./middleware/auth');

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -67,6 +67,9 @@ const config = {
 
     sslEnabled:
         production && process.env.TUDUDI_INTERNAL_SSL_ENABLED === 'true',
+
+    uploadLocation:
+        process.env.UPLOAD_LOCATION || path.join(projectRootPath, 'uploads'),
 };
 
 console.log(`Using database file '${config.dbFile}'`);

--- a/backend/routes/projects.js
+++ b/backend/routes/projects.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const multer = require('multer');
 const path = require('path');
+const { getConfig } = require('../config/config');
+const config = getConfig();
 const fs = require('fs');
 const { Project, Task, Tag, Area, Note, sequelize } = require('../models');
 const { Op } = require('sequelize');
@@ -21,7 +23,10 @@ const formatDate = (date) => {
 // Configure multer for file uploads
 const storage = multer.diskStorage({
     destination: function (req, file, cb) {
-        const uploadDir = path.join(__dirname, '../uploads/projects');
+        const uploadDir = path.join(
+            config.uploadLocation,
+            '../uploads/projects'
+        );
         if (!fs.existsSync(uploadDir)) {
             fs.mkdirSync(uploadDir, { recursive: true });
         }

--- a/backend/routes/projects.js
+++ b/backend/routes/projects.js
@@ -23,10 +23,7 @@ const formatDate = (date) => {
 // Configure multer for file uploads
 const storage = multer.diskStorage({
     destination: function (req, file, cb) {
-        const uploadDir = path.join(
-            config.uploadLocation,
-            '../uploads/projects'
-        );
+        const uploadDir = path.join(config.uploadLocation, '/projects');
         if (!fs.existsSync(uploadDir)) {
             fs.mkdirSync(uploadDir, { recursive: true });
         }


### PR DESCRIPTION
This PR adds the `UPLOAD_LOCATION` environment variable to the configuration, so users can configure a custom path for their Project background uploads.

I just made a few small adjustments to 3 files. I don't use Docker so I'm not sure if there is anything else needed for that side of things.