### PR TITLE
Multiline paste in New Subtask input field to automatically create multiple subtasks

### DIFF
--- a/frontend/components/Task/TaskForm/TaskSubtasksSection.tsx
+++ b/frontend/components/Task/TaskForm/TaskSubtasksSection.tsx
@@ -37,7 +37,7 @@ const TaskSubtasksSection: React.FC<TaskSubtasksSectionProps> = ({
         }, 100);
     };
 
-    const makeSubtask = (name: string): Task => ({
+    const newSubtask = (name: string): Task => ({
         name: name.trim(),
         status: 'not_started',
         priority: 'low',
@@ -57,7 +57,7 @@ const TaskSubtasksSection: React.FC<TaskSubtasksSectionProps> = ({
             return;
         }
 
-        const newOnes = cleaned.map(makeSubtask);
+        const newOnes = cleaned.map(newSubtask);
 
         onSubtasksChange([...subtasks, ...newOnes]);
         setNewSubtaskName('');

--- a/frontend/components/Task/TaskForm/TaskSubtasksSection.tsx
+++ b/frontend/components/Task/TaskForm/TaskSubtasksSection.tsx
@@ -60,6 +60,29 @@ const TaskSubtasksSection: React.FC<TaskSubtasksSectionProps> = ({
         scrollToBottom();
     };
 
+    const makeSubtask = (name: string): Task => ({
+        name: name.trim(),
+        status: 'not_started',
+        priority: 'low',
+        today: false,
+        parent_task_id: parentTaskId,
+        isNew: true,
+        _isNew: true,
+        completed_at: null,
+    } as Task);
+
+    const handleCreateSubtasks = (names: string[]) => {
+        const cleaned = names.map(n => n.trim()).filter(Boolean);
+        if (cleaned.length === 0) {
+            return;
+        }
+
+        const newOnes = cleaned.map(makeSubtask);
+        onSubtasksChange([...subtasks, ...newOnes]);
+        setNewSubtaskName('');
+        scrollToBottom();
+    };
+
     const handleDeleteSubtask = (index: number) => {
         const updatedSubtasks = subtasks.filter((_, i) => i !== index);
         onSubtasksChange(updatedSubtasks);
@@ -324,6 +347,11 @@ const TaskSubtasksSection: React.FC<TaskSubtasksSectionProps> = ({
                     value={newSubtaskName}
                     onChange={(e) => setNewSubtaskName(e.target.value)}
                     onKeyDown={handleKeyPress}
+                    onPaste={(e) => {
+                      e.preventDefault();
+                      const text = e.clipboardData.getData('text');
+                      handleCreateSubtasks(text.split(/\r?\n/));
+                    }}
                     placeholder={t('subtasks.placeholder', 'Add a subtask...')}
                     className="flex-1 px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
                 />

--- a/frontend/components/Task/TaskForm/TaskSubtasksSection.tsx
+++ b/frontend/components/Task/TaskForm/TaskSubtasksSection.tsx
@@ -37,51 +37,37 @@ const TaskSubtasksSection: React.FC<TaskSubtasksSectionProps> = ({
         }, 100);
     };
 
-    const handleCreateSubtask = () => {
-        if (!newSubtaskName.trim()) return;
+    const makeSubtask = (name: string): Task => ({
+        name: name.trim(),
+        status: 'not_started',
+        priority: 'low',
+        today: false,
+        parent_task_id: parentTaskId, // Set the parent task ID immediately
+        // Mark as new for backend processing
+        isNew: true,
+        // Also keep for UI purposes
+        _isNew: true,
+        completed_at: null,
+    } as Task);
 
-        const newSubtask: Task = {
-            name: newSubtaskName.trim(),
-            status: 'not_started',
-            priority: 'low',
-            today: false,
-            parent_task_id: parentTaskId, // Set the parent task ID immediately
-            // Mark as new for backend processing
-            isNew: true,
-            // Also keep for UI purposes
-            _isNew: true,
-            completed_at: null,
-        } as Task;
+    const addSubtasks = (names: string | string[]) => {
+        const list = Array.isArray(names) ? names : [names];
+        const cleaned = list.map(n => n.trim()).filter(Boolean);
+        if (cleaned.length === 0) {
+            return;
+        }
 
-        onSubtasksChange([...subtasks, newSubtask]);
+        const newOnes = cleaned.map(makeSubtask);
+
+        onSubtasksChange([...subtasks, ...newOnes]);
         setNewSubtaskName('');
 
         // Only scroll when adding new subtask, not when toggling completion
         scrollToBottom();
     };
 
-    const makeSubtask = (name: string): Task => ({
-        name: name.trim(),
-        status: 'not_started',
-        priority: 'low',
-        today: false,
-        parent_task_id: parentTaskId,
-        isNew: true,
-        _isNew: true,
-        completed_at: null,
-    } as Task);
-
-    const handleCreateSubtasks = (names: string[]) => {
-        const cleaned = names.map(n => n.trim()).filter(Boolean);
-        if (cleaned.length === 0) {
-            return;
-        }
-
-        const newOnes = cleaned.map(makeSubtask);
-        onSubtasksChange([...subtasks, ...newOnes]);
-        setNewSubtaskName('');
-        scrollToBottom();
-    };
+    const handleCreateSubtask = () => addSubtasks(newSubtaskName);
+    const handleCreateSubtasks = (names: string[]) => addSubtasks(names);
 
     const handleDeleteSubtask = (index: number) => {
         const updatedSubtasks = subtasks.filter((_, i) => i !== index);


### PR DESCRIPTION
Often I have a list of new-line separated tasks to complete from arbitrary chat histories. Moving them one by one is tedious so I added support to paste a new-line separated list of strings into the New Subtask input field, where each line becomes a new subtask.

Note: I have very little insight into the code-base and no experience with these frameworks and how to use them so carefully look at these changes if you are going to accept this contribution.

/klarre