### PR TITLE
Fix note creation with project assignment

### DIFF
--- a/frontend/utils/notesService.ts
+++ b/frontend/utils/notesService.ts
@@ -21,11 +21,25 @@ export const fetchNotes = async (): Promise<Note[]> => {
 };
 
 export const createNote = async (noteData: Note): Promise<Note> => {
+    // Transform project_id to project_uid if needed (same as updateNote)
+    const requestData = { ...noteData };
+    if (noteData.project && noteData.project.uid) {
+        requestData.project_uid = noteData.project.uid;
+    } else if (noteData.project_uid) {
+        // project_uid is already set, use it as-is
+    } else if (noteData.project_id && !noteData.project_uid) {
+        // Legacy: if only project_id is provided, we can't convert it to uid here
+        // This should not happen with the new implementation, but keeping for safety
+        console.warn(
+            'Note creation with project_id but no project_uid - this may fail'
+        );
+    }
+
     const response = await fetch(getApiPath('note'), {
         method: 'POST',
         credentials: 'include',
         headers: getPostHeaders(),
-        body: JSON.stringify(noteData),
+        body: JSON.stringify(requestData),
     });
 
     await handleAuthResponse(response, 'Failed to create note.');


### PR DESCRIPTION
Transform project data in createNote to match updateNote behavior. This ensures project_uid is properly extracted from nested project object when creating notes with project associations.

Fixes #926

<!--
Thank you for contributing to tududi!

Before submitting:
1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
2. Run: npm run pre-push (linting, formatting, tests)
3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
4. Delete sections that don't apply to your PR
-->

## Description

<!-- What does this PR do? Why is this change needed? -->


## Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

<!-- Link issues using: Fixes #123, Closes #456 -->

Fixes #

## Testing

**How did you test this?**

<!-- Describe your testing steps -->

**Commands run:**

- [ ] `npm run pre-push` (linting + formatting + tests)
- [ ] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Screenshots

<!-- If UI changes, add before/after screenshots. Delete this section if not applicable. -->


## Checklist

- [ ] This is not an AI slop crap, I know what I am doing
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

<!-- Anything else reviewers should know? -->

