### PR TITLE
Fix sidebar toggle causing unnecessary task list reload

### DIFF
--- a/frontend/components/Tasks.tsx
+++ b/frontend/components/Tasks.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState, useRef, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { useSidebar } from '../contexts/SidebarContext';
 import TaskList from './Task/TaskList';
 import GroupedTaskList from './Task/GroupedTaskList';
 import NewTask from './Task/NewTask';
@@ -40,7 +39,7 @@ const getSearchPlaceholder = (language: string): string => {
 const Tasks: React.FC = () => {
     const { t, i18n } = useTranslation();
     const { showSuccessToast } = useToast();
-    const { isSidebarOpen } = useSidebar();
+
     const [tasks, setTasks] = useState<Task[]>([]);
     const projects = useStore((state: any) => state.projectsStore.projects);
     const [groupedTasks, setGroupedTasks] = useState<GroupedTasks | null>(null);
@@ -197,7 +196,6 @@ const Tasks: React.FC = () => {
                 allTasksUrl.set('type', 'upcoming');
                 allTasksUrl.set('groupBy', 'day');
                 allTasksUrl.set('maxDays', '7');
-                allTasksUrl.set('sidebarOpen', isSidebarOpen.toString());
                 allTasksUrl.set('isMobile', isMobile.toString());
             }
 
@@ -312,7 +310,7 @@ const Tasks: React.FC = () => {
                   }
                 : undefined
         );
-    }, [location, isSidebarOpen, isMobile, groupBy, isUpcomingView]);
+    }, [location, isMobile, groupBy, isUpcomingView]);
 
     useEffect(() => {
         const handleResize = () => {


### PR DESCRIPTION
## Summary
- Removes `isSidebarOpen` from the `useEffect` dependency array in `Tasks.tsx` that triggers `fetchData()`, so toggling the sidebar no longer re-fetches the entire task list
- Removes the unused `sidebarOpen` URL parameter from the API request
- Removes the now-unused `useSidebar` import

Fixes #888

## Test plan
- [ ] Open All Tasks view
- [ ] Toggle the left sidebar panel multiple times
- [ ] Verify the task list does not reload on each toggle
- [ ] Verify the upcoming view still loads correctly