### PR TITLE
fix: null project id on edit task

### DIFF
--- a/frontend/components/Task/TaskModal.tsx
+++ b/frontend/components/Task/TaskModal.tsx
@@ -370,11 +370,11 @@ const TaskModal: React.FC<TaskModalProps> = ({
                 addNewTags(newTagNames);
             }
 
-            // If project name is empty, clear the project_id
+            // CORRECTION: Use formData.project_id directly instead of the logic based on newProjectName
+            // newProjectName is just a temporary lookup field, not the actual project state
             const finalFormData = {
                 ...formData,
-                project_id:
-                    newProjectName.trim() === '' ? null : formData.project_id,
+                project_id: formData.project_id,
                 tags: tags.map((tag) => ({ name: tag })),
                 subtasks: subtasks,
             };


### PR DESCRIPTION
<!--
Thank you for contributing to tududi!

Before submitting:
1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
2. Run: npm run pre-push (linting, formatting, tests)
3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
4. Delete sections that don't apply to your PR
-->

## Description

<!-- What does this PR do? Why is this change needed? -->
Solve the issue with the task PATCH request in front-end.

Whenever I edit a task that's inside a project, the project ID is cleared, and I can't edit it back to add a new project. The problem is in the front-end, it's passing null to the backend, even though the field is filled with the original value.


## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

<!-- Link issues using: Fixes #123, Closes #456 -->

Fixes #504 

## Testing

**How did you test this?**

1. Add task in project
2. Edit this same task, and observe if is in correct project.

<!-- Describe your testing steps -->

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [x] Tested on mobile (if UI changes)

## Screenshots

<!-- If UI changes, add before/after screenshots. Delete this section if not applicable. -->


## Checklist

- [ ] This is not an AI slop crap, I know what I am doing
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

<!-- Anything else reviewers should know? -->

