### PR TITLE
fix: use correct InboxItem model name in MCP inbox tools

### DIFF
--- a/backend/modules/mcp/tools/inboxTools.js
+++ b/backend/modules/mcp/tools/inboxTools.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Inbox } = require('../../../models');
+const { InboxItem } = require('../../../models');
 
 /**
  * Register all inbox-related MCP tools
@@ -29,7 +29,7 @@ function registerInboxTools(server, context, tools) {
             const limit = params.limit || 20;
             const offset = params.offset || 0;
 
-            const items = await Inbox.findAll({
+            const items = await InboxItem.findAll({
                 where: { user_id: context.userId },
                 limit: limit,
                 offset: offset,
@@ -91,7 +91,7 @@ function registerInboxTools(server, context, tools) {
                 processed: false,
             };
 
-            const item = await Inbox.create(inboxData);
+            const item = await InboxItem.create(inboxData);
 
             const serialized = {
                 id: item.id,


### PR DESCRIPTION
## Description
  The `add_to_inbox` and `list_inbox` MCP tools fail at runtime because `inboxTools.js` imports the inbox model as `Inbox`, but it is exported from
  `models/index` as `InboxItem`. This causes both tools to throw `Cannot read properties of undefined (reading 'create'/'findAll')` on every call,
  making the MCP inbox integration completely non-functional.

  **Fix:** Rename the import and all three references from `Inbox` → `InboxItem`.

  ## Type of Change

  - [x] Bug fix (fixes an issue)
  - [ ] New feature (adds functionality)
  - [ ] Breaking change (breaks existing functionality)
  - [ ] Documentation/Translation update

  ## Related Issues

  Fixes Issue #985 

  ## Testing

  **How did you test this?**

  Connected Claude Code as an MCP client against a self-hosted Tududi instance (`FF_ENABLE_MCP=true`). Called `add_to_inbox` before and after the fix.

  - Before: `Cannot read properties of undefined (reading 'create')`
  - After: Item created successfully in inbox

  **Commands run:**

  - [x] `npm run pre-push` (linting + formatting + tests)
  - [x] Tested manually in browser
  - [ ] Tested on mobile (if UI changes)

  ## Screenshots

  N/A — no UI changes.

  ## Checklist

  - [x] This is not an AI slop crap, I know what I am doing
  - [x] Code follows project style guidelines
  - [x] Self-reviewed my own code
  - [ ] Added/updated tests (if applicable)
  - [ ] Updated documentation (if needed)
  - [ ] Database migrations included and tested (if applicable)
  - [ ] Translation keys added and synced (if applicable)

  ## Additional Notes

  The fix is a one-line import rename. Verified by inspecting the exported keys from `models/index` at runtime — `InboxItem` is present, `Inbox` is not.