### PR TITLE
Fix healthcheck command to use 127.0.0.1 instead of localhost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ ENV NODE_ENV=production \
     SWAGGER_ENABLED=false
 
 HEALTHCHECK --interval=60s --timeout=3s --start-period=10s --retries=2 \
-    CMD wget -q -T 3 -t 1 --spider http://127.0.0.1:3002/api/health || exit 1
+    CMD wget -q -T 3 --spider http://127.0.0.1:3002/api/health || exit 1
 
 WORKDIR /app/backend
 ENTRYPOINT ["/app/scripts/docker-entrypoint.sh"]


### PR DESCRIPTION
## Description

Fixes the healthcheck. DNS lookup for `localhost` returned IPv6 address, while the app is running IPv4 only internally.
Replaces `localhost` with `127.0.0.1`.

Also fixes alpine image wget parameters.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #668

## Testing

**How did you test this?**

Docker build and run. Healthcheck returns healthy now.

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [x] Updated documentation (if needed)
- [x] Database migrations included and tested (if applicable)
- [x] Translation keys added and synced (if applicable)
