### PR TITLE
fix(mcp): Include subtasks in get_task API response

### DIFF
--- a/backend/modules/mcp/tools/taskTools.js
+++ b/backend/modules/mcp/tools/taskTools.js
@@ -15,23 +15,37 @@ const { Task, Project, Tag } = require('../../../models');
 async function findTaskByIdentifier(identifier, userId) {
     const isNumeric = !isNaN(identifier);
 
+    const includeOptions = [
+        { model: Project, as: 'Project' },
+        { model: Tag, as: 'Tags' },
+        {
+            model: Task,
+            as: 'Subtasks',
+            required: false,
+            include: [
+                {
+                    model: Tag,
+                    as: 'Tags',
+                    through: { attributes: [] },
+                },
+            ],
+            separate: true,
+            order: [
+                ['order', 'ASC'],
+                ['created_at', 'ASC'],
+            ],
+        },
+    ];
+
     if (isNumeric) {
         return await taskRepository.findByIdAndUser(
             parseInt(identifier),
             userId,
-            {
-                include: [
-                    { model: Project, as: 'Project' },
-                    { model: Tag, as: 'Tags' },
-                ],
-            }
+            { include: includeOptions }
         );
     } else {
         return await taskRepository.findByUid(identifier, {
-            include: [
-                { model: Project, as: 'Project' },
-                { model: Tag, as: 'Tags' },
-            ],
+            include: includeOptions,
         });
     }
 }


### PR DESCRIPTION
## Description

This PR fixes the MCP API's `get_task` endpoint to include subtasks in the response. Previously, when retrieving a single task via the MCP API, subtasks were not included even if they existed, making it difficult for client applications to display or process the full task hierarchy.

The fix updates the `findTaskByIdentifier` function to include the `Subtasks` association with proper configuration (ordering by `order` and `created_at`, including Tags for subtasks). The `serializeTask` function already supported subtasks serialization, so only the query includes needed to be updated.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1029

## Testing

**How did you test this?**

- Verified the code follows the existing pattern used in `TASK_INCLUDES_WITH_SUBTASKS` from `backend/modules/tasks/utils/constants.js`
- Confirmed the `serializeTask` function already handles subtasks serialization (lines 98-117 in `backend/modules/tasks/core/serializers.js`)
- Ran linting to ensure code style compliance

**Commands run:**

- [x] `npm run lint` (passed successfully)
- [ ] Tested manually in browser (MCP API requires client setup)
- [ ] Tested on mobile (not applicable)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [ ] Added/updated tests (no existing MCP tests found)
- [ ] Updated documentation (not needed - internal API fix)
- [ ] Database migrations included and tested (not applicable)
- [ ] Translation keys added and synced (not applicable)

## Additional Notes

This change enables clients using the MCP API to access the full task hierarchy (task + subtasks) in a single API call, eliminating the need for multiple round trips to fetch subtasks separately.