### PR TITLE
fix(admin): add CSRF token to admin user management operations

### DIFF
--- a/frontend/components/Admin/AdminUsersPage.tsx
+++ b/frontend/components/Admin/AdminUsersPage.tsx
@@ -10,6 +10,7 @@ import {
 import ConfirmDialog from '../Shared/ConfirmDialog';
 import { getApiPath } from '../../config/paths';
 import { useToast } from '../Shared/ToastContext';
+import { fetchWithCsrf } from '../../utils/csrfService';
 
 interface AdminUserItem {
     id: number;
@@ -43,7 +44,7 @@ const createAdminUser = async (
     surname?: string,
     role?: 'admin' | 'user'
 ): Promise<AdminUserItem> => {
-    const res = await fetch(getApiPath('admin/users'), {
+    const res = await fetchWithCsrf(getApiPath('admin/users'), {
         method: 'POST',
         credentials: 'include',
         headers: {
@@ -84,7 +85,7 @@ const updateAdminUser = async (
     const body: any = { email, name, surname, role };
     if (password) body.password = password;
 
-    const res = await fetch(getApiPath(`admin/users/${id}`), {
+    const res = await fetchWithCsrf(getApiPath(`admin/users/${id}`), {
         method: 'PUT',
         credentials: 'include',
         headers: {
@@ -116,7 +117,7 @@ const updateAdminUser = async (
 };
 
 const deleteAdminUser = async (id: number, t: any): Promise<void> => {
-    const res = await fetch(getApiPath(`admin/users/${id}`), {
+    const res = await fetchWithCsrf(getApiPath(`admin/users/${id}`), {
         method: 'DELETE',
         credentials: 'include',
         headers: { Accept: 'application/json' },
@@ -466,7 +467,7 @@ const AdminUsersPage: React.FC = () => {
     // Toggle registration
     const toggleRegistration = async () => {
         try {
-            const res = await fetch(getApiPath('admin/toggle-registration'), {
+            const res = await fetchWithCsrf(getApiPath('admin/toggle-registration'), {
                 method: 'POST',
                 credentials: 'include',
                 headers: {


### PR DESCRIPTION
## Description

This PR fixes the "CSRF token missing" error that occurred when admins tried to create, update, or delete users through the admin panel, particularly when Tududi is accessed behind a reverse proxy.

The issue was that the admin user management functions were using plain `fetch()` calls instead of the `fetchWithCsrf()` utility, which automatically includes the required `x-csrf-token` header for state-changing operations.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

Fixes #1064

## Changes Made

Updated `frontend/components/Admin/AdminUsersPage.tsx` to use `fetchWithCsrf` instead of plain `fetch` for:
- `createAdminUser` - POST /admin/users
- `updateAdminUser` - PUT /admin/users/:id
- `deleteAdminUser` - DELETE /admin/users/:id
- `toggleRegistration` - POST /admin/toggle-registration

## Testing

- [x] Linting passed (`npm run lint:fix`)
- [ ] Manual testing needed: Test admin user creation/update/delete behind reverse proxy
- [ ] Manual testing needed: Test registration toggle behind reverse proxy

### Testing Steps

1. Set up Tududi behind a reverse proxy (nginx) with proper CORS and trust proxy settings
2. Log in as admin user
3. Navigate to Admin > Manage users
4. Try to create a new user - should succeed without CSRF error
5. Try to edit an existing user - should succeed without CSRF error
6. Try to delete a user - should succeed without CSRF error
7. Try to toggle registration on/off - should succeed without CSRF error

## Checklist

- [x] My code follows the project's code conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have run linting and fixed any issues

## Additional Notes

This fix ensures consistency with other parts of the application that already use `fetchWithCsrf` for state-changing operations. The CSRF service automatically fetches and caches the CSRF token, then includes it in the `x-csrf-token` header for POST, PUT, PATCH, and DELETE requests.