### PR TITLE
Fix date format inconsistency in Defer Until field

### DIFF
--- a/frontend/components/Task/TaskDetails/TaskDeferUntilCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskDeferUntilCard.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ClockIcon } from '@heroicons/react/24/outline';
 import TaskDeferUntilSection from '../TaskForm/TaskDeferUntilSection';
 import { Task } from '../../../entities/Task';
+import { resolveUserLocale } from '../../../utils/localeUtils';
 
 interface TaskDeferUntilCardProps {
     task: Task;
@@ -24,12 +25,16 @@ const TaskDeferUntilCard: React.FC<TaskDeferUntilCardProps> = ({
     onCancel,
 }) => {
     const { t, i18n } = useTranslation();
+    const displayLocale = useMemo(
+        () => resolveUserLocale(i18n.language),
+        [i18n.language]
+    );
 
     const getDeferUntilDisplay = (deferUntil: string) => {
         const date = new Date(deferUntil);
         if (Number.isNaN(date.getTime())) return null;
 
-        const formattedDateTime = date.toLocaleString(i18n.language, {
+        const formattedDateTime = date.toLocaleString(displayLocale, {
             day: '2-digit',
             month: '2-digit',
             year: 'numeric',


### PR DESCRIPTION
## Description

Fixes #938 

This PR resolves the date format inconsistency where the "Defer Until" field displayed dates in MM/DD/YYYY format while the "Due Date" field correctly showed DD/MM/YYYY format (when using English language with a timezone like Europe/Athens).

## Problem

The `TaskDeferUntilCard` component was using `i18n.language` directly when formatting dates, which defaults to US format (MM/DD/YYYY) for English. Meanwhile, `TaskDueDateCard` correctly uses `resolveUserLocale()` which combines the language with the timezone-derived country code to produce the appropriate regional format.

**Example:**
- User settings: English language + Greek timezone (Europe/Athens)
- Expected format: DD/MM/YYYY (Greek convention)
- Due Date field: ✅ Showed DD/MM/YYYY correctly
- Defer Until field: ❌ Showed MM/DD/YYYY incorrectly

## Solution

Updated `TaskDeferUntilCard.tsx` to match the pattern used in `TaskDueDateCard.tsx`:
1. Import `useMemo` and `resolveUserLocale` 
2. Add a memoized `displayLocale` that resolves the timezone-aware locale
3. Use `displayLocale` instead of `i18n.language` in the `toLocaleString()` call

This ensures both fields respect the timezone's regional date formatting conventions.

## Changes

- Modified: `frontend/components/Task/TaskDetails/TaskDeferUntilCard.tsx`
  - Added imports for `useMemo` and `resolveUserLocale`
  - Added `displayLocale` memo (lines 27-30)
  - Changed `date.toLocaleString(i18n.language, ...)` to `date.toLocaleString(displayLocale, ...)`

## Testing

**Manual Testing:**
1. Set language to English and timezone to Europe/Athens (or any non-US timezone)
2. Open a task detail page with both "Due Date" and "Defer Until" fields populated
3. Verify both fields now display dates in DD/MM/YYYY format consistently

**Expected Results:**
- English + Greek timezone → DD/MM/YYYY format
- English + US timezone → MM/DD/YYYY format  
- Both fields should always match