### PR TITLE
fix(tasks): fix projectless task visibility leak in dashboard metrics (#1063)

### DIFF
--- a/backend/modules/tasks/queries/metrics-queries.js
+++ b/backend/modules/tasks/queries/metrics-queries.js
@@ -26,10 +26,14 @@ function isTaskInTodayPlan(task) {
 async function countTotalOpenTasks(visibleTasksWhere) {
     return await Task.count({
         where: {
-            ...visibleTasksWhere,
-            status: { [Op.ne]: Task.STATUS.DONE },
-            parent_task_id: null,
-            recurring_parent_id: null,
+            [Op.and]: [
+                visibleTasksWhere,
+                {
+                    status: { [Op.ne]: Task.STATUS.DONE },
+                    parent_task_id: null,
+                    recurring_parent_id: null,
+                },
+            ],
         },
         raw: true,
     });
@@ -39,11 +43,15 @@ async function countTasksPendingOverMonth(visibleTasksWhere) {
     const oneMonthAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
     return await Task.count({
         where: {
-            ...visibleTasksWhere,
-            status: { [Op.ne]: Task.STATUS.DONE },
-            created_at: { [Op.lt]: oneMonthAgo },
-            parent_task_id: null,
-            recurring_parent_id: null,
+            [Op.and]: [
+                visibleTasksWhere,
+                {
+                    status: { [Op.ne]: Task.STATUS.DONE },
+                    created_at: { [Op.lt]: oneMonthAgo },
+                    parent_task_id: null,
+                    recurring_parent_id: null,
+                },
+            ],
         },
         raw: true,
     });
@@ -53,15 +61,23 @@ async function fetchTasksInProgress(visibleTasksWhere) {
     const now = new Date();
     return await Task.findAll({
         where: {
-            ...visibleTasksWhere,
-            status: { [Op.in]: [Task.STATUS.IN_PROGRESS, 'in_progress'] },
-            // Exclude tasks deferred to the future
-            [Op.or]: [
-                { defer_until: null },
-                { defer_until: { [Op.lte]: now } },
+            [Op.and]: [
+                visibleTasksWhere,
+                {
+                    status: {
+                        [Op.in]: [Task.STATUS.IN_PROGRESS, 'in_progress'],
+                    },
+                    parent_task_id: null,
+                    recurring_parent_id: null,
+                },
+                // Exclude tasks deferred to the future
+                {
+                    [Op.or]: [
+                        { defer_until: null },
+                        { defer_until: { [Op.lte]: now } },
+                    ],
+                },
             ],
-            parent_task_id: null,
-            recurring_parent_id: null,
         },
         include: getTaskIncludeConfigLight(),
         order: [
@@ -276,15 +292,22 @@ async function fetchNonProjectTasks(
     limit = null
 ) {
     const exclusionIds = [...excludedTaskIds, ...somedayTaskIds];
+    const filters = {
+        status: {
+            [Op.in]: [Task.STATUS.NOT_STARTED, Task.STATUS.WAITING],
+        },
+        [Op.or]: [{ project_id: null }, { project_id: '' }],
+        parent_task_id: null,
+        recurring_parent_id: null,
+    };
+
+    if (exclusionIds.length > 0) {
+        filters.id = { [Op.notIn]: exclusionIds };
+    }
+
     const queryOptions = {
         where: {
-            ...visibleTasksWhere,
-            status: {
-                [Op.in]: [Task.STATUS.NOT_STARTED, Task.STATUS.WAITING],
-            },
-            [Op.or]: [{ project_id: null }, { project_id: '' }],
-            parent_task_id: null,
-            recurring_parent_id: null,
+            [Op.and]: [visibleTasksWhere, filters],
         },
         include: getTaskIncludeConfigLight(),
         order: [
@@ -293,10 +316,6 @@ async function fetchNonProjectTasks(
             ['project_id', 'ASC'],
         ],
     };
-
-    if (exclusionIds.length > 0) {
-        queryOptions.where.id = { [Op.notIn]: exclusionIds };
-    }
 
     if (limit && Number.isInteger(limit)) {
         queryOptions.limit = limit;
@@ -312,15 +331,22 @@ async function fetchProjectTasks(
     limit = null
 ) {
     const exclusionIds = [...excludedTaskIds, ...somedayTaskIds];
+    const filters = {
+        status: {
+            [Op.in]: [Task.STATUS.NOT_STARTED, Task.STATUS.WAITING],
+        },
+        project_id: { [Op.not]: null, [Op.ne]: '' },
+        parent_task_id: null,
+        recurring_parent_id: null,
+    };
+
+    if (exclusionIds.length > 0) {
+        filters.id = { [Op.notIn]: exclusionIds };
+    }
+
     const queryOptions = {
         where: {
-            ...visibleTasksWhere,
-            status: {
-                [Op.in]: [Task.STATUS.NOT_STARTED, Task.STATUS.WAITING],
-            },
-            project_id: { [Op.not]: null, [Op.ne]: '' },
-            parent_task_id: null,
-            recurring_parent_id: null,
+            [Op.and]: [visibleTasksWhere, filters],
         },
         include: getTaskIncludeConfigLight(),
         order: [
@@ -329,10 +355,6 @@ async function fetchProjectTasks(
             ['project_id', 'ASC'],
         ],
     };
-
-    if (exclusionIds.length > 0) {
-        queryOptions.where.id = { [Op.notIn]: exclusionIds };
-    }
 
     if (limit && Number.isInteger(limit)) {
         queryOptions.limit = limit;

--- a/backend/tests/integration/permissions-tasks.test.js
+++ b/backend/tests/integration/permissions-tasks.test.js
@@ -96,4 +96,57 @@ describe('Tasks Permissions', () => {
         expect(res.status).toBe(403);
         expect(res.body.error).toBe('Forbidden');
     });
+
+    it("GET /api/tasks/metrics should not include another user's projectless in-progress task", async () => {
+        const myTask = await Task.create({
+            name: 'My In Progress Task',
+            user_id: user.id,
+            status: Task.STATUS.IN_PROGRESS,
+        });
+        const otherTask = await Task.create({
+            name: 'Other In Progress Task',
+            user_id: otherUser.id,
+            status: Task.STATUS.IN_PROGRESS,
+        });
+
+        const res = await agent.get('/api/tasks/metrics');
+        expect(res.status).toBe(200);
+
+        const taskIds = res.body.tasks_in_progress.map((task) => task.id);
+        expect(taskIds).toContain(myTask.id);
+        expect(taskIds).not.toContain(otherTask.id);
+    });
+
+    it("GET /api/tasks/metrics should not suggest another user's projectless task", async () => {
+        await Task.bulkCreate([
+            {
+                name: 'My Task 1',
+                user_id: user.id,
+                status: Task.STATUS.NOT_STARTED,
+            },
+            {
+                name: 'My Task 2',
+                user_id: user.id,
+                status: Task.STATUS.NOT_STARTED,
+            },
+            {
+                name: 'My Task 3',
+                user_id: user.id,
+                status: Task.STATUS.NOT_STARTED,
+            },
+        ]);
+        const otherTask = await Task.create({
+            name: 'Other Suggested Task',
+            user_id: otherUser.id,
+            status: Task.STATUS.NOT_STARTED,
+        });
+
+        const res = await agent.get('/api/tasks/metrics');
+        expect(res.status).toBe(200);
+
+        const suggestedTaskIds = res.body.suggested_tasks.map(
+            (task) => task.id
+        );
+        expect(suggestedTaskIds).not.toContain(otherTask.id);
+    });
 });


### PR DESCRIPTION
## Description

This PR fixes private projectless tasks appearing in other users' Today/dashboard task lists.

The issue was that some task metrics queries combined the permission visibility filter with dashboard-specific filters using object spread. When both objects contained `Op.or` conditions, the later `Op.or` overwrote the visibility condition. As a result, projectless tasks created from Inbox, Telegram, or directly in the web app could appear for users who did not own the task and did not have access through a shared project.

This keeps the intended visibility model intact: tasks remain private to their owner unless they are directly shared or belong to a project shared with another user.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1063

## Testing

**How did you test this?**

Added regression tests covering projectless tasks from another user not appearing in task metrics lists.

Also manually tested the fix against the same database where the visibility problem originally occurred. After the fix, private projectless tasks were no longer visible to other users, while tasks in shared projects remained visible as expected.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

Additional commands run:

```bash
npx prettier --write backend/modules/tasks/queries/metrics-queries.js backend/tests/integration/permissions-tasks.test.js
npm test -- --runTestsByPath backend/tests/integration/permissions-tasks.test.js
```

Note: Formatting and the relevant regression test were run directly for the changed files instead of running the full `npm run pre-push` command.

## Screenshots

Not applicable. This is a backend permissions/query fix with no UI changes.

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

The root cause was limited to task metrics/dashboard queries. General task access checks already used the expected ownership/shared-project model, but the affected metrics queries accidentally allowed dashboard-specific `Op.or` filters to replace the visibility `Op.or` filter.

The fix combines visibility filters and dashboard filters with `Op.and`, so both access control and list-specific filtering must match.
