### PR TITLE
Fix subtask icons invisible on Today page

### DIFF
--- a/frontend/components/Task/TaskHeader.tsx
+++ b/frontend/components/Task/TaskHeader.tsx
@@ -294,15 +294,17 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
                             </div>
                         ) : (
                             <div className="flex items-center gap-1.5 min-w-0 flex-1">
-                                {task.habit_mode && (
-                                    <FireIcon
-                                        className="h-4 w-4 text-orange-500 flex-shrink-0"
-                                        title="Habit"
-                                    />
-                                )}
-                                <span className="text-md font-medium text-gray-900 dark:text-gray-300 truncate">
-                                    {task.original_name || task.name}
-                                </span>
+                                <div className="flex items-center gap-1.5 flex-1 min-w-0">
+                                    {task.habit_mode && (
+                                        <FireIcon
+                                            className="h-4 w-4 text-orange-500 flex-shrink-0"
+                                            title="Habit"
+                                        />
+                                    )}
+                                    <span className="text-md font-medium text-gray-900 dark:text-gray-300 truncate">
+                                        {task.original_name || task.name}
+                                    </span>
+                                </div>
                                 <SubtasksToggleButton />
                             </div>
                         )}


### PR DESCRIPTION
## Summary
- Fixes subtask toggle icons being completely invisible on the Today page while displaying normally on Upcoming and All Tasks pages
- The `SubtasksToggleButton` was inside the same flex container as the truncated task name, causing it to be squeezed to zero width
- Wraps the task name in an inner flex container (matching the existing upcoming view layout) so the button stays visible

Closes #839

## Test plan
- [ ] Open the Today page and verify subtask icons are visible on tasks that have subtasks
- [ ] Verify subtask icons still work correctly on Upcoming and All Tasks pages
- [ ] Test with long task names to ensure truncation still works properly