### PR TITLE
Fix subtask ordering to prevent random reordering

### DIFF
--- a/backend/modules/tasks/queries/query-builders.js
+++ b/backend/modules/tasks/queries/query-builders.js
@@ -100,6 +100,11 @@ async function filterTasksByParams(
                 },
             ],
             required: false,
+            separate: true, // Required for order to work with associations
+            order: [
+                ['order', 'ASC'],
+                ['created_at', 'ASC'],
+            ],
         },
     ];
 
@@ -429,6 +434,11 @@ function getTaskIncludeConfig() {
                 },
             ],
             required: false,
+            separate: true, // Required for order to work with associations
+            order: [
+                ['order', 'ASC'],
+                ['created_at', 'ASC'],
+            ],
         },
     ];
 }


### PR DESCRIPTION
Added proper ordering configuration (separate: true and order clause) to subtask queries in query-builders.js. This ensures subtasks are always returned in the correct order based on the 'order' field and 'created_at' timestamp, preventing the intermittent reordering bug that occurred after checking subtasks as complete and reloading.

Fixes #921

<!--
Thank you for contributing to tududi!

Before submitting:
1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
2. Run: npm run pre-push (linting, formatting, tests)
3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
4. Delete sections that don't apply to your PR
-->

## Description

<!-- What does this PR do? Why is this change needed? -->


## Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

<!-- Link issues using: Fixes #123, Closes #456 -->

Fixes #

## Testing

**How did you test this?**

<!-- Describe your testing steps -->

**Commands run:**

- [ ] `npm run pre-push` (linting + formatting + tests)
- [ ] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Screenshots

<!-- If UI changes, add before/after screenshots. Delete this section if not applicable. -->


## Checklist

- [ ] This is not an AI slop crap, I know what I am doing
- [ ] Code follows project style guidelines
- [ ] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

<!-- Anything else reviewers should know? -->

