### PR TITLE
Add check for title on new notes

### DIFF
--- a/backend/routes/notes.js
+++ b/backend/routes/notes.js
@@ -160,6 +160,10 @@ router.post('/note', async (req, res) => {
 
         const { title, content, project_id, tags } = req.body;
 
+        if (!title || !title.trim()) {
+            return res.status(400).json({ error: 'Title is required' });
+        }
+
         const noteAttributes = {
             title,
             content,


### PR DESCRIPTION
Creating a new **note** without a **title** makes the Notes page on the web break. This patch adds a check that **title** is not empty when creating a new **note**.