### PR TITLE
Fix Telegram notification spam by marking JSON field as changed

### DIFF
--- a/backend/models/notification.js
+++ b/backend/models/notification.js
@@ -309,6 +309,7 @@ module.exports = (sequelize) => {
         const sentTimes = this.channel_sent_at || {};
         sentTimes[channel] = new Date().toISOString();
         this.channel_sent_at = sentTimes;
+        this.changed('channel_sent_at', true);
         await this.save();
         return this;
     };


### PR DESCRIPTION
## Summary
Fixes #968 - Telegram notifications were being sent every 15 minutes instead of being rate-limited to once per 24 hours.

## Problem
The `markChannelAsSent()` method in `backend/models/notification.js` was modifying the `channel_sent_at` JSON field without calling `this.changed('channel_sent_at', true)`, causing Sequelize to not detect the change and not persist the updated timestamp to the database.

**Result**: Same notification sent via Telegram every 15 minutes (up to 96 times per day per task).

## Solution
Added `this.changed('channel_sent_at', true)` before `save()` to explicitly mark the JSON field as modified, which is required for Sequelize to persist changes to JSON columns.

## Changes
- `backend/models/notification.js`: Added `this.changed('channel_sent_at', true)` in `markChannelAsSent()` method

## Testing
- ✅ All existing unit tests pass (11 tests in notification.test.js)
- ✅ Verified fix in production Docker environment
- ✅ Rate limiting now works correctly (max 1 notification per 24h per task)

## Impact
- **Before**: 96+ Telegram notifications per day per task
- **After**: Maximum 1 notification per 24 hours per task
- No breaking changes
- Backwards compatible

## Environment-Specific Note
The existing test "should persist to database" passes in test environment but didn't catch this bug in production due to environment differences (SQLite in-memory vs WAL mode). The fix works correctly in both environments.

## Checklist
- [x] Code follows project conventions
- [x] All tests pass
- [x] No breaking changes
- [x] Tested in production environment
- [x] Issue linked (#968)
