### PR TITLE
Prevent pwa zoom

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no, maximum-scale=1">
     <base href="/">
     <script>
       (function () {


### PR DESCRIPTION
## Description
PR adds a small change, that improves the handling of tududi in PWAs. Before the change, zooming was enabeled and at least iOS tends to zoom in on text fields. That interrupted the user flow.

With the PR zooming is disabled.


## Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update


## Testing

Did local testing on Windows and iOS. Deployed, checked functionality. Everything operational.

**Commands run:**

- [ ] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [x] Tested on mobile (if UI changes)


## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [x] Updated documentation (if needed)
- [x] Database migrations included and tested (if applicable)
- [x] Translation keys added and synced (if applicable)


