### PR TITLE
fix: add missing i18next dependency to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,6 +76,7 @@
         "globals": "^15.11.0",
         "highlight.js": "^11.11.1",
         "html-webpack-plugin": "^5.6.3",
+        "i18next": "^24.2.3",
         "i18next-browser-languagedetector": "^8.0.4",
         "i18next-http-backend": "^3.0.2",
         "identity-obj-proxy": "^3.0.0",
@@ -10886,7 +10887,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10"
       },

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "globals": "^15.11.0",
     "highlight.js": "^11.11.1",
     "html-webpack-plugin": "^5.6.3",
+    "i18next": "^24.2.3",
     "i18next-browser-languagedetector": "^8.0.4",
     "i18next-http-backend": "^3.0.2",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
## Description

This PR adds the missing `i18next` dependency to `package.json`. The package was being imported throughout the frontend code but was not explicitly declared in `devDependencies`. It was only being installed indirectly as a peer dependency of `react-i18next`, which can cause issues with strict package managers like pnpm.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

Fixes #987

## Testing

- [x] Verified `npm install` completes successfully
- [x] Ran `npm run lint` and all checks passed
- [x] Confirmed i18next is now explicitly declared in devDependencies

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Additional Notes

This is a simple dependency fix that ensures i18next is always installed, regardless of the package manager used. The version added (^24.2.3) matches what was already in the lock file.