### PR TITLE
fix: add copy button to note details page

### DIFF
--- a/frontend/components/Note/NoteDetails.tsx
+++ b/frontend/components/Note/NoteDetails.tsx
@@ -7,6 +7,7 @@ import {
     TagIcon,
     FolderIcon,
 } from '@heroicons/react/24/solid';
+import { DocumentDuplicateIcon } from '@heroicons/react/24/outline';
 import { useToast } from '../Shared/ToastContext';
 import ConfirmDialog from '../Shared/ConfirmDialog';
 import NoteModal from './NoteModal';
@@ -91,6 +92,16 @@ const NoteDetails: React.FC = () => {
 
     const handleEditNote = () => {
         setIsNoteModalOpen(true);
+    };
+
+    const handleCopyNote = async () => {
+        if (!note) return;
+        try {
+            await navigator.clipboard.writeText(note.content);
+            showSuccessToast(t('notes.copiedToClipboard', 'Note content copied to clipboard'));
+        } catch (err) {
+            console.error('Error copying to clipboard:', err);
+        }
     };
 
     const handleCreateProject = async (name: string) => {
@@ -209,6 +220,14 @@ const NoteDetails: React.FC = () => {
                     </div>
                     {/* Action Buttons */}
                     <div className="flex space-x-2">
+                        <button
+                            onClick={handleCopyNote}
+                            className="text-gray-500 hover:text-green-700 dark:hover:text-green-300 focus:outline-none"
+                            aria-label={t('notes.copyContent', 'Copy note content')}
+                            title={t('notes.copyContent', 'Copy note content')}
+                        >
+                            <DocumentDuplicateIcon className="h-5 w-5" />
+                        </button>
                         <button
                             onClick={handleEditNote}
                             className="text-gray-500 hover:text-blue-700 dark:hover:text-blue-300 focus:outline-none"


### PR DESCRIPTION
## Description

This PR adds a copy button to the note details page, allowing users to easily copy note content to their clipboard. Previously, users may have been confused about how to copy note content, as only edit and delete buttons were available.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

Fixes #1061

## Changes Made

- Added `DocumentDuplicateIcon` from Heroicons to the imports
- Implemented `handleCopyNote` function that:
  - Copies the note content to the clipboard using `navigator.clipboard.writeText()`
  - Shows a success toast notification when content is copied successfully
  - Handles errors gracefully with console logging
- Added a copy button in the top right of the note details view
- Copy button is positioned before the edit and delete buttons
- Button uses green hover color to differentiate from edit (blue) and delete (red)
- Added appropriate aria-label and title for accessibility

## Testing

- [x] Manually tested copying note content to clipboard
- [x] Verified success toast appears when content is copied
- [x] Checked that the button appears in the correct position
- [x] Tested button hover states and accessibility
- [x] Ran `npm run lint` - all checks passed

## Screenshots

The copy button now appears as the first button in the top right corner of note details:
- Copy button (green hover) - DocumentDuplicateIcon
- Edit button (blue hover) - PencilSquareIcon  
- Delete button (red hover) - TrashIcon

## Checklist

- [x] My code follows the project's code conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (if applicable)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

This fix improves the user experience by providing an intuitive way to copy note content. The button is clearly distinguishable from the edit button and follows the existing design patterns in the codebase (similar to the copy button in the MCP tab).