### PR TITLE
Fix healthcheck command to use array syntax

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ ENV NODE_ENV=production \
     SWAGGER_ENABLED=false
 
 HEALTHCHECK --interval=60s --timeout=3s --start-period=10s --retries=2 \
-    CMD wget -q -T 3 --spider http://127.0.0.1:3002/api/health || exit 1
+    CMD ["wget", "-q", "--spider", "http://127.0.0.1:3002/api/health"]
 
 WORKDIR /app/backend
 ENTRYPOINT ["/app/scripts/docker-entrypoint.sh"]


### PR DESCRIPTION
## Description

PR #669 sadly didn't fix the Healthcheck entirely. 
This pull request makes a minor update to the health check configuration in the `Dockerfile`. The change updates the syntax of the `HEALTHCHECK` command to use the exec form, which is generally preferred for better signal handling and compatibility.

_The existing syntax in Healthcheck was wrong and could not have worked._

This PR fixes the Healthcheck once and for all.

P.S. Removed `-T 3` as it was redundant.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #668 once and for all, as it was not really resolved.

## Testing

**How did you test this?**

Built the container and ran it in my environment. Returned `healthy`

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code

## Additional Notes

Sorry for opening another PR for the same issue ❤️
Had the Healthcheck overridden in my Compose with the correct solution while testing, resulting in false positive test while doing PR #669