### PR TITLE
Fix subtask completion not persisting (#920)

### DIFF
--- a/frontend/components/Task/TaskForm/TaskSubtasksSection.tsx
+++ b/frontend/components/Task/TaskForm/TaskSubtasksSection.tsx
@@ -160,14 +160,17 @@ const TaskSubtasksSection: React.FC<TaskSubtasksSectionProps> = ({
                                                 subtask.status || 'not_started'
                                             }
                                             onToggleCompletion={async () => {
-                                                if (
+                                                const isPersisted =
                                                     subtask.id &&
-                                                    onSubtaskUpdate &&
+                                                    subtask.uid &&
                                                     !(
                                                         (subtask as any)
                                                             ._isNew ||
                                                         (subtask as any).isNew
-                                                    )
+                                                    );
+                                                if (
+                                                    isPersisted &&
+                                                    onSubtaskUpdate
                                                 ) {
                                                     try {
                                                         const updatedSubtask =
@@ -176,6 +179,20 @@ const TaskSubtasksSection: React.FC<TaskSubtasksSectionProps> = ({
                                                             );
                                                         await onSubtaskUpdate(
                                                             updatedSubtask
+                                                        );
+                                                    } catch (error) {
+                                                        console.error(
+                                                            'Error toggling subtask completion:',
+                                                            error
+                                                        );
+                                                    }
+                                                } else if (isPersisted) {
+                                                    try {
+                                                        await toggleTaskCompletion(
+                                                            subtask.uid!
+                                                        );
+                                                        handleToggleNewSubtaskCompletion(
+                                                            index
                                                         );
                                                     } catch (error) {
                                                         console.error(
@@ -231,15 +248,18 @@ const TaskSubtasksSection: React.FC<TaskSubtasksSectionProps> = ({
                                                     'not_started'
                                                 }
                                                 onToggleCompletion={async () => {
-                                                    if (
+                                                    const isPersisted =
                                                         subtask.id &&
-                                                        onSubtaskUpdate &&
+                                                        subtask.uid &&
                                                         !(
                                                             (subtask as any)
                                                                 ._isNew ||
                                                             (subtask as any)
                                                                 .isNew
-                                                        )
+                                                        );
+                                                    if (
+                                                        isPersisted &&
+                                                        onSubtaskUpdate
                                                     ) {
                                                         try {
                                                             const updatedSubtask =
@@ -248,6 +268,20 @@ const TaskSubtasksSection: React.FC<TaskSubtasksSectionProps> = ({
                                                                 );
                                                             await onSubtaskUpdate(
                                                                 updatedSubtask
+                                                            );
+                                                        } catch (error) {
+                                                            console.error(
+                                                                'Error toggling subtask completion:',
+                                                                error
+                                                            );
+                                                        }
+                                                    } else if (isPersisted) {
+                                                        try {
+                                                            await toggleTaskCompletion(
+                                                                subtask.uid!
+                                                            );
+                                                            handleToggleNewSubtaskCompletion(
+                                                                index
                                                             );
                                                         } catch (error) {
                                                             console.error(


### PR DESCRIPTION
## Summary
- Fixes subtask toggle not sending network requests when `onSubtaskUpdate` callback is not provided
- When `TaskSubtasksCard` renders subtasks in the task details view, it doesn't pass `onSubtaskUpdate` to `TaskSubtasksSection`, so toggling a persisted subtask only updated local state without calling the API
- Adds an intermediate code path: when the subtask is persisted but `onSubtaskUpdate` is absent, calls `toggleTaskCompletion()` directly then updates local state

## Test plan
- [ ] Open a task with subtasks in the task details view
- [ ] Toggle a subtask to mark it as done
- [ ] Verify network request is sent (check browser DevTools Network tab)
- [ ] Reload the page and verify the subtask completion state persists
- [ ] Verify toggling subtasks in the main task list still works correctly
- [ ] Verify creating new subtasks and toggling them before save still works (local-only path)

Fixes #920

🤖 Generated with [Claude Code](https://claude.com/claude-code)