### PR TITLE
fix: task title auto-focus on module popup

### DIFF
--- a/frontend/components/Task/TaskForm/TaskTitleSection.tsx
+++ b/frontend/components/Task/TaskForm/TaskTitleSection.tsx
@@ -15,6 +15,7 @@ interface TaskTitleSectionProps {
     taskAnalysis: TaskAnalysis | null;
     taskIntelligenceEnabled: boolean;
     onSubmit?: () => void;
+    inputRef?: React.RefObject<HTMLInputElement>;
 }
 
 const TaskTitleSection: React.FC<TaskTitleSectionProps> = ({
@@ -24,6 +25,7 @@ const TaskTitleSection: React.FC<TaskTitleSectionProps> = ({
     taskAnalysis,
     taskIntelligenceEnabled,
     onSubmit,
+    inputRef,
 }) => {
     const { t } = useTranslation();
 
@@ -40,6 +42,7 @@ const TaskTitleSection: React.FC<TaskTitleSectionProps> = ({
     return (
         <div className="px-4 py-4">
             <input
+                ref={inputRef}
                 type="text"
                 id={`task_name_${taskId}`}
                 name="name"

--- a/frontend/components/Task/TaskModal.tsx
+++ b/frontend/components/Task/TaskModal.tsx
@@ -72,6 +72,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
     const [isCreatingProject, setIsCreatingProject] = useState(false);
     const [dropdownOpen, setDropdownOpen] = useState(false);
     const modalRef = useRef<HTMLDivElement>(null);
+    const titleInputRef = useRef<HTMLInputElement>(null);
     const [isClosing, setIsClosing] = useState(false);
     const [showConfirmDialog, setShowConfirmDialog] = useState(false);
     const [parentTask, setParentTask] = useState<Task | null>(null);
@@ -448,6 +449,15 @@ const TaskModal: React.FC<TaskModalProps> = ({
         }
     }, [isOpen, task.id]);
 
+    // Auto-focus on the title input when modal opens
+    useEffect(() => {
+        if (isOpen) {
+            setTimeout(() => {
+                titleInputRef.current?.focus();
+            }, 100);
+        }
+    }, [isOpen]);
+
     if (!isOpen) return null;
 
     return createPortal(
@@ -506,6 +516,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
                                                         taskIntelligenceEnabled
                                                     }
                                                     onSubmit={handleSubmit}
+                                                    inputRef={titleInputRef}
                                                 />
 
                                                 {/* Content Section - Always Visible */}


### PR DESCRIPTION
Addresses https://github.com/chrisvel/tududi/issues/379. I have implemented the fix based on the `NoteModal` implementation.

Using `opencode` for the development here, a lil-bit of vibe coding, let me know if that is something you are okay with.

This is the final opencode output related to the change:

```md
## Changes Made:

1. TaskTitleSection.tsx: Added an optional inputRef prop to the component interface and forwarded it to the input element.
2. TaskModal.tsx:
 • Added titleInputRef using useRef<HTMLInputElement>(null)
 • Added a useEffect that focuses the title input when the modal opens (with a 100ms delay like NoteModal)
 • Passed the inputRef prop to the TaskTitleSection component


The implementation mirrors NoteModal's approach exactly:

• Uses the same ref pattern and timing
• Focuses the title input automatically when the modal opens
• Maintains all existing functionality

The build completed successfully with no TypeScript or linting errors, confirming the changes work correctly. Now when you open a TaskModal, the title input will be
automatically focused, just like in NoteModal.
```