### PR TITLE
fix(migration): resolve v1.0.0 password column migration causing login failures

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -26,6 +26,8 @@ if (config.trustProxy !== false) {
     console.log(`[Trust Proxy] Disabled (value: false)`);
 }
 
+console.log(`[Trust Proxy] Express setting confirmed:`, app.get('trust proxy'));
+
 // Session store
 const sessionStore = new SequelizeStore({
     db: sequelize,

--- a/backend/migrations/20260420000004-make-password-optional.js
+++ b/backend/migrations/20260420000004-make-password-optional.js
@@ -48,6 +48,26 @@ module.exports = {
             );
         `);
 
+        const [columns] = await queryInterface.sequelize.query(
+            'PRAGMA table_info(users);'
+        );
+        const hasPasswordDigest = columns.some(
+            (col) => col.name === 'password_digest'
+        );
+        const hasPassword = columns.some((col) => col.name === 'password');
+
+        const passwordColumn = hasPasswordDigest
+            ? 'password_digest'
+            : hasPassword
+              ? 'password'
+              : null;
+
+        if (!passwordColumn) {
+            throw new Error(
+                'Neither password nor password_digest column found in users table'
+            );
+        }
+
         await queryInterface.sequelize.query(`
             INSERT INTO users_new (
                 id, uid, name, surname, email, password_digest, appearance, language,
@@ -64,7 +84,7 @@ module.exports = {
             )
             SELECT
                 id, uid, name, surname, email,
-                COALESCE(password_digest, password) as password_digest,
+                ${passwordColumn} as password_digest,
                 appearance, language,
                 timezone, first_day_of_week, avatar_image, telegram_bot_token,
                 telegram_chat_id, task_summary_enabled, task_summary_frequency,


### PR DESCRIPTION
## Description

Fixes a critical bug where users upgrading from v1.0.0 to v1.1.0-dev.16 cannot login after migration.

**Root Cause:**
The migration `20260420000004-make-password-optional.js` was using `COALESCE(password_digest, password)` to handle both old and new schemas. However, SQLite's `COALESCE` function fails when referencing a non-existent column, even as a fallback. In v1.0.0, the users table had a column named `password`, not `password_digest`, causing the migration to fail with "no such column: password_digest".

**Solution:**
- Dynamically detect which password column exists before running the migration
- Use the detected column name (`password` or `password_digest`) in the SELECT statement
- Added enhanced trust proxy diagnostics to help users debug `TUDUDI_TRUST_PROXY` configuration issues

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

Reported by Discord users unable to login after upgrading from v1.0.0

## Testing

**Reproduction Test:**
1. Created v1.0.0 database with `password` column
2. Inserted test user with bcrypt-hashed password
3. Verified login works in v1.0.0 format
4. Ran migration with fix
5. Verified password hash preserved correctly
6. Confirmed login still works post-migration

**Test Results:**
```
✓ v1.0.0 login works (before migration)
✓ Migration completes successfully
✓ Password hash matches original (no corruption)
✓ Login works after migration (authentication preserved)
```

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have tested my changes
- [x] My changes generate no new warnings
- [x] I have updated documentation if necessary
- [x] All tests pass locally

## Additional Notes

This is a critical fix for users upgrading from v1.0.0. The migration silently failed before, leaving users unable to login. With this fix:
- Users upgrading from v1.0.0 (with `password` column) can migrate successfully
- Users with newer databases (with `password_digest` column) remain unaffected
- Password hashes are preserved during migration
- Authentication continues to work post-upgrade