### PR TITLE
fix: use getAssetPath() for logo images in Navbar and Login

### DIFF
--- a/frontend/components/Login.tsx
+++ b/frontend/components/Login.tsx
@@ -136,11 +136,11 @@ const Login: React.FC = () => {
             <nav className="fixed top-0 left-0 right-0 z-50 text-gray-900 dark:text-white">
                 <div className="h-16 flex items-center px-4 sm:px-6 lg:px-8">
                     <img
-                        src={
+                        src={getAssetPath(
                             isDarkMode
-                                ? '/wide-logo-light.png'
-                                : '/wide-logo-dark.png'
-                        }
+                                ? 'wide-logo-light.png'
+                                : 'wide-logo-dark.png'
+                        )}
                         alt="tududi"
                         className="h-9 w-auto"
                     />

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -11,7 +11,7 @@ import { useTranslation } from 'react-i18next';
 import PomodoroTimer from './Shared/PomodoroTimer';
 import UniversalSearch from './UniversalSearch/UniversalSearch';
 import NotificationsDropdown from './Notifications/NotificationsDropdown';
-import { getApiPath } from '../config/paths';
+import { getApiPath, getAssetPath } from '../config/paths';
 import { getFeatureFlags, FeatureFlags } from '../utils/featureFlags';
 import { setUserTimezone } from '../utils/dateUtils';
 
@@ -185,11 +185,11 @@ const Navbar: React.FC<NavbarProps> = ({
                         className={`flex items-center no-underline ml-2 ${isSidebarOpen ? 'sm:ml-0' : 'sm:ml-2'}`}
                     >
                         <img
-                            src={
+                            src={getAssetPath(
                                 isDarkMode
-                                    ? '/wide-logo-light.png'
-                                    : '/wide-logo-dark.png'
-                            }
+                                    ? 'wide-logo-light.png'
+                                    : 'wide-logo-dark.png'
+                            )}
                             alt="tududi"
                             className="h-9 w-auto"
                         />


### PR DESCRIPTION
## Description

Both `Navbar.tsx` and `Login.tsx` hardcode absolute paths for the logo images (`'/wide-logo-light.png'`, `'/wide-logo-dark.png'`). This breaks when tududi is served behind a reverse proxy with a subpath, such as Home Assistant ingress (`/api/hassio_ingress/<token>/`).

The `getAssetPath()` helper from `config/paths.ts` already handles base path detection — including automatic HA ingress detection — and `Login.tsx` already uses it correctly for the login graphic (`getAssetPath('login-gfx.png')`). This PR applies the same pattern to the logo images.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

N/A — no existing issue for this. The [[C2gl/tududi_addon](https://github.com/C2gl/tududi_addon)](https://github.com/C2gl/tududi_addon) HA addon works around this with `sed` rewrites in its Dockerfile.

## Testing

**How did you test this?**

Tested via the Home Assistant addon (built from source with and without the sed workarounds). Logos render correctly on both the login page and the main navbar when accessed through HA ingress.

**Commands run:**

- [ ] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Checklist

- [ ] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

This PR was created with AI assistance. The change follows the exact same pattern already used in `Login.tsx` for the login graphic. `Login.tsx` already imports `getAssetPath`; `Navbar.tsx` just needed it added to the existing import from `../config/paths`.
