### PR TITLE
Fix subtask ordering to prevent random reordering

### DIFF
--- a/backend/modules/tasks/queries/query-builders.js
+++ b/backend/modules/tasks/queries/query-builders.js
@@ -100,6 +100,11 @@ async function filterTasksByParams(
                 },
             ],
             required: false,
+            separate: true, // Required for order to work with associations
+            order: [
+                ['order', 'ASC'],
+                ['created_at', 'ASC'],
+            ],
         },
     ];
 
@@ -429,6 +434,11 @@ function getTaskIncludeConfig() {
                 },
             ],
             required: false,
+            separate: true, // Required for order to work with associations
+            order: [
+                ['order', 'ASC'],
+                ['created_at', 'ASC'],
+            ],
         },
     ];
 }


### PR DESCRIPTION
## Summary
- Fixed subtask ordering issue where subtasks would randomly reorder after checking some as complete and reloading the page
- Added `separate: true` and proper `order` clause to subtask queries in `query-builders.js`
- Ensures subtasks are always returned sorted by `order` field (ASC) then `created_at` field (ASC)

## Root Cause
The `filterTasksByParams` and `getTaskIncludeConfig` functions in `query-builders.js` were including Subtasks without the proper ordering configuration. This caused Sequelize to return subtasks in an unpredictable order (likely by ID or database insertion order), which appeared as random reordering to users.

## Changes
- Updated `filterTasksByParams` includeClause to add ordering for Subtasks
- Updated `getTaskIncludeConfig` to add ordering for Subtasks
- Both now match the pattern used in `TASK_INCLUDES_WITH_SUBTASKS` constant

## Test Plan
- [x] All 919 existing tests pass
- [x] Verified ordering configuration matches the working pattern in constants.js
- [ ] Manual test: Create task with multiple subtasks, complete some, reload page - order should remain stable

Fixes #921