### PR TITLE
Fix tag view showing completed projects when Open filter is active

### DIFF
--- a/frontend/components/Tag/TagDetails.tsx
+++ b/frontend/components/Tag/TagDetails.tsx
@@ -50,14 +50,26 @@ const TagDetails: React.FC = () => {
     const [groupBy, setGroupBy] = useState<'none' | 'project'>('none');
     const [orderBy, setOrderBy] = useState<string>('created_at:desc');
 
-    // Filter projects by current tag
-    const projects = allProjects.filter(
-        (project: any) =>
+    // Filter projects by current tag and status filter
+    const projects = allProjects.filter((project: any) => {
+        const hasTag =
             project.tags &&
             project.tags.some(
                 (projectTag: any) => projectTag.name === tag?.name
-            )
-    );
+            );
+        if (!hasTag) return false;
+
+        if (taskStatusFilter === 'active') {
+            return (
+                project.status !== 'done' && project.status !== 'cancelled'
+            );
+        } else if (taskStatusFilter === 'completed') {
+            return (
+                project.status === 'done' || project.status === 'cancelled'
+            );
+        }
+        return true;
+    });
 
     const projectLookupList = useMemo(() => {
         const map = new Map<string, Project>();


### PR DESCRIPTION
## Summary

- Fixes #933 — the projects list in the Tag Details view now respects the status filter dropdown
- When "Open" is selected, completed/cancelled projects are hidden; when "Completed" is selected, only those are shown

## Root Cause

In `TagDetails.tsx`, the `projects` array was filtered only by tag name but never checked against `taskStatusFilter`. Tasks already had this filtering applied via `displayTasks`, but projects were missed.

## Test plan

- [ ] Navigate to a tag that has both active and completed projects
- [ ] Verify "Open" filter hides completed/cancelled projects
- [ ] Verify "Completed" filter shows only completed/cancelled projects
- [ ] Verify "All" filter shows everything