### PR TITLE
changed ignore condition for telegram processing

### DIFF
--- a/backend/services/telegramPoller.js
+++ b/backend/services/telegramPoller.js
@@ -320,8 +320,13 @@ const processMessage = async (user, update) => {
         return; // Silently ignore unauthorized users
     }
 
-    // If this user already has a chat bound and it doesn't match this update, ignore
-    if (user.telegram_chat_id && user.telegram_chat_id !== chatId) {
+    // If allowed users list is configured allow multiple chats
+    if (
+        (!user.telegram_allowed_users ||
+            user.telegram_allowed_users.trim() === '') &&
+        user.telegram_chat_id &&
+        user.telegram_chat_id !== chatId
+    ) {
         return;
     }
 
@@ -571,4 +576,5 @@ module.exports = {
     _createMessageParams: createMessageParams,
     _createTelegramUrl: createTelegramUrl,
     _isAuthorizedTelegramUser: isAuthorizedTelegramUser,
+    _processMessage: processMessage,
 };


### PR DESCRIPTION
<!--
Thank you for contributing to tududi!

Before submitting:
1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
2. Run: npm run pre-push (linting, formatting, tests)
3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
4. Delete sections that don't apply to your PR
-->

## Description

<!-- What does this PR do? Why is this change needed? -->
### Bug Scenario
Bob sends first message, telegram_chat_id gets set to his chat.
Then Alice (also authorized) tries to send message from different chat.
Without fix: Alice would be rejected because her chatId !== user.telegram_chat_id 
With fix: Alice should be allowed because she's in telegram_allowed_users


## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

<!-- Link issues using: Fixes #123, Closes #456 -->

Fixes #671 

## Testing

**How did you test this?**

<!-- Describe your testing steps -->

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [ ] Tested on mobile (if UI changes)


## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

<!-- Anything else reviewers should know? -->

