### PR TITLE
Show original task names for recurring tasks in search results (#914)

### DIFF
--- a/backend/modules/search/service.js
+++ b/backend/modules/search/service.js
@@ -233,7 +233,9 @@ class SearchService {
             params.offset
         );
 
-        const serializedTasks = await serializeTasks(tasks, timezone);
+        const serializedTasks = await serializeTasks(tasks, timezone, {
+            skipDisplayNameTransform: true,
+        });
 
         return {
             count,

--- a/backend/tests/integration/search.test.js
+++ b/backend/tests/integration/search.test.js
@@ -731,6 +731,28 @@ describe('Universal Search Routes', () => {
                     .filter((r) => r.type === 'Task')
                     .map((task) => task.original_name || task.name);
 
+            it('should include recurring tasks in default search with their original names', async () => {
+                const response = await agent.get('/api/search').query({
+                    q: 'Recurring',
+                    filters: 'Task',
+                });
+
+                expect(response.status).toBe(200);
+                const names = getTaskNames(response);
+                expect(names).toContain('Recurring Template');
+                expect(names).toContain('Recurring Instance');
+
+                // Verify template shows original name, not recurrence type label
+                const template = response.body.results.find(
+                    (r) =>
+                        r.type === 'Task' &&
+                        r.recurrence_type === 'weekly' &&
+                        !r.recurring_parent_id
+                );
+                expect(template).toBeDefined();
+                expect(template.name).toBe('Recurring Template');
+            });
+
             it('should return only recurring tasks when extras contains recurring', async () => {
                 const response = await agent.get('/api/search').query({
                     filters: 'Task',


### PR DESCRIPTION
Recurring task templates had their names replaced with the recurrence type label (e.g. "Weekly") in search results, making them unrecognizable. Skip the display name transform when serializing tasks for search.

<!--
Thank you for contributing to tududi!

Before submitting:
1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
2. Run: npm run pre-push (linting, formatting, tests)
3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
4. Delete sections that don't apply to your PR
-->

## Description

<!-- What does this PR do? Why is this change needed? -->


## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

<!-- Link issues using: Fixes #123, Closes #456 -->

Fixes #914

## Testing

**How did you test this?**

<!-- Describe your testing steps -->

**Commands run:**

- [ ] `npm run pre-push` (linting + formatting + tests)
- [ ] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Screenshots

<!-- If UI changes, add before/after screenshots. Delete this section if not applicable. -->


## Checklist

- [ ] This is not an AI slop crap, I know what I am doing
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

<!-- Anything else reviewers should know? -->

