### PR TITLE
feat(oauth): Add OAuth2 resource server support (RFC 9728)

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -123,6 +123,10 @@ app.use((req, res, next) => {
     })(req, res, next);
 });
 
+// RFC 9728 — Protected Resource Metadata (no auth required)
+const oauthRoutes = require('./modules/oauth/routes');
+app.use(oauthRoutes);
+
 // Session configuration
 const sessionMiddleware = session({
     secret: config.secret,
@@ -150,52 +154,22 @@ app.use(sessionMiddleware);
 const caldavRoutes = require('./modules/caldav/routes');
 app.use(caldavRoutes);
 
-// CSRF protection using lusca (CodeQL recommended library)
+// CSRF protection using lusca (CodeQL recommended library).
+// Only applies to session-authenticated state-changing requests (POST/PUT/PATCH/DELETE).
+// CSRF protects against cross-site requests that hijack an existing browser session;
+// unauthenticated requests and Bearer-token requests have no session to hijack.
 const lusca = require('lusca');
 const { csrfMiddleware } = require('./middleware/csrf');
 
-// Pre-check middleware to exempt test/Bearer requests before lusca runs
-app.use((req, res, next) => {
-    // Public unauthenticated endpoints that should bypass CSRF
-    // These are routes that don't require authentication and are used during login/registration
-    const publicPaths = [
-        '/api/login',
-        '/api/register',
-        '/api/verify-email',
-        '/api/version',
-        '/api/registration-status',
-        '/api/health',
-    ];
-
-    const isPublicPath = publicPaths.some((path) => req.path === path);
-    const isOidcPath = req.path.startsWith('/api/oidc/');
-    const isFeatureFlagsPath = req.path.startsWith('/api/feature-flags');
-    const isCalDAVPath =
-        req.path.startsWith('/caldav/') ||
-        req.path.startsWith('/.well-known/caldav');
-
-    // Mark exempt requests so lusca wrapper can skip them
-    if (
-        process.env.NODE_ENV === 'test' ||
-        req.headers.authorization?.startsWith('Bearer ') ||
-        isPublicPath ||
-        isOidcPath ||
-        isFeatureFlagsPath ||
-        isCalDAVPath
-    ) {
-        req._csrfExempt = true;
-    }
-    next();
-});
-
-// Apply lusca CSRF - wrapped to check exemption flag
-// Only apply to state-changing methods (POST, PUT, PATCH, DELETE)
 app.use((req, res, next) => {
     const statefulMethods = ['POST', 'PUT', 'PATCH', 'DELETE'];
-    if (req._csrfExempt || !statefulMethods.includes(req.method)) {
-        return next();
+    const hasSession = !!(req.session && req.session.userId);
+    const isTest = process.env.NODE_ENV === 'test';
+
+    if (!isTest && hasSession && statefulMethods.includes(req.method)) {
+        return csrfMiddleware(req, res, next);
     }
-    return csrfMiddleware(req, res, next);
+    return next();
 });
 
 // Static files

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -21,6 +21,7 @@ module.exports = {
     testTimeout: 30000,
     maxWorkers: '100%',
     moduleNameMapper: {
+        '^jose$': '<rootDir>/tests/mocks/jose.js',
         '^nanoid$': '<rootDir>/tests/mocks/nanoid.js',
     },
 };

--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -1,5 +1,6 @@
-const { User } = require('../models');
+const { User, OIDCIdentity } = require('../models');
 const { findValidTokenByValue } = require('../modules/users/apiTokenService');
+const { validateAccessToken } = require('../modules/oidc/service');
 
 const getBearerToken = (req) => {
     const authHeader = req.headers?.authorization || '';
@@ -8,6 +9,21 @@ const getBearerToken = (req) => {
         return token.trim();
     }
     return null;
+};
+
+// Sends a 401 and, when OIDC is enabled, sets WWW-Authenticate so OAuth2 clients
+// can discover the authorization server (RFC 9728).
+const unauthorized = (res, message) => {
+    if (process.env.OIDC_ENABLED === 'true') {
+        const baseUrl = process.env.BASE_URL?.replace(/\/$/, ''); // trim trailing slash
+        if (baseUrl) {
+            res.set(
+                'WWW-Authenticate',
+                `Bearer resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`
+            );
+        }
+    }
+    return res.status(401).json({ error: message });
 };
 
 const requireAuth = async (req, res, next) => {
@@ -30,35 +46,67 @@ const requireAuth = async (req, res, next) => {
 
         const bearerToken = getBearerToken(req);
         if (!bearerToken) {
-            return res.status(401).json({ error: 'Authentication required' });
+            return unauthorized(res, 'Authentication required');
         }
 
-        const apiToken = await findValidTokenByValue(bearerToken);
-        if (!apiToken) {
-            return res
-                .status(401)
-                .json({ error: 'Invalid or expired API token' });
+        if (bearerToken.startsWith('tt_')) {
+            // Tududi API key — validate via bcrypt
+            const apiToken = await findValidTokenByValue(bearerToken);
+            if (!apiToken) {
+                return unauthorized(res, 'Invalid or expired API token');
+            }
+
+            const user = await User.findByPk(apiToken.user_id);
+            if (!user) {
+                return unauthorized(res, 'User not found');
+            }
+
+            req.currentUser = user;
+            req.authToken = apiToken;
+
+            // Update last_used_at asynchronously (non-blocking) to avoid slowing down the request
+            // Only update if it hasn't been updated in the last 5 minutes to reduce database writes
+            const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
+            if (
+                !apiToken.last_used_at ||
+                apiToken.last_used_at < fiveMinutesAgo
+            ) {
+                // Fire and forget - don't await this update
+                apiToken.update({ last_used_at: new Date() }).catch((err) => {
+                    console.error('Failed to update token last_used_at:', err);
+                });
+            }
+
+            return next();
         }
 
-        const user = await User.findByPk(apiToken.user_id);
-        if (!user) {
-            return res.status(401).json({ error: 'User not found' });
-        }
+        // OAuth2 JWT — validate via OIDC provider JWKS
+        if (process.env.OIDC_ENABLED === 'true') {
+            let payload;
+            try {
+                payload = await validateAccessToken(bearerToken);
+            } catch (err) {
+                console.error('JWT validation failed:', err);
+                return unauthorized(res, 'Invalid or expired access token');
+            }
 
-        req.currentUser = user;
-        req.authToken = apiToken;
-
-        // Update last_used_at asynchronously (non-blocking) to avoid slowing down the request
-        // Only update if it hasn't been updated in the last 5 minutes to reduce database writes
-        const fiveMinutesAgo = new Date(Date.now() - 5 * 60 * 1000);
-        if (!apiToken.last_used_at || apiToken.last_used_at < fiveMinutesAgo) {
-            // Fire and forget - don't await this update
-            apiToken.update({ last_used_at: new Date() }).catch((err) => {
-                console.error('Failed to update token last_used_at:', err);
+            const identity = await OIDCIdentity.findOne({
+                where: { subject: payload.sub },
+                include: [{ model: User, as: 'User' }],
             });
+
+            if (!identity?.User) {
+                return unauthorized(
+                    res,
+                    'No account found for this identity. Please log in via OIDC first.'
+                );
+            }
+
+            req.currentUser = identity.User;
+            return next();
         }
 
-        next();
+        return unauthorized(res, 'Invalid or expired API token');
     } catch (error) {
         console.error('Authentication error:', error);
         res.status(500).json({ error: 'Authentication error' });

--- a/backend/modules/mcp/controller.js
+++ b/backend/modules/mcp/controller.js
@@ -49,10 +49,9 @@ async function getMcpConfig(req, res) {
 async function handleMcpMessage(req, res) {
     try {
         const user = req.mcpUser;
-        const apiToken = req.mcpApiToken;
 
         // Delegate to HTTP transport handler
-        await handleMcpHttpRequest(req, res, user, apiToken);
+        await handleMcpHttpRequest(req, res, user);
     } catch (error) {
         console.error('Error handling MCP message:', error);
 

--- a/backend/modules/mcp/httpTransport.js
+++ b/backend/modules/mcp/httpTransport.js
@@ -14,13 +14,12 @@ const { registerAllTools } = require('./toolRegistry');
  * Handle MCP HTTP request
  * This creates a stateless MCP server for each request
  */
-async function handleMcpHttpRequest(req, res, user, apiToken) {
+async function handleMcpHttpRequest(req, res, user) {
     try {
         // Create context for tools
         const context = {
             userId: user.id,
             user: user,
-            apiToken: apiToken,
         };
 
         // Initialize MCP server
@@ -88,13 +87,6 @@ async function handleMcpHttpRequest(req, res, user, apiToken) {
 
         // Handle the HTTP request
         await transport.handleRequest(req, res, req.body);
-
-        // Update token last_used_at (fire and forget)
-        apiToken
-            .update({ last_used_at: new Date() })
-            .catch((err) =>
-                console.error('Failed to update token last_used_at:', err)
-            );
     } catch (error) {
         console.error('MCP HTTP handler error:', error);
 

--- a/backend/modules/mcp/middleware.js
+++ b/backend/modules/mcp/middleware.js
@@ -1,68 +1,14 @@
 'use strict';
 
-const { findValidTokenByValue } = require('../users/apiTokenService');
-const { User } = require('../../models');
-
 /**
- * Middleware to authenticate MCP requests using Bearer token
- * Validates the Authorization header and attaches user context to req
+ * Middleware to attach MCP-specific user context after requireAuth has run.
+ * Authentication (API key or OAuth2 JWT) is handled by requireAuth, which
+ * populates req.currentUser. This middleware maps that to the MCP-specific
+ * fields expected by the MCP controller.
  */
-async function authenticateMcpRequest(req, res, next) {
-    try {
-        // Extract Bearer token from Authorization header
-        const authHeader = req.headers.authorization;
-
-        if (!authHeader) {
-            return res.status(401).json({
-                error: 'Unauthorized',
-                message:
-                    'Missing Authorization header. Include: Authorization: Bearer YOUR_API_TOKEN',
-            });
-        }
-
-        // Parse Bearer token
-        const parts = authHeader.split(' ');
-        if (parts.length !== 2 || parts[0] !== 'Bearer') {
-            return res.status(401).json({
-                error: 'Unauthorized',
-                message:
-                    'Invalid Authorization header format. Use: Authorization: Bearer YOUR_API_TOKEN',
-            });
-        }
-
-        const apiToken = parts[1];
-
-        // Validate token
-        const tokenRecord = await findValidTokenByValue(apiToken);
-        if (!tokenRecord) {
-            return res.status(401).json({
-                error: 'Unauthorized',
-                message:
-                    'Invalid or expired API token. Generate a new token in Profile → API Keys.',
-            });
-        }
-
-        // Get user
-        const user = await User.findByPk(tokenRecord.user_id);
-        if (!user) {
-            return res.status(401).json({
-                error: 'Unauthorized',
-                message: 'User not found for the provided token.',
-            });
-        }
-
-        // Attach to request
-        req.mcpUser = user;
-        req.mcpApiToken = tokenRecord;
-
-        next();
-    } catch (error) {
-        console.error('MCP authentication error:', error);
-        return res.status(500).json({
-            error: 'Authentication error',
-            message: error.message,
-        });
-    }
+function authenticateMcpRequest(req, res, next) {
+    req.mcpUser = req.currentUser;
+    next();
 }
 
 module.exports = {

--- a/backend/modules/oauth/protectedResource.js
+++ b/backend/modules/oauth/protectedResource.js
@@ -1,0 +1,27 @@
+'use strict';
+
+/**
+ * Serves the OAuth 2.0 Protected Resource Metadata document (RFC 9728).
+ *
+ * Registered at /.well-known/oauth-protected-resource before requireAuth.
+ * Only active when OIDC_ENABLED=true, OIDC_ISSUER_URL and BASE_URL are set.
+ */
+function handleProtectedResource(req, res) {
+    const issuerUrl = process.env.OIDC_ISSUER_URL?.replace(/\/$/, ''); // trim trailing slash
+    if (!issuerUrl || process.env.OIDC_ENABLED !== 'true') {
+        return res.status(404).end();
+    }
+
+    const resource = process.env.BASE_URL?.replace(/\/$/, ''); // trim trailing slash
+    if (!resource) {
+        return res.status(404).end();
+    }
+
+    return res.json({
+        resource,
+        authorization_servers: [issuerUrl],
+        scopes_supported: ['openid', 'email', 'profile'],
+    });
+}
+
+module.exports = { handleProtectedResource };

--- a/backend/modules/oauth/routes.js
+++ b/backend/modules/oauth/routes.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const express = require('express');
+const { handleProtectedResource } = require('./protectedResource');
+
+const router = express.Router();
+
+router.get('/.well-known/oauth-protected-resource', handleProtectedResource);
+
+module.exports = router;

--- a/backend/modules/oidc/service.js
+++ b/backend/modules/oidc/service.js
@@ -1,8 +1,10 @@
 const { Issuer, generators } = require('openid-client');
+const { createRemoteJWKSet, jwtVerify } = require('jose');
 const providerConfig = require('./providerConfig');
 const stateManager = require('./stateManager');
 
 const issuerCache = new Map();
+let jwksCache = null;
 
 async function discoverProvider(config) {
     if (issuerCache.has(config.issuer)) {
@@ -138,8 +140,32 @@ async function refreshAccessToken(providerSlug, refreshToken) {
     };
 }
 
+/**
+ * Validates an OAuth2 access token (JWT) issued by the configured OIDC provider.
+ * Used by the MCP middleware to authenticate requests from OAuth2 clients.
+ * Returns the token payload on success, or throws on failure.
+ */
+async function validateAccessToken(token) {
+    const issuerUrl = process.env.OIDC_ISSUER_URL;
+    if (!issuerUrl) {
+        throw new Error('OIDC_ISSUER_URL is not configured');
+    }
+
+    if (!jwksCache) {
+        const issuer = await Issuer.discover(issuerUrl);
+        jwksCache = createRemoteJWKSet(new URL(issuer.jwks_uri));
+    }
+
+    const { payload } = await jwtVerify(token, jwksCache, {
+        issuer: issuerUrl,
+    });
+
+    return payload;
+}
+
 function clearIssuerCache() {
     issuerCache.clear();
+    jwksCache = null;
 }
 
 module.exports = {
@@ -148,6 +174,7 @@ module.exports = {
     handleCallback,
     validateIdToken,
     refreshAccessToken,
+    validateAccessToken,
     getRedirectUri,
     clearIssuerCache,
 };

--- a/backend/tests/integration/oauth.test.js
+++ b/backend/tests/integration/oauth.test.js
@@ -1,0 +1,205 @@
+'use strict';
+
+const request = require('supertest');
+const { OIDCIdentity } = require('../../models');
+const { createTestUser } = require('../helpers/testUtils');
+
+// Prevent openid-client from making real network calls during discovery.
+jest.mock('openid-client', () => {
+    const MockClient = jest.fn();
+    const MockIssuer = {
+        discover: jest.fn().mockResolvedValue({
+            jwks_uri: 'https://id.example.com/.well-known/jwks.json',
+            authorization_endpoint: 'https://id.example.com/authorize',
+            token_endpoint: 'https://id.example.com/token',
+            Client: MockClient,
+        }),
+        Client: MockClient,
+    };
+    return {
+        Issuer: MockIssuer,
+        generators: {
+            state: jest.fn(),
+            nonce: jest.fn(),
+            codeVerifier: jest.fn(),
+            codeChallenge: jest.fn(),
+        },
+    };
+});
+
+// Mock validateAccessToken so JWT tests don't need a live JWKS endpoint.
+// All other logic in auth.js (OIDCIdentity lookup, WWW-Authenticate header, etc.) runs for real.
+jest.mock('../../modules/oidc/service', () => ({
+    validateAccessToken: jest.fn(),
+}));
+
+const { validateAccessToken } = require('../../modules/oidc/service');
+const app = require('../../app');
+
+// jest.replaceProperty restores automatically between tests (restoreMocks: true in jest.config.js).
+const withEnv = (vars) =>
+    jest.replaceProperty(process, 'env', { ...process.env, ...vars });
+
+describe('OAuth2 resource server', () => {
+    afterEach(async () => {
+        await OIDCIdentity.destroy({ where: {} });
+    });
+
+    describe('GET /.well-known/oauth-protected-resource', () => {
+        it('returns 404 when OIDC is disabled', async () => {
+            withEnv({
+                BASE_URL: 'https://app.example.com',
+                OIDC_ENABLED: undefined,
+                OIDC_ISSUER_URL: 'https://id.example.com',
+            });
+            const res = await request(app).get(
+                '/.well-known/oauth-protected-resource'
+            );
+            expect(res.status).toBe(404);
+        });
+
+        it('returns 200 without authentication when OIDC is enabled', async () => {
+            withEnv({
+                BASE_URL: 'https://app.example.com',
+                OIDC_ENABLED: 'true',
+                OIDC_ISSUER_URL: 'https://id.example.com',
+            });
+            const res = await request(app).get(
+                '/.well-known/oauth-protected-resource'
+            );
+            expect(res.status).toBe(200);
+        });
+
+        it('returns correct RFC 9728 body', async () => {
+            withEnv({
+                BASE_URL: 'https://app.example.com',
+                OIDC_ENABLED: 'true',
+                OIDC_ISSUER_URL: 'https://id.example.com',
+            });
+            const res = await request(app).get(
+                '/.well-known/oauth-protected-resource'
+            );
+            expect(res.body).toEqual({
+                resource: 'https://app.example.com',
+                authorization_servers: ['https://id.example.com'],
+                scopes_supported: ['openid', 'email', 'profile'],
+            });
+        });
+
+        it('returns application/json content type', async () => {
+            withEnv({
+                BASE_URL: 'https://app.example.com',
+                OIDC_ENABLED: 'true',
+                OIDC_ISSUER_URL: 'https://id.example.com',
+            });
+            const res = await request(app).get(
+                '/.well-known/oauth-protected-resource'
+            );
+            expect(res.headers['content-type']).toMatch(/application\/json/);
+        });
+    });
+
+    describe('WWW-Authenticate header on 401', () => {
+        it('is present when OIDC is enabled and no credentials are supplied', async () => {
+            withEnv({
+                BASE_URL: 'https://app.example.com',
+                OIDC_ENABLED: 'true',
+            });
+            const res = await request(app).get('/api/tasks');
+            expect(res.status).toBe(401);
+            expect(res.headers['www-authenticate']).toMatch(
+                /Bearer resource_metadata="https:\/\/app\.example\.com\/.well-known\/oauth-protected-resource"/
+            );
+        });
+
+        it('is present when OIDC is enabled and an invalid Bearer token is supplied', async () => {
+            withEnv({
+                BASE_URL: 'https://app.example.com',
+                OIDC_ENABLED: 'true',
+            });
+            validateAccessToken.mockRejectedValueOnce(
+                new Error('invalid token')
+            );
+            const res = await request(app)
+                .get('/api/tasks')
+                .set('Authorization', 'Bearer bogus');
+            expect(res.status).toBe(401);
+            expect(res.headers['www-authenticate']).toBeDefined();
+        });
+
+        it('is absent when OIDC is disabled', async () => {
+            withEnv({
+                BASE_URL: 'https://app.example.com',
+                OIDC_ENABLED: undefined,
+            });
+            const res = await request(app).get('/api/tasks');
+            expect(res.status).toBe(401);
+            expect(res.headers['www-authenticate']).toBeUndefined();
+        });
+    });
+
+    describe('JWT Bearer authentication', () => {
+        let user;
+
+        beforeEach(async () => {
+            withEnv({
+                BASE_URL: 'https://app.example.com',
+                OIDC_ENABLED: 'true',
+                OIDC_ISSUER_URL: 'https://id.example.com',
+            });
+
+            user = await createTestUser({
+                email: `jwt_${Date.now()}@example.com`,
+            });
+            await OIDCIdentity.create({
+                user_id: user.id,
+                provider_slug: 'test-provider',
+                subject: 'sub-abc123',
+                email: user.email,
+            });
+        });
+
+        it('authenticates a valid JWT and allows access', async () => {
+            validateAccessToken.mockResolvedValueOnce({ sub: 'sub-abc123' });
+            const res = await request(app)
+                .get('/api/tasks')
+                .set('Authorization', 'Bearer valid.jwt.token');
+            expect(res.status).toBe(200);
+        });
+
+        it('rejects a JWT that fails validation', async () => {
+            validateAccessToken.mockRejectedValueOnce(
+                new Error('invalid signature')
+            );
+            const res = await request(app)
+                .get('/api/tasks')
+                .set('Authorization', 'Bearer bad.jwt.token');
+            expect(res.status).toBe(401);
+            expect(res.headers['www-authenticate']).toBeDefined();
+        });
+
+        it('rejects a JWT whose sub has no linked OIDC identity', async () => {
+            validateAccessToken.mockResolvedValueOnce({ sub: 'unknown-sub' });
+            const res = await request(app)
+                .get('/api/tasks')
+                .set('Authorization', 'Bearer valid.jwt.token');
+            expect(res.status).toBe(401);
+            expect(res.body.error).toMatch(/No account found/i);
+        });
+
+        it('does not invoke JWT validation for tt_ API keys', async () => {
+            const agent = request.agent(app);
+            await agent
+                .post('/api/login')
+                .send({ email: user.email, password: 'password123' });
+            const keyRes = await agent
+                .post('/api/profile/api-keys')
+                .send({ name: 'test' });
+            const res = await request(app)
+                .get('/api/tasks')
+                .set('Authorization', `Bearer ${keyRes.body.token}`);
+            expect(res.status).toBe(200);
+            expect(validateAccessToken).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/backend/tests/mocks/jose.js
+++ b/backend/tests/mocks/jose.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+    createRemoteJWKSet: jest.fn(),
+    jwtVerify: jest.fn(),
+};

--- a/backend/tests/unit/modules/mcp/controller.test.js
+++ b/backend/tests/unit/modules/mcp/controller.test.js
@@ -226,8 +226,7 @@ describe('MCP Controller', () => {
 
         it('should delegate to handleMcpHttpRequest', async () => {
             const mockUser = { id: 1, email: 'test@example.com' };
-            const mockToken = { name: 'test-token' };
-            const mockReq = { mcpUser: mockUser, mcpApiToken: mockToken };
+            const mockReq = { mcpUser: mockUser };
             const mockRes = {};
 
             handleMcpHttpRequest.mockResolvedValue(undefined);
@@ -237,13 +236,12 @@ describe('MCP Controller', () => {
             expect(handleMcpHttpRequest).toHaveBeenCalledWith(
                 mockReq,
                 mockRes,
-                mockUser,
-                mockToken
+                mockUser
             );
         });
 
         it('should return 500 when handleMcpHttpRequest throws', async () => {
-            const mockReq = { mcpUser: {}, mcpApiToken: {} };
+            const mockReq = { mcpUser: {} };
             const mockRes = {
                 headersSent: false,
                 status: jest.fn().mockReturnThis(),
@@ -266,7 +264,7 @@ describe('MCP Controller', () => {
         });
 
         it('should not send response when headers already sent', async () => {
-            const mockReq = { mcpUser: {}, mcpApiToken: {} };
+            const mockReq = { mcpUser: {} };
             const mockRes = {
                 headersSent: true,
                 status: jest.fn(),

--- a/backend/tests/unit/modules/mcp/middleware.test.js
+++ b/backend/tests/unit/modules/mcp/middleware.test.js
@@ -4,31 +4,11 @@ const {
     authenticateMcpRequest,
 } = require('../../../../modules/mcp/middleware');
 
-// Mock dependencies
-jest.mock('../../../../modules/users/apiTokenService', () => ({
-    findValidTokenByValue: jest.fn(),
-}));
-
-jest.mock('../../../../models', () => ({
-    User: {
-        findByPk: jest.fn(),
-    },
-}));
-
-const {
-    findValidTokenByValue,
-} = require('../../../../modules/users/apiTokenService');
-const { User } = require('../../../../models');
-
 describe('MCP Middleware', () => {
     let req, res, next;
 
     beforeEach(() => {
-        jest.clearAllMocks();
-
-        req = {
-            headers: {},
-        };
+        req = { headers: {} };
         res = {
             status: jest.fn().mockReturnThis(),
             json: jest.fn(),
@@ -37,106 +17,24 @@ describe('MCP Middleware', () => {
     });
 
     describe('authenticateMcpRequest', () => {
-        it('should reject request without Authorization header', async () => {
-            await authenticateMcpRequest(req, res, next);
+        it('should map req.currentUser to req.mcpUser and call next', () => {
+            const mockUser = { id: 1, email: 'test@example.com' };
+            req.currentUser = mockUser;
 
-            expect(res.status).toHaveBeenCalledWith(401);
-            expect(res.json).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    error: 'Unauthorized',
-                    message: expect.stringContaining(
-                        'Missing Authorization header'
-                    ),
-                })
-            );
-            expect(next).not.toHaveBeenCalled();
-        });
+            authenticateMcpRequest(req, res, next);
 
-        it('should reject request with non-Bearer Authorization header', async () => {
-            req.headers.authorization = 'Token some-token';
-
-            await authenticateMcpRequest(req, res, next);
-
-            expect(res.status).toHaveBeenCalledWith(401);
-            expect(res.json).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    error: 'Unauthorized',
-                    message: expect.stringContaining(
-                        'Invalid Authorization header format'
-                    ),
-                })
-            );
-            expect(next).not.toHaveBeenCalled();
-        });
-
-        it('should reject request with invalid API token', async () => {
-            req.headers.authorization = 'Bearer invalid-token';
-            findValidTokenByValue.mockResolvedValue(null);
-
-            await authenticateMcpRequest(req, res, next);
-
-            expect(res.status).toHaveBeenCalledWith(401);
-            expect(res.json).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    error: 'Unauthorized',
-                    message: expect.stringContaining(
-                        'Invalid or expired API token'
-                    ),
-                })
-            );
-            expect(next).not.toHaveBeenCalled();
-        });
-
-        it('should reject request when user is not found for token', async () => {
-            req.headers.authorization = 'Bearer valid-token';
-            findValidTokenByValue.mockResolvedValue({ user_id: 42 });
-            User.findByPk.mockResolvedValue(null);
-
-            await authenticateMcpRequest(req, res, next);
-
-            expect(res.status).toHaveBeenCalledWith(401);
-            expect(res.json).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    error: 'Unauthorized',
-                    message: expect.stringContaining('User not found'),
-                })
-            );
-            expect(next).not.toHaveBeenCalled();
-        });
-
-        it('should attach user and token context and call next on valid auth', async () => {
-            const mockUser = { id: 42, email: 'test@example.com' };
-            const mockToken = { user_id: 42, name: 'test-token' };
-
-            req.headers.authorization = 'Bearer valid-token';
-            findValidTokenByValue.mockResolvedValue(mockToken);
-            User.findByPk.mockResolvedValue(mockUser);
-
-            await authenticateMcpRequest(req, res, next);
-
-            expect(findValidTokenByValue).toHaveBeenCalledWith('valid-token');
-            expect(User.findByPk).toHaveBeenCalledWith(42);
             expect(req.mcpUser).toBe(mockUser);
-            expect(req.mcpApiToken).toBe(mockToken);
             expect(next).toHaveBeenCalled();
             expect(res.status).not.toHaveBeenCalled();
         });
 
-        it('should handle errors from token validation gracefully', async () => {
-            req.headers.authorization = 'Bearer token';
-            findValidTokenByValue.mockRejectedValue(
-                new Error('DB connection failed')
-            );
+        it('should pass through when currentUser is undefined', () => {
+            req.currentUser = undefined;
 
-            await authenticateMcpRequest(req, res, next);
+            authenticateMcpRequest(req, res, next);
 
-            expect(res.status).toHaveBeenCalledWith(500);
-            expect(res.json).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    error: 'Authentication error',
-                    message: 'DB connection failed',
-                })
-            );
+            expect(req.mcpUser).toBeUndefined();
+            expect(next).toHaveBeenCalled();
         });
     });
 });

--- a/backend/tests/unit/modules/oauth/protectedResource.test.js
+++ b/backend/tests/unit/modules/oauth/protectedResource.test.js
@@ -1,0 +1,77 @@
+'use strict';
+
+const {
+    handleProtectedResource,
+} = require('../../../../modules/oauth/protectedResource');
+
+describe('handleProtectedResource', () => {
+    let req, res;
+
+    beforeEach(() => {
+        req = {};
+        res = {
+            status: jest.fn().mockReturnThis(),
+            end: jest.fn(),
+            json: jest.fn(),
+        };
+    });
+
+    afterEach(() => {
+        delete process.env.OIDC_ENABLED;
+        delete process.env.OIDC_ISSUER_URL;
+        delete process.env.BASE_URL;
+    });
+
+    it('returns 404 when OIDC_ENABLED is not set', () => {
+        process.env.OIDC_ISSUER_URL = 'https://id.example.com';
+        process.env.BASE_URL = 'https://app.example.com';
+        handleProtectedResource(req, res);
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.end).toHaveBeenCalled();
+        expect(res.json).not.toHaveBeenCalled();
+    });
+
+    it('returns 404 when OIDC_ENABLED is false', () => {
+        process.env.OIDC_ENABLED = 'false';
+        process.env.OIDC_ISSUER_URL = 'https://id.example.com';
+        process.env.BASE_URL = 'https://app.example.com';
+        handleProtectedResource(req, res);
+        expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('returns 404 when OIDC_ISSUER_URL is not set', () => {
+        process.env.OIDC_ENABLED = 'true';
+        process.env.BASE_URL = 'https://app.example.com';
+        handleProtectedResource(req, res);
+        expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('returns 404 when BASE_URL is not set', () => {
+        process.env.OIDC_ENABLED = 'true';
+        process.env.OIDC_ISSUER_URL = 'https://id.example.com';
+        handleProtectedResource(req, res);
+        expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it('returns RFC 9728 metadata when fully configured', () => {
+        process.env.OIDC_ENABLED = 'true';
+        process.env.OIDC_ISSUER_URL = 'https://id.example.com';
+        process.env.BASE_URL = 'https://app.example.com';
+        handleProtectedResource(req, res);
+        expect(res.json).toHaveBeenCalledWith({
+            resource: 'https://app.example.com',
+            authorization_servers: ['https://id.example.com'],
+            scopes_supported: ['openid', 'email', 'profile'],
+        });
+    });
+
+    it('strips trailing slashes from BASE_URL and OIDC_ISSUER_URL', () => {
+        process.env.OIDC_ENABLED = 'true';
+        process.env.OIDC_ISSUER_URL = 'https://id.example.com/';
+        process.env.BASE_URL = 'https://app.example.com/';
+        handleProtectedResource(req, res);
+        const body = res.json.mock.calls[0][0];
+        expect(body.resource).toBe('https://app.example.com');
+        expect(body.authorization_servers[0]).toBe('https://id.example.com');
+    });
+});

--- a/docs/08-user-management.md
+++ b/docs/08-user-management.md
@@ -214,6 +214,12 @@ This document explains how user management works in tududi from a user behavior 
     - Expired or revoked tokens are rejected
     - Last used timestamp is updated on successful authentication
 
+30. **OAuth2 JWT authentication (resource server):**
+    - When `OIDC_ENABLED=true`, Bearer tokens without the `tt_` prefix are treated as JWTs
+    - Validated against the OIDC provider's JWKS endpoint (`OIDC_ISSUER_URL`)
+    - The token's `sub` claim must match a linked OIDC identity in the database
+    - Discovery metadata available at `/.well-known/oauth-protected-resource` (RFC 9728)
+
 ---
 
 ## **Admin User Management**

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,6 +175,15 @@ graph TD
 6. Attaches user to request
 ```
 
+**3. OAuth2 JWT Bearer (Resource Server)**
+
+- Accepts JWT access tokens issued by a configured OIDC provider
+- Enabled when `OIDC_ENABLED=true` and `OIDC_ISSUER_URL` is set
+- Token validated against provider's JWKS endpoint
+- Subject (`sub`) claim mapped to a linked `OIDCIdentity` record
+- RFC 9728 discovery document served at `/.well-known/oauth-protected-resource`
+- `WWW-Authenticate` header returned on 401 responses when `BASE_URL` is set
+
 ### Permission System
 
 **Permission Levels:**

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "express-session": "~1.18.1",
         "helmet": "~8.1.0",
         "ical.js": "^2.1.0",
+        "jose": "^6.0.0",
         "js-yaml": "~4.1.0",
         "linguaisync": "^0.1.2",
         "lodash": "~4.18.1",
@@ -20019,6 +20020,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "express-session": "~1.18.1",
     "helmet": "~8.1.0",
     "ical.js": "^2.1.0",
+    "jose": "^6.0.0",
     "js-yaml": "~4.1.0",
     "linguaisync": "^0.1.2",
     "lodash": "~4.18.1",


### PR DESCRIPTION
<!--
Thank you for contributing to tududi!

Before submitting:
1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
2. Run: npm run pre-push (linting, formatting, tests)
3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
4. Delete sections that don't apply to your PR
-->

## Description

<!-- What does this PR do? Why is this change needed? -->
Implements [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728), providing "Protected Resource Metadata" for this resource server (if OIDC is enabled).

As a side-effect, the CSRF middleware logic is refactored to use a `hasSession` semantic check instead of an explicit path allowlist. This closes two security gaps in the existing implementation:

1. **CSRF bypass on session-authenticated CalDAV API routes** — #1106 moved CalDAV routes after session middleware so that `/api/caldav/*` endpoints can authenticate via session cookies. However, the CSRF middleware still exempts all `isCalDAVPath` requests, meaning a CSRF attack against those now session-bearing routes would succeed. The `hasSession` approach correctly protects any request that carries a session, regardless of path.

2. **Path allowlist rot** — the explicit public-path and feature-path exemptions in the CSRF middleware are a maintenance hazard: any new route registered before `requireAuth` that isn't added to the allowlist will have CSRF incorrectly applied to Bearer-token clients. Gating on `req.session.userId` instead means Bearer-token and unauthenticated requests are naturally exempt (no session = nothing to hijack), and no allowlist needs to be maintained.

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Testing

**How did you test this?**

<!-- Describe your testing steps -->

I am running it on my homelab, and used it to enable Claude Cloud to connect to Tududi's MCP.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [x] Tested on mobile (if UI changes)
  - No UI change

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
  - I used Claude to implement it, but I'm a software engineer of over a decade and have implemented a few OAuth2 flows in my day
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [x] Updated documentation (if needed)
- [x] Database migrations included and tested (if applicable)
- [x] Translation keys added and synced (if applicable)

## Additional Notes

<!-- Anything else reviewers should know? -->

Apologies for not discussing this first, I only stumbled across this project today and got excited because it was so close to my dream of having a self-hosted task manager I could control from Claude. The only missing part was being able to authenticate to the MCP with Oauth2, that's the primary purpose of this PR.

To use this with Claude and Pocket ID (my chosen OIDC provider):

1. Create a client for Claude in Pocket ID
2. Set up Tududi to use OIDC with Pocket ID
3. Configure a new Connector using `https://domain/api/v1/mcp`

Done, you can now create tasks from Claude :tada: 

<img width="1092" height="1020" alt="image" src="https://github.com/user-attachments/assets/1efdca28-8f94-439e-a9f8-171963b6a72e" />