### PR TITLE
Fix date format to respect timezone preference (#898)

### DIFF
--- a/frontend/components/Task/TaskDetails/TaskDueDateCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskDueDateCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
     CalendarIcon,
@@ -7,6 +7,7 @@ import {
 import TaskDueDateSection from '../TaskForm/TaskDueDateSection';
 import { Task } from '../../../entities/Task';
 import { parseDateString } from '../../../utils/dateUtils';
+import { resolveUserLocale } from '../../../utils/localeUtils';
 
 interface TaskDueDateCardProps {
     task: Task;
@@ -28,12 +29,16 @@ const TaskDueDateCard: React.FC<TaskDueDateCardProps> = ({
     onCancel,
 }) => {
     const { t, i18n } = useTranslation();
+    const displayLocale = useMemo(
+        () => resolveUserLocale(i18n.language),
+        [i18n.language]
+    );
 
     const getDueDateDisplay = (dueDate: string) => {
         const date = parseDateString(dueDate);
         if (!date) return null;
 
-        const formattedDate = date.toLocaleDateString(i18n.language, {
+        const formattedDate = date.toLocaleDateString(displayLocale, {
             day: '2-digit',
             month: '2-digit',
             year: 'numeric',

--- a/frontend/components/Task/TaskDetails/TaskRecurrenceCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskRecurrenceCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import RecurrenceDisplay from '../RecurrenceDisplay';
 import TaskRecurrenceSection from '../TaskForm/TaskRecurrenceSection';
@@ -6,6 +6,7 @@ import TaskRecurringInstanceInfo from './TaskRecurringInstanceInfo';
 import { Task, RecurrenceType } from '../../../entities/Task';
 import { TaskIteration } from '../../../utils/tasksService';
 import { getTodayDateString } from '../../../utils/dateUtils';
+import { resolveUserLocale } from '../../../utils/localeUtils';
 
 interface TaskRecurrenceCardProps {
     task: Task;
@@ -46,16 +47,20 @@ const TaskRecurrenceCard: React.FC<TaskRecurrenceCardProps> = ({
     canEdit,
 }) => {
     const { t, i18n } = useTranslation();
+    const displayLocale = useMemo(
+        () => resolveUserLocale(i18n.language),
+        [i18n.language]
+    );
 
     const formatDateWithDayName = (dateString: string) => {
         const date = new Date(dateString);
         const today = getTodayDateString();
         const isToday = dateString === today;
 
-        const dayName = date.toLocaleDateString(i18n.language, {
+        const dayName = date.toLocaleDateString(displayLocale, {
             weekday: 'long',
         });
-        const formattedDate = date.toLocaleDateString(i18n.language, {
+        const formattedDate = date.toLocaleDateString(displayLocale, {
             day: 'numeric',
             month: 'long',
         });

--- a/frontend/utils/localeUtils.ts
+++ b/frontend/utils/localeUtils.ts
@@ -1,14 +1,132 @@
+import { getUserTimezone } from './dateUtils';
+
+/**
+ * Maps IANA timezone identifiers to ISO 3166-1 alpha-2 country codes.
+ * Used to derive the correct date format from the user's timezone preference.
+ */
+const timezoneToCountry: Record<string, string> = {
+    // Africa
+    'Africa/Abidjan': 'CI',
+    'Africa/Accra': 'GH',
+    'Africa/Algiers': 'DZ',
+    'Africa/Cairo': 'EG',
+    'Africa/Casablanca': 'MA',
+    'Africa/Johannesburg': 'ZA',
+    'Africa/Lagos': 'NG',
+    'Africa/Nairobi': 'KE',
+    'Africa/Tunis': 'TN',
+    // Americas
+    'America/Anchorage': 'US',
+    'America/Argentina/Buenos_Aires': 'AR',
+    'America/Bogota': 'CO',
+    'America/Caracas': 'VE',
+    'America/Chicago': 'US',
+    'America/Denver': 'US',
+    'America/Edmonton': 'CA',
+    'America/Halifax': 'CA',
+    'America/Lima': 'PE',
+    'America/Los_Angeles': 'US',
+    'America/Mexico_City': 'MX',
+    'America/New_York': 'US',
+    'America/Phoenix': 'US',
+    'America/Regina': 'CA',
+    'America/Santiago': 'CL',
+    'America/Sao_Paulo': 'BR',
+    'America/St_Johns': 'CA',
+    'America/Toronto': 'CA',
+    'America/Vancouver': 'CA',
+    'America/Whitehorse': 'CA',
+    'America/Winnipeg': 'CA',
+    // Asia
+    'Asia/Bangkok': 'TH',
+    'Asia/Dhaka': 'BD',
+    'Asia/Dubai': 'AE',
+    'Asia/Hong_Kong': 'HK',
+    'Asia/Jakarta': 'ID',
+    'Asia/Jerusalem': 'IL',
+    'Asia/Karachi': 'PK',
+    'Asia/Kolkata': 'IN',
+    'Asia/Kuala_Lumpur': 'MY',
+    'Asia/Manila': 'PH',
+    'Asia/Riyadh': 'SA',
+    'Asia/Seoul': 'KR',
+    'Asia/Shanghai': 'CN',
+    'Asia/Singapore': 'SG',
+    'Asia/Taipei': 'TW',
+    'Asia/Tehran': 'IR',
+    'Asia/Tokyo': 'JP',
+    // Atlantic
+    'Atlantic/Azores': 'PT',
+    'Atlantic/Reykjavik': 'IS',
+    // Australia
+    'Australia/Adelaide': 'AU',
+    'Australia/Brisbane': 'AU',
+    'Australia/Darwin': 'AU',
+    'Australia/Hobart': 'AU',
+    'Australia/Melbourne': 'AU',
+    'Australia/Perth': 'AU',
+    'Australia/Sydney': 'AU',
+    // Europe
+    'Europe/Amsterdam': 'NL',
+    'Europe/Athens': 'GR',
+    'Europe/Berlin': 'DE',
+    'Europe/Brussels': 'BE',
+    'Europe/Copenhagen': 'DK',
+    'Europe/Dublin': 'IE',
+    'Europe/Helsinki': 'FI',
+    'Europe/Istanbul': 'TR',
+    'Europe/Lisbon': 'PT',
+    'Europe/London': 'GB',
+    'Europe/Madrid': 'ES',
+    'Europe/Moscow': 'RU',
+    'Europe/Oslo': 'NO',
+    'Europe/Paris': 'FR',
+    'Europe/Prague': 'CZ',
+    'Europe/Rome': 'IT',
+    'Europe/Stockholm': 'SE',
+    'Europe/Vienna': 'AT',
+    'Europe/Warsaw': 'PL',
+    'Europe/Zurich': 'CH',
+    // Pacific
+    'Pacific/Auckland': 'NZ',
+    'Pacific/Fiji': 'FJ',
+    'Pacific/Guam': 'GU',
+    'Pacific/Honolulu': 'US',
+};
+
+/**
+ * Gets the ISO 3166-1 country code from an IANA timezone identifier.
+ */
+export const getCountryFromTimezone = (timezone: string): string | null => {
+    return timezoneToCountry[timezone] || null;
+};
+
 /**
  * Resolves the best locale to use for date/time formatting.
- * It attempts the active i18n language first, then the browser locale,
- * and falls back to US English if none are valid.
+ * Combines the user's language preference with their timezone-derived region
+ * to produce a locale that respects regional date formatting conventions.
+ *
+ * For example: language "en" + timezone "Europe/Athens" → "en-GR" → DD/MM format
  */
 export const resolveUserLocale = (preferredLanguage?: string): string => {
-    const localesToTry = [
+    const timezone = getUserTimezone();
+    const country = getCountryFromTimezone(timezone);
+
+    // Build locale candidates in priority order
+    const localesToTry: (string | undefined)[] = [];
+
+    // First priority: language + timezone-derived country (e.g., "en-GR")
+    if (preferredLanguage && country) {
+        const baseLang = preferredLanguage.split('-')[0];
+        localesToTry.push(`${baseLang}-${country}`);
+    }
+
+    // Fallbacks
+    localesToTry.push(
         preferredLanguage,
         typeof navigator !== 'undefined' ? navigator.language : undefined,
-        'en-US',
-    ];
+        'en-US'
+    );
 
     for (const locale of localesToTry) {
         if (!locale) {


### PR DESCRIPTION
## Summary
- Date fields in the task edit page (Due Date, Recurrence) used the UI language to determine date format (e.g., "en" → MM/DD), ignoring the user's timezone preference
- Enhanced `resolveUserLocale` to derive the country from the user's timezone and combine it with the language (e.g., language "en" + timezone "Europe/Athens" → locale "en-GR" → DD/MM format)
- This affects `TaskDueDateCard`, `TaskRecurrenceCard`, `DatePicker`, and `DateTimePicker` — all components that use `resolveUserLocale`

## Test plan
- [ ] Set language to English and timezone to Europe/Athens
- [ ] Open a task with a due date → verify date shows DD/MM/YYYY format
- [ ] Set timezone to America/New_York → verify date shows MM/DD/YYYY format  
- [ ] Set language to Greek → verify dates still display correctly
- [ ] Check DatePicker and DateTimePicker dropdowns show correct format

Closes #898
