### PR TITLE
fix: add missing CSRF token to today settings PUT request

### DIFF
--- a/backend/tests/integration/profile-today-settings.test.js
+++ b/backend/tests/integration/profile-today-settings.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const request = require('supertest');
+const app = require('../../app');
+const { createTestUser } = require('../helpers/testUtils');
+
+describe('PUT /api/profile/today-settings', () => {
+    let agent;
+
+    beforeEach(async () => {
+        await createTestUser({ email: 'test@example.com' });
+        agent = request.agent(app);
+        await agent.post('/api/login').send({
+            email: 'test@example.com',
+            password: 'password123',
+        });
+    });
+
+    it('should save showSuggestions setting', async () => {
+        const response = await agent
+            .put('/api/v1/profile/today-settings')
+            .send({ showSuggestions: true });
+
+        expect(response.status).toBe(200);
+        expect(response.body.today_settings.showSuggestions).toBe(true);
+    });
+
+    it('should persist settings across requests', async () => {
+        await agent
+            .put('/api/v1/profile/today-settings')
+            .send({ showSuggestions: true });
+
+        const profile = await agent.get('/api/v1/profile');
+        expect(profile.status).toBe(200);
+        expect(profile.body.today_settings.showSuggestions).toBe(true);
+    });
+
+    it('should preserve existing settings when updating a single field', async () => {
+        await agent
+            .put('/api/v1/profile/today-settings')
+            .send({ showMetrics: true });
+        await agent
+            .put('/api/v1/profile/today-settings')
+            .send({ showSuggestions: true });
+
+        const profile = await agent.get('/api/v1/profile');
+        expect(profile.body.today_settings.showMetrics).toBe(true);
+        expect(profile.body.today_settings.showSuggestions).toBe(true);
+    });
+
+    it('should require authentication', async () => {
+        const response = await request(app)
+            .put('/api/v1/profile/today-settings')
+            .send({ showSuggestions: true });
+
+        expect(response.status).toBe(401);
+    });
+});

--- a/frontend/components/Task/TodaySettingsDropdown.tsx
+++ b/frontend/components/Task/TodaySettingsDropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { getCsrfToken } from '../../utils/csrfService';
 import { useTranslation } from 'react-i18next';
 import {
     ChartBarIcon,
@@ -86,6 +87,7 @@ const TodaySettingsDropdown: React.FC<TodaySettingsDropdownProps> = ({
                 credentials: 'include',
                 headers: {
                     'Content-Type': 'application/json',
+                    'x-csrf-token': await getCsrfToken(),
                 },
                 body: JSON.stringify(settingsToSave),
             });


### PR DESCRIPTION
## Description

`TodaySettingsDropdown` was missing the `x-csrf-token` header on its `PUT /api/profile/today-settings` request, causing a 500 error for session-authenticated users trying to toggle today view settings (e.g. "Show suggested"). Every other settings component in the codebase already includes this header — this one was overlooked.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1045

## Testing

**How did you test this?**

Reproduced the 500 error by toggling "Show suggested" in the today view, confirmed the fix resolves it. Integration tests added for the endpoint.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [x] Tested on mobile (if UI changes)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [x] Updated documentation (if needed)
- [x] Database migrations included and tested (if applicable)
- [x] Translation keys added and synced (if applicable)