### PR TITLE
fix: deferred planned task loses status on partial update (#851)

### DIFF
--- a/backend/modules/tasks/core/builders.js
+++ b/backend/modules/tasks/core/builders.js
@@ -78,7 +78,7 @@ function buildUpdateAttributes(body, task, timezone) {
         status:
             body.status !== undefined
                 ? parseStatus(body.status)
-                : Task.STATUS.NOT_STARTED,
+                : undefined,
         note: body.note,
         recurrence_type: recurrenceType,
         recurrence_interval:

--- a/backend/modules/tasks/queries/metrics-queries.js
+++ b/backend/modules/tasks/queries/metrics-queries.js
@@ -87,6 +87,8 @@ async function fetchTodayPlanTasks(visibleTasksWhere) {
         'cancelled',
     ];
 
+    const now = new Date();
+
     return await Task.findAll({
         where: {
             [Op.and]: [
@@ -97,7 +99,16 @@ async function fetchTodayPlanTasks(visibleTasksWhere) {
                         [Op.notIn]: excludedStatuses,
                     },
                     parent_task_id: null,
-                    // Exclude recurring parent tasks - only include non-recurring tasks or recurring instances
+                },
+                // Exclude tasks whose defer_until is still in the future
+                {
+                    [Op.or]: [
+                        { defer_until: null },
+                        { defer_until: { [Op.lte]: now } },
+                    ],
+                },
+                // Exclude recurring parent tasks - only include non-recurring tasks or recurring instances
+                {
                     [Op.or]: [
                         {
                             // Non-recurring tasks

--- a/backend/tests/integration/deferred-planned-task.test.js
+++ b/backend/tests/integration/deferred-planned-task.test.js
@@ -1,0 +1,142 @@
+const request = require('supertest');
+const app = require('../../app');
+const { Task } = require('../../models');
+const { createTestUser } = require('../helpers/testUtils');
+
+describe('Deferred Planned Task - Status Preservation (#851)', () => {
+    let user, agent;
+
+    beforeEach(async () => {
+        user = await createTestUser({
+            email: 'deferred-planned@example.com',
+        });
+
+        agent = request.agent(app);
+        await agent.post('/api/login').send({
+            email: 'deferred-planned@example.com',
+            password: 'password123',
+        });
+    });
+
+    describe('PATCH /api/task/:uid - defer_until without status', () => {
+        it('should preserve planned status when only defer_until is updated', async () => {
+            const task = await Task.create({
+                name: 'Planned Deferred Task',
+                user_id: user.id,
+                status: Task.STATUS.PLANNED,
+            });
+
+            const tomorrow = new Date(
+                Date.now() + 24 * 60 * 60 * 1000
+            ).toISOString();
+
+            const response = await agent
+                .patch(`/api/task/${task.uid}`)
+                .send({ defer_until: tomorrow })
+                .expect(200);
+
+            // Status should be preserved as PLANNED (numeric 6)
+            expect(response.body.status).toBe(Task.STATUS.PLANNED);
+
+            // Verify in DB
+            const updated = await Task.findByPk(task.id);
+            expect(updated.status).toBe(Task.STATUS.PLANNED);
+        });
+
+        it('should preserve in_progress status when only defer_until is updated', async () => {
+            const task = await Task.create({
+                name: 'In Progress Deferred Task',
+                user_id: user.id,
+                status: Task.STATUS.IN_PROGRESS,
+            });
+
+            const tomorrow = new Date(
+                Date.now() + 24 * 60 * 60 * 1000
+            ).toISOString();
+
+            const response = await agent
+                .patch(`/api/task/${task.uid}`)
+                .send({ defer_until: tomorrow })
+                .expect(200);
+
+            expect(response.body.status).toBe(Task.STATUS.IN_PROGRESS);
+        });
+
+        it('should preserve waiting status when only note is updated', async () => {
+            const task = await Task.create({
+                name: 'Waiting Task',
+                user_id: user.id,
+                status: Task.STATUS.WAITING,
+            });
+
+            const response = await agent
+                .patch(`/api/task/${task.uid}`)
+                .send({ note: 'Updated note' })
+                .expect(200);
+
+            expect(response.body.status).toBe(Task.STATUS.WAITING);
+        });
+    });
+
+    describe('GET /api/tasks?type=today&include_lists=true - defer_until filtering', () => {
+        it('should exclude planned tasks with future defer_until from today plan', async () => {
+            const futureDate = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+            await Task.create({
+                name: 'Future Deferred Planned',
+                user_id: user.id,
+                status: Task.STATUS.PLANNED,
+                defer_until: futureDate,
+            });
+
+            await Task.create({
+                name: 'Active Planned',
+                user_id: user.id,
+                status: Task.STATUS.PLANNED,
+            });
+
+            const response = await agent
+                .get('/api/tasks?type=today&include_lists=true')
+                .expect(200);
+
+            expect(response.body.tasks_today_plan).toBeDefined();
+            const names = response.body.tasks_today_plan.map((t) => t.name);
+            expect(names).toContain('Active Planned');
+            expect(names).not.toContain('Future Deferred Planned');
+        });
+
+        it('should include planned tasks whose defer_until has passed', async () => {
+            const pastDate = new Date(Date.now() - 60 * 60 * 1000); // 1 hour ago
+
+            await Task.create({
+                name: 'Past Deferred Planned',
+                user_id: user.id,
+                status: Task.STATUS.PLANNED,
+                defer_until: pastDate,
+            });
+
+            const response = await agent
+                .get('/api/tasks?type=today&include_lists=true')
+                .expect(200);
+
+            const names = response.body.tasks_today_plan.map((t) => t.name);
+            expect(names).toContain('Past Deferred Planned');
+        });
+
+        it('should include planned tasks with null defer_until', async () => {
+            await Task.create({
+                name: 'No Defer Planned',
+                user_id: user.id,
+                status: Task.STATUS.PLANNED,
+                defer_until: null,
+            });
+
+            const response = await agent
+                .get('/api/tasks?type=today&include_lists=true')
+                .expect(200);
+
+            const names = response.body.tasks_today_plan.map((t) => t.name);
+            expect(names).toContain('No Defer Planned');
+        });
+    });
+});


### PR DESCRIPTION
## Problem

A deferred planned task loses its "planned" status when the defer time arrives (or on any partial update). Two root causes:

### 1. `buildUpdateAttributes()` resets status to `NOT_STARTED` on partial updates

In `backend/modules/tasks/core/builders.js`, when `body.status` is `undefined` (i.e. not included in the update request), the status defaults to `Task.STATUS.NOT_STARTED` instead of being preserved:

```js
// Before (broken)
status: body.status !== undefined
    ? parseStatus(body.status)
    : Task.STATUS.NOT_STARTED,

// After (fixed)
status: body.status !== undefined
    ? parseStatus(body.status)
    : undefined,
```

This means any update that does not explicitly include a `status` field (e.g. setting only `defer_until`, updating a note) silently resets the task status to `not_started`, losing `planned`, `in_progress`, or `waiting` states.

### 2. `fetchTodayPlanTasks()` missing `defer_until` filter

In `backend/modules/tasks/queries/metrics-queries.js`, the today plan query did not exclude tasks whose `defer_until` is still in the future. A planned task with a future defer date would incorrectly appear in today's plan before the defer time arrived.

Added filter:
```js
{ [Op.or]: [
    { defer_until: null },
    { defer_until: { [Op.lte]: now } },
] }
```

## Changes

- `backend/modules/tasks/core/builders.js` — return `undefined` instead of `NOT_STARTED` when `body.status` is not provided, so Sequelize skips the field and preserves the existing value
- `backend/modules/tasks/queries/metrics-queries.js` — exclude tasks with future `defer_until` from today plan results
- `backend/tests/integration/deferred-planned-task.test.js` — 6 new integration tests covering both fixes

## Testing

All 896 existing tests pass, plus 6 new tests:
- Planned status preserved when only `defer_until` is updated
- In-progress status preserved when only `defer_until` is updated  
- Waiting status preserved when only `note` is updated
- Future-deferred planned tasks excluded from today plan
- Past-deferred planned tasks included in today plan
- Null `defer_until` planned tasks included in today plan

Fixes #851