### PR TITLE
feat(task-content): make markdown checkboxes interactive in task description view

### DIFF
--- a/frontend/components/Task/TaskDetails/TaskContentCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskContentCard.tsx
@@ -156,6 +156,7 @@ const TaskContentCard: React.FC<TaskContentCardProps> = ({
                     <MarkdownRenderer
                         content={content}
                         className="prose dark:prose-invert max-w-none"
+                        onContentChange={onUpdate}
                     />
                 </div>
             ) : (

--- a/frontend/components/Task/TaskDetails/__tests__/TaskContentCard.test.tsx
+++ b/frontend/components/Task/TaskDetails/__tests__/TaskContentCard.test.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TaskContentCard from '../TaskContentCard';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({ t: (key: string, fallback: string) => fallback }),
+}));
+
+// Capture props passed to MarkdownRenderer so we can assert on them
+let capturedMarkdownProps: any = null;
+jest.mock('../../../Shared/MarkdownRenderer', () => {
+    return function MockMarkdownRenderer(props: any) {
+        capturedMarkdownProps = props;
+        // Render a simple checkbox so we can test click-through
+        const lines = (props.content as string).split('\n');
+        return (
+            <div>
+                {lines.map((line: string, idx: number) => {
+                    const match = line.match(/^(\s*)-\s*\[([ xX])\](.*)$/);
+                    if (match) {
+                        const checked = match[2].toLowerCase() === 'x';
+                        return (
+                            <input
+                                key={idx}
+                                type="checkbox"
+                                checked={checked}
+                                disabled={!props.onContentChange}
+                                onChange={() => {
+                                    if (props.onContentChange) {
+                                        const toggled = checked
+                                            ? line.replace(/\[x\]/i, '[ ]')
+                                            : line.replace('[ ]', '[x]');
+                                        props.onContentChange(toggled);
+                                    }
+                                }}
+                            />
+                        );
+                    }
+                    return <span key={idx}>{line}</span>;
+                })}
+            </div>
+        );
+    };
+});
+
+describe('TaskContentCard - checkbox interactivity', () => {
+    beforeEach(() => {
+        capturedMarkdownProps = null;
+    });
+
+    it('passes onContentChange to MarkdownRenderer in view mode', () => {
+        const onUpdate = jest.fn().mockResolvedValue(undefined);
+        render(<TaskContentCard content="- [ ] Do something" onUpdate={onUpdate} />);
+
+        expect(capturedMarkdownProps).not.toBeNull();
+        expect(capturedMarkdownProps.onContentChange).toBeDefined();
+    });
+
+    it('checkboxes are enabled in view mode', () => {
+        const onUpdate = jest.fn().mockResolvedValue(undefined);
+        render(<TaskContentCard content="- [ ] Do something" onUpdate={onUpdate} />);
+
+        const checkbox = screen.getByRole('checkbox');
+        expect(checkbox).not.toBeDisabled();
+    });
+
+    it('clicking a checkbox calls onUpdate with toggled content', async () => {
+        const onUpdate = jest.fn().mockResolvedValue(undefined);
+        render(<TaskContentCard content="- [ ] Do something" onUpdate={onUpdate} />);
+
+        const checkbox = screen.getByRole('checkbox');
+        fireEvent.click(checkbox);
+
+        expect(onUpdate).toHaveBeenCalledTimes(1);
+        expect(onUpdate).toHaveBeenCalledWith('- [x] Do something');
+    });
+
+    it('clicking a checked checkbox calls onUpdate to uncheck it', async () => {
+        const onUpdate = jest.fn().mockResolvedValue(undefined);
+        render(<TaskContentCard content="- [x] Do something" onUpdate={onUpdate} />);
+
+        const checkbox = screen.getByRole('checkbox');
+        fireEvent.click(checkbox);
+
+        expect(onUpdate).toHaveBeenCalledWith('- [ ] Do something');
+    });
+});


### PR DESCRIPTION
## Description

`TaskContentCard` rendered the task description via `MarkdownRenderer` in view mode without passing `onContentChange`, so all markdown checkboxes (`- [ ] item`) were disabled and could not be clicked. Users had to enter edit mode to manually toggle them.

`MarkdownRenderer` already has full checkbox-toggle logic — it tracks checkbox indices and calls `onContentChange` with the updated markdown string on click. The fix passes `onContentChange={onUpdate}` to `MarkdownRenderer` in the view-mode branch of `TaskContentCard`, making checkboxes interactive and self-saving without entering edit mode.

The checkbox `onClick` handler already calls `e.stopPropagation()`, so clicking a checkbox does not trigger the surrounding div's click-to-edit behaviour.

Closes discussion #272.

## Type of Change

- [x] New feature (adds functionality)

## Testing

**How did you test this?**

Unit tests added for `TaskContentCard` verifying that `onContentChange` is passed in view mode, checkboxes are enabled, and toggling check/uncheck both call `onUpdate` with the correct updated content.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [x] Tested on mobile (if UI changes)

## Checklist

- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked that this doesn't break existing functionality