### PR TITLE
fix(oidc): Add logging to help debug missing OIDC button (Issue #1036)

### DIFF
--- a/backend/modules/oidc/providerConfig.js
+++ b/backend/modules/oidc/providerConfig.js
@@ -8,6 +8,9 @@ function parseCommaSeparated(value) {
 
 function loadProvidersFromEnv() {
     if (process.env.OIDC_ENABLED !== 'true') {
+        console.log(
+            'OIDC is disabled. Set OIDC_ENABLED=true to enable SSO authentication.'
+        );
         return [];
     }
 
@@ -31,17 +34,24 @@ function loadProvidersFromEnv() {
             ),
         };
 
-        if (
-            !provider.slug ||
-            !provider.name ||
-            !provider.issuer ||
-            !provider.clientId ||
-            !provider.clientSecret
-        ) {
+        const missingFields = [];
+        if (!provider.slug) missingFields.push(`OIDC_PROVIDER_${i}_SLUG`);
+        if (!provider.name) missingFields.push(`OIDC_PROVIDER_${i}_NAME`);
+        if (!provider.issuer) missingFields.push(`OIDC_PROVIDER_${i}_ISSUER`);
+        if (!provider.clientId)
+            missingFields.push(`OIDC_PROVIDER_${i}_CLIENT_ID`);
+        if (!provider.clientSecret)
+            missingFields.push(`OIDC_PROVIDER_${i}_CLIENT_SECRET`);
+
+        if (missingFields.length > 0) {
+            console.warn(
+                `Skipping OIDC provider ${i} due to missing required fields: ${missingFields.join(', ')}`
+            );
             i++;
             continue;
         }
 
+        console.log(`Loaded OIDC provider ${i}: ${provider.name}`);
         providers.push(provider);
         i++;
     }
@@ -60,11 +70,26 @@ function loadProvidersFromEnv() {
             ),
         };
 
-        if (!provider.issuer || !provider.clientId || !provider.clientSecret) {
+        const missingFields = [];
+        if (!provider.issuer) missingFields.push('OIDC_ISSUER_URL');
+        if (!provider.clientId) missingFields.push('OIDC_CLIENT_ID');
+        if (!provider.clientSecret) missingFields.push('OIDC_CLIENT_SECRET');
+
+        if (missingFields.length > 0) {
+            console.error(
+                `Cannot load OIDC provider "${provider.name}": missing required fields: ${missingFields.join(', ')}`
+            );
             return [];
         }
 
+        console.log(`Loaded OIDC provider: ${provider.name}`);
         providers.push(provider);
+    }
+
+    if (providers.length === 0) {
+        console.warn(
+            'OIDC is enabled but no valid providers are configured. Please check your environment variables.'
+        );
     }
 
     return providers;

--- a/backend/tests/unit/modules/oidc/providerConfig.test.js
+++ b/backend/tests/unit/modules/oidc/providerConfig.test.js
@@ -120,6 +120,10 @@ describe('OIDC Provider Configuration', () => {
         });
 
         it('should return empty array if configuration is incomplete', () => {
+            const consoleErrorSpy = jest
+                .spyOn(console, 'error')
+                .mockImplementation();
+
             process.env.OIDC_ENABLED = 'true';
             process.env.OIDC_PROVIDER_NAME = 'Google';
 
@@ -127,6 +131,11 @@ describe('OIDC Provider Configuration', () => {
             const providers = providerConfig.getAllProviders();
 
             expect(providers).toEqual([]);
+            expect(consoleErrorSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Cannot load OIDC provider')
+            );
+
+            consoleErrorSpy.mockRestore();
         });
     });
 
@@ -155,6 +164,13 @@ describe('OIDC Provider Configuration', () => {
         });
 
         it('should skip numbered providers with incomplete config', () => {
+            const consoleWarnSpy = jest
+                .spyOn(console, 'warn')
+                .mockImplementation();
+            const consoleLogSpy = jest
+                .spyOn(console, 'log')
+                .mockImplementation();
+
             process.env.OIDC_ENABLED = 'true';
 
             process.env.OIDC_PROVIDER_1_NAME = 'Google';
@@ -171,6 +187,15 @@ describe('OIDC Provider Configuration', () => {
 
             expect(providers).toHaveLength(1);
             expect(providers[0].slug).toBe('okta');
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Skipping OIDC provider 1')
+            );
+            expect(consoleLogSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Loaded OIDC provider 2: Okta')
+            );
+
+            consoleWarnSpy.mockRestore();
+            consoleLogSpy.mockRestore();
         });
 
         it('should handle different settings per provider', () => {
@@ -229,6 +254,10 @@ describe('OIDC Provider Configuration', () => {
 
     describe('isOidcEnabled', () => {
         it('should return true when OIDC is enabled with valid provider', () => {
+            const consoleLogSpy = jest
+                .spyOn(console, 'log')
+                .mockImplementation();
+
             process.env.OIDC_ENABLED = 'true';
             process.env.OIDC_PROVIDER_NAME = 'Google';
             process.env.OIDC_PROVIDER_SLUG = 'google';
@@ -238,18 +267,37 @@ describe('OIDC Provider Configuration', () => {
 
             providerConfig.reloadProviders();
             expect(providerConfig.isOidcEnabled()).toBe(true);
+
+            consoleLogSpy.mockRestore();
         });
 
         it('should return false when OIDC_ENABLED is false', () => {
+            const consoleLogSpy = jest
+                .spyOn(console, 'log')
+                .mockImplementation();
+
             process.env.OIDC_ENABLED = 'false';
             providerConfig.reloadProviders();
             expect(providerConfig.isOidcEnabled()).toBe(false);
+
+            consoleLogSpy.mockRestore();
         });
 
         it('should return false when no providers configured', () => {
+            const consoleWarnSpy = jest
+                .spyOn(console, 'warn')
+                .mockImplementation();
+
             process.env.OIDC_ENABLED = 'true';
             providerConfig.reloadProviders();
             expect(providerConfig.isOidcEnabled()).toBe(false);
+            expect(consoleWarnSpy).toHaveBeenCalledWith(
+                expect.stringContaining(
+                    'OIDC is enabled but no valid providers are configured'
+                )
+            );
+
+            consoleWarnSpy.mockRestore();
         });
     });
 


### PR DESCRIPTION
## Description

Adds comprehensive logging to the OIDC provider configuration module to help users debug why the OIDC login button isn't appearing after configuration.

**What does this PR do?**
When OIDC is configured but the login button doesn't appear on the login page, users previously had no way to debug what was wrong. This PR adds detailed console logging at various stages of provider loading to help identify configuration issues.

**Why is this change needed?**
Issue #1036 reported that after configuring OIDC following the documentation, the OIDC login button did not appear. The current code silently skips providers with missing required fields, making it very difficult for users to debug their configuration.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

Fixes #1036

## Changes Made

Added logging for:
- When OIDC is disabled (with helpful message to set `OIDC_ENABLED=true`)
- When providers are successfully loaded (shows provider name)
- When numbered providers are skipped due to missing fields (shows which fields are missing)
- When single provider config is incomplete (error with specific missing fields)
- When OIDC is enabled but no valid providers are found

This helps users quickly identify configuration issues like:
- Typos in environment variable names  
- Missing required fields (issuer, clientId, clientSecret)
- Incorrect `OIDC_ENABLED` value
- Docker environment variable mounting issues

## Testing

- [x] Existing unit tests pass
- [x] Added new test cases to verify logging behavior
- [x] Tested with missing required fields to verify warning messages
- [x] Tested with valid configuration to verify success messages
- [x] Linting passes (`npm run lint`)

**Commands run:**
```bash
npm test -- backend/tests/unit/modules/oidc/providerConfig.test.js
npm run lint:fix
```

All 18 tests pass with the new logging functionality.

## Example Output

**When OIDC is disabled:**
```
OIDC is disabled. Set OIDC_ENABLED=true to enable SSO authentication.
```

**When single provider is loaded successfully:**
```
Loaded OIDC provider: Google
```

**When provider config is missing required fields:**
```
Cannot load OIDC provider "Google": missing required fields: OIDC_ISSUER_URL, OIDC_CLIENT_ID
```

**When numbered provider is skipped:**
```
Skipping OIDC provider 1 due to missing required fields: OIDC_PROVIDER_1_ISSUER, OIDC_PROVIDER_1_CLIENT_ID
```

## Checklist

- [x] My code follows the project's code conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated tests to cover my changes  
- [x] All new and existing tests pass
- [x] I have run the linter and fixed any issues
- [x] My changes do not introduce new warnings
- [x] I have checked that my changes work in the development environment

## Additional Notes

This is a non-breaking change that only adds logging. No functional behavior changes - providers are loaded exactly the same way as before, but now users get helpful feedback in the console logs when things go wrong.

For users affected by issue #1036, after deploying this fix, they should check their Docker/server logs for the specific error messages which will tell them exactly which environment variables are missing or incorrectly set.