### PR TITLE
Fix task name not being saved for new tasks (#904)

### DIFF
--- a/frontend/components/Task/TaskDetails.tsx
+++ b/frontend/components/Task/TaskDetails.tsx
@@ -264,7 +264,7 @@ const TaskDetails: React.FC = () => {
                 completion_based: recurrenceForm.completion_based,
             };
 
-            await updateTask(task.uid, { ...task, ...recurrencePayload });
+            await updateTask(task.uid, recurrencePayload);
 
             if (uid) {
                 const updatedTask = await fetchTaskByUid(uid);
@@ -658,7 +658,7 @@ const TaskDetails: React.FC = () => {
 
         try {
             taskModifiedRef.current = true;
-            await updateTask(task.uid, { ...task, subtasks: subtasksToSave });
+            await updateTask(task.uid, { subtasks: subtasksToSave });
 
             if (uid) {
                 const updatedTask = await fetchTaskByUid(uid);
@@ -689,7 +689,7 @@ const TaskDetails: React.FC = () => {
 
         try {
             taskModifiedRef.current = true;
-            await updateTask(task.uid, { ...task, project_id: project.id });
+            await updateTask(task.uid, { project_id: project.id });
 
             if (uid) {
                 const updatedTask = await fetchTaskByUid(uid);
@@ -721,7 +721,7 @@ const TaskDetails: React.FC = () => {
 
         try {
             taskModifiedRef.current = true;
-            await updateTask(task.uid, { ...task, project_id: null });
+            await updateTask(task.uid, { project_id: null });
 
             if (uid) {
                 const updatedTask = await fetchTaskByUid(uid);
@@ -927,7 +927,7 @@ const TaskDetails: React.FC = () => {
 
         try {
             taskModifiedRef.current = true;
-            await updateTask(task.uid, { ...task, name: newTitle.trim() });
+            await updateTask(task.uid, { name: newTitle.trim() });
 
             if (uid) {
                 const updatedTask = await fetchTaskByUid(uid);
@@ -968,7 +968,7 @@ const TaskDetails: React.FC = () => {
 
         try {
             taskModifiedRef.current = true;
-            await updateTask(task.uid, { ...task, note: trimmedContent });
+            await updateTask(task.uid, { note: trimmedContent });
 
             if (uid) {
                 const updatedTask = await fetchTaskByUid(uid);
@@ -1005,7 +1005,7 @@ const TaskDetails: React.FC = () => {
 
             projectsStore.setProjects([...projectsStore.projects, newProject]);
 
-            await updateTask(task.uid, { ...task, project_id: newProject.id });
+            await updateTask(task.uid, { project_id: newProject.id });
 
             if (uid) {
                 const updatedTask = await fetchTaskByUid(uid);


### PR DESCRIPTION
## Description

Task names were not being saved for new tasks despite showing a success message. This was caused by spreading the entire task object in `updateTask` calls, which included the `original_name` field. The `tasksService.updateTask` function has logic to use `original_name` when both `original_name` and `name` are present, causing the new user-entered name to be overwritten.

**Root Cause:**
```typescript
// TaskDetails.tsx - spreads entire task object
await updateTask(task.uid, { ...task, name: newTitle.trim() });

// tasksService.ts - overwrites name with original_name
if (payload.original_name && payload.name !== undefined) {
    payload.name = payload.original_name;  // Overwrites new name!
}
```

**Fix:** Only send the specific fields being updated instead of spreading the entire task object.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #904

## Testing

**How did you test this?**

1. Verified the root cause by analyzing the code flow
2. Applied the fix to remove `...task` spreads from all `updateTask` calls
3. Built the frontend successfully with `npm run build`
4. Verified the logic change prevents the `original_name` override

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [ ] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

This fix also improves efficiency by sending smaller API payloads and prevents similar issues with other fields. The following updateTask calls were fixed:

- Title updates: `{ name }` instead of `{ ...task, name }`
- Note updates: `{ note }` instead of `{ ...task, note }`
- Project updates: `{ project_id }` instead of `{ ...task, project_id }`
- Subtasks updates: `{ subtasks }` instead of `{ ...task, subtasks }`
- Recurrence updates: `recurrencePayload` instead of `{ ...task, ...recurrencePayload }`