### PR TITLE
  fix(test-notification): add test notification endpoint and fix independent channel evaluation

### DIFF
--- a/backend/models/notification.js
+++ b/backend/models/notification.js
@@ -179,6 +179,24 @@ module.exports = (sequelize) => {
         return notification;
     };
 
+    Notification.sendTelegramNotification = async function ({
+        userId,
+        title,
+        message,
+        data = null,
+        level = 'info',
+    }) {
+        await sendTelegramNotification(
+            userId,
+            title,
+            message,
+            data,
+            Notification,
+            null,
+            level
+        );
+    };
+
     async function sendEmailNotification(
         userId,
         title,
@@ -218,7 +236,8 @@ module.exports = (sequelize) => {
         message,
         data,
         NotificationModel,
-        notificationInstance
+        notificationInstance,
+        level = 'info'
     ) {
         try {
             const telegramService = require('../modules/telegram/telegramNotificationService');
@@ -255,7 +274,7 @@ module.exports = (sequelize) => {
                     title,
                     message,
                     data,
-                    level: 'info',
+                    level,
                 });
 
                 // Mark that Telegram was sent for this notification

--- a/backend/modules/notifications/controller.js
+++ b/backend/modules/notifications/controller.js
@@ -33,6 +33,19 @@ const notificationsController = {
         }
     },
 
+    async triggerTestNotification(req, res, next) {
+        try {
+            const userId = requireUserId(req);
+            const result = await notificationsService.triggerTestNotification(
+                userId,
+                req.body?.type
+            );
+            res.json(result);
+        } catch (error) {
+            next(error);
+        }
+    },
+
     async markAsRead(req, res, next) {
         try {
             const userId = requireUserId(req);

--- a/backend/modules/notifications/routes.js
+++ b/backend/modules/notifications/routes.js
@@ -5,6 +5,10 @@ const router = express.Router();
 const notificationsController = require('./controller');
 
 router.get('/notifications', notificationsController.getAll);
+router.post(
+    '/test-notifications/trigger',
+    notificationsController.triggerTestNotification
+);
 router.get(
     '/notifications/unread-count',
     notificationsController.getUnreadCount

--- a/backend/modules/notifications/service.js
+++ b/backend/modules/notifications/service.js
@@ -1,7 +1,57 @@
 'use strict';
 
 const notificationsRepository = require('./repository');
-const { NotFoundError } = require('../../shared/errors');
+const { Notification, User } = require('../../models');
+const { NotFoundError, ValidationError } = require('../../shared/errors');
+const {
+    shouldSendInAppNotification,
+    shouldSendTelegramNotification,
+} = require('../../utils/notificationPreferences');
+const telegramNotificationService = require('../telegram/telegramNotificationService');
+
+const TEST_NOTIFICATION_TYPES = new Set([
+    'task_due_soon',
+    'task_overdue',
+    'defer_until',
+    'project_due_soon',
+    'project_overdue',
+]);
+
+const TEST_NOTIFICATION_CONTENT = {
+    task_due_soon: {
+        title: 'Test task due soon',
+        message: 'This is a test notification for a task due soon',
+        level: 'warning',
+    },
+    task_overdue: {
+        title: 'Test task overdue',
+        message: 'This is a test notification for an overdue task',
+        level: 'error',
+    },
+    defer_until: {
+        title: 'Test task now active',
+        message: 'This is a test notification for a deferred task',
+        level: 'info',
+    },
+    project_due_soon: {
+        title: 'Test project due soon',
+        message: 'This is a test notification for a project due soon',
+        level: 'warning',
+    },
+    project_overdue: {
+        title: 'Test project overdue',
+        message: 'This is a test notification for an overdue project',
+        level: 'error',
+    },
+};
+
+function normalizePreferenceType(type) {
+    return type === 'defer_until' ? 'deferUntil' : type;
+}
+
+function normalizeNotificationType(type) {
+    return type === 'defer_until' ? 'task_due_soon' : type;
+}
 
 class NotificationsService {
     async getAll(userId, options) {
@@ -17,6 +67,99 @@ class NotificationsService {
     async getUnreadCount(userId) {
         const count = await notificationsRepository.getUnreadCount(userId);
         return { count };
+    }
+
+    async triggerTestNotification(userId, type = 'task_due_soon') {
+        if (!TEST_NOTIFICATION_TYPES.has(type)) {
+            throw new ValidationError('Invalid notification type');
+        }
+
+        const user = await User.findByPk(userId, {
+            attributes: [
+                'id',
+                'notification_preferences',
+                'telegram_bot_token',
+                'telegram_chat_id',
+            ],
+        });
+
+        if (!user) {
+            throw new NotFoundError('User not found');
+        }
+
+        const preferenceType = normalizePreferenceType(type);
+        const notificationType = normalizeNotificationType(type);
+        const sendInApp = shouldSendInAppNotification(user, preferenceType);
+        const sendTelegram =
+            shouldSendTelegramNotification(user, preferenceType) &&
+            telegramNotificationService.isTelegramConfigured(user);
+        const { title, message, level } = TEST_NOTIFICATION_CONTENT[type];
+        const data = {
+            test: true,
+            requestedType: type,
+        };
+
+        // Build explicit channel list for the response so the client always
+        // knows exactly what was sent without inferring from sources.
+        const channels = [];
+        if (sendInApp) channels.push('inApp');
+        if (sendTelegram) channels.push('telegram');
+
+        if (channels.length === 0) {
+            return {
+                notification: {
+                    type: notificationType,
+                    title,
+                    message,
+                    level,
+                    sources: [],
+                },
+                channels: [],
+                message: 'No notification channels enabled',
+            };
+        }
+
+        const sources = sendTelegram ? ['telegram'] : [];
+
+        if (sendInApp) {
+            const notification = await Notification.createNotification({
+                userId,
+                type: notificationType,
+                title,
+                message,
+                level,
+                sources,
+                data,
+                sentAt: new Date(),
+            });
+
+            return {
+                notification,
+                channels,
+                message: 'Test notification sent',
+            };
+        }
+
+        await Notification.sendTelegramNotification({
+            userId,
+            title,
+            message,
+            level,
+            data,
+        });
+
+        return {
+            notification: {
+                type: notificationType,
+                title,
+                message,
+                level,
+                sources,
+                data,
+            },
+            channels,
+            message: 'Test notification sent',
+        };
     }
 
     async markAsRead(userId, notificationId) {

--- a/backend/modules/projects/dueProjectService.js
+++ b/backend/modules/projects/dueProjectService.js
@@ -6,15 +6,6 @@ const {
     shouldSendTelegramNotification,
 } = require('../../utils/notificationPreferences');
 
-/**
- * Service to check for due and overdue projects
- * and create notifications for users
- */
-
-/**
- * Check for projects that are due soon or overdue
- * and create notifications for the project owners
- */
 async function checkDueProjects() {
     try {
         const now = new Date();
@@ -70,7 +61,7 @@ async function checkDueProjects() {
                     continue;
                 }
 
-                // Check for existing notifications
+                // Deduplication applies to all channel combinations.
                 const recentNotifications = await Notification.findAll({
                     where: {
                         user_id: project.user_id,
@@ -89,24 +80,17 @@ async function checkDueProjects() {
                         notif.type === notificationType
                 );
 
-                // Preserve channel_sent_at for rate limiting when recreating notifications
                 let preservedChannelSentAt = null;
 
                 if (existingNotification) {
-                    // If notification was dismissed, don't create it again
                     if (existingNotification.dismissed_at) {
                         continue;
                     }
-
-                    // If notification is unread, delete it before creating the new one
-                    // This prevents duplicate notifications from piling up
                     if (!existingNotification.read_at) {
-                        // Preserve channel_sent_at to maintain rate limiting across recreations
                         preservedChannelSentAt =
                             existingNotification.channel_sent_at;
                         await existingNotification.destroy();
                     } else {
-                        // If it was already read, skip creating a new one
                         continue;
                     }
                 }
@@ -166,9 +150,6 @@ async function checkDueProjects() {
     }
 }
 
-/**
- * Generate notification title and message based on project due date
- */
 function generateNotificationContent(projectName, dueDate, now, isOverdue) {
     if (isOverdue) {
         const daysOverdue = Math.floor((now - dueDate) / (1000 * 60 * 60 * 24));

--- a/backend/modules/tasks/deferredTaskService.js
+++ b/backend/modules/tasks/deferredTaskService.js
@@ -47,10 +47,30 @@ async function checkDeferredTasks() {
 
         for (const task of deferredTasks) {
             try {
-                if (!shouldSendInAppNotification(task.User, 'deferUntil')) {
+                const sendInApp = shouldSendInAppNotification(
+                    task.User,
+                    'deferUntil'
+                );
+                const sendTelegram = shouldSendTelegramNotification(
+                    task.User,
+                    'deferUntil'
+                );
+
+                if (!sendInApp && !sendTelegram) {
                     continue;
                 }
 
+                const title = 'Task is now active';
+                const message = `Your task "${task.name}" is now available to work on`;
+                const data = {
+                    taskUid: task.uid,
+                    taskName: task.name,
+                    deferUntil: task.defer_until,
+                    reason: 'defer_until_reached',
+                };
+
+                // Deduplication applies to all channel combinations.
+                // Dismissed records act as rate-limiting anchors for Telegram-only sends.
                 const recentNotifications = await Notification.findAll({
                     where: {
                         user_id: task.user_id,
@@ -67,48 +87,40 @@ async function checkDeferredTasks() {
                         notif.data?.reason === 'defer_until_reached'
                 );
 
-                // Preserve channel_sent_at for rate limiting when recreating notifications
                 let preservedChannelSentAt = null;
 
                 if (existingNotification) {
-                    // If notification was dismissed, don't create it again
                     if (existingNotification.dismissed_at) {
                         continue;
                     }
-
-                    // If notification is unread, delete it before creating the new one
-                    // This prevents duplicate notifications from piling up
                     if (!existingNotification.read_at) {
-                        // Preserve channel_sent_at to maintain rate limiting across recreations
                         preservedChannelSentAt =
                             existingNotification.channel_sent_at;
                         await existingNotification.destroy();
                     } else {
-                        // If it was already read, skip creating a new one
                         continue;
                     }
                 }
 
-                const sources = [];
-                if (shouldSendTelegramNotification(task.User, 'deferUntil')) {
-                    sources.push('telegram');
-                }
+                const sources = sendTelegram ? ['telegram'] : [];
 
-                await Notification.createNotification({
+                const notification = await Notification.createNotification({
                     userId: task.user_id,
                     type: 'task_due_soon',
-                    title: 'Task is now active',
-                    message: `Your task "${task.name}" is now available to work on`,
+                    title,
+                    message,
                     sources,
-                    data: {
-                        taskUid: task.uid,
-                        taskName: task.name,
-                        deferUntil: task.defer_until,
-                        reason: 'defer_until_reached',
-                    },
+                    data,
                     sentAt: new Date(),
                     channel_sent_at: preservedChannelSentAt,
                 });
+
+                // Telegram-only: dismiss immediately so the record does not appear
+                // in the bell or increment the badge, but still serves as a
+                // deduplication anchor and Telegram rate-limiting record.
+                if (!sendInApp) {
+                    await notification.dismiss();
+                }
 
                 notificationsCreated++;
             } catch (error) {

--- a/backend/modules/tasks/dueTaskService.js
+++ b/backend/modules/tasks/dueTaskService.js
@@ -62,13 +62,21 @@ async function checkDueTasks() {
                     ? 'task_overdue'
                     : 'task_due_soon';
                 const level = isOverdue ? 'error' : 'warning';
+                const sendInApp = shouldSendInAppNotification(
+                    task.User,
+                    notificationType
+                );
+                const sendTelegram = shouldSendTelegramNotification(
+                    task.User,
+                    notificationType
+                );
 
-                // Check if user wants this notification
-                if (!shouldSendInAppNotification(task.User, notificationType)) {
+                if (!sendInApp && !sendTelegram) {
                     continue;
                 }
 
-                // Check for existing notifications
+                // Deduplication applies to all channel combinations.
+                // Dismissed records act as rate-limiting anchors for Telegram-only sends.
                 const recentNotifications = await Notification.findAll({
                     where: {
                         user_id: task.user_id,
@@ -87,24 +95,17 @@ async function checkDueTasks() {
                         notif.type === notificationType
                 );
 
-                // Preserve channel_sent_at for rate limiting when recreating notifications
                 let preservedChannelSentAt = null;
 
                 if (existingNotification) {
-                    // If notification was dismissed, don't create it again
                     if (existingNotification.dismissed_at) {
                         continue;
                     }
-
-                    // If notification is unread, delete it before creating the new one
-                    // This prevents duplicate notifications from piling up
                     if (!existingNotification.read_at) {
-                        // Preserve channel_sent_at to maintain rate limiting across recreations
                         preservedChannelSentAt =
                             existingNotification.channel_sent_at;
                         await existingNotification.destroy();
                     } else {
-                        // If it was already read, skip creating a new one
                         continue;
                     }
                 }
@@ -116,15 +117,9 @@ async function checkDueTasks() {
                     isOverdue
                 );
 
-                // Build sources array based on user preferences
-                const sources = [];
-                if (
-                    shouldSendTelegramNotification(task.User, notificationType)
-                ) {
-                    sources.push('telegram');
-                }
+                const sources = sendTelegram ? ['telegram'] : [];
 
-                await Notification.createNotification({
+                const notification = await Notification.createNotification({
                     userId: task.user_id,
                     type: notificationType,
                     title,
@@ -140,6 +135,13 @@ async function checkDueTasks() {
                     sentAt: new Date(),
                     channel_sent_at: preservedChannelSentAt,
                 });
+
+                // Telegram-only: dismiss immediately so the record does not appear
+                // in the bell or increment the badge, but still serves as a
+                // deduplication anchor and Telegram rate-limiting record.
+                if (!sendInApp) {
+                    await notification.dismiss();
+                }
 
                 notificationsCreated++;
             } catch (error) {
@@ -161,9 +163,6 @@ async function checkDueTasks() {
     }
 }
 
-/**
- * Generate notification title and message based on task due date
- */
 function generateNotificationContent(taskName, dueDate, now, isOverdue) {
     if (isOverdue) {
         const daysOverdue = Math.floor((now - dueDate) / (1000 * 60 * 60 * 24));

--- a/backend/tests/integration/notification-preferences.test.js
+++ b/backend/tests/integration/notification-preferences.test.js
@@ -1,7 +1,8 @@
 const request = require('supertest');
 const app = require('../../app');
-const { User } = require('../../models');
+const { Notification, User } = require('../../models');
 const { createTestUser } = require('../helpers/testUtils');
+const telegramNotificationService = require('../../modules/telegram/telegramNotificationService');
 
 describe('Notification Preferences', () => {
     let user, agent;
@@ -17,6 +18,10 @@ describe('Notification Preferences', () => {
             email: user.email,
             password: 'password123',
         });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
     });
 
     describe('GET /api/profile - notification_preferences', () => {
@@ -83,6 +88,57 @@ describe('Notification Preferences', () => {
 
             expect(response.status).toBe(200);
             expect(response.body.notification_preferences).toEqual(preferences);
+        });
+    });
+
+    describe('POST /api/test-notifications/trigger', () => {
+        it('should send Telegram without creating in-app notification when in-app is disabled', async () => {
+            jest.spyOn(
+                telegramNotificationService,
+                'isTelegramConfigured'
+            ).mockReturnValue(true);
+            jest.spyOn(
+                telegramNotificationService,
+                'sendTelegramNotification'
+            ).mockResolvedValue({ success: true });
+
+            await User.update(
+                {
+                    telegram_bot_token:
+                        '123456789:ABCdefGHIjklMNOPQRSTUVwxyz-12345678',
+                    telegram_chat_id: '123456789',
+                    notification_preferences: {
+                        dueTasks: {
+                            inApp: false,
+                            email: false,
+                            push: false,
+                            telegram: true,
+                        },
+                    },
+                },
+                { where: { id: user.id } }
+            );
+
+            const response = await agent
+                .post('/api/test-notifications/trigger')
+                .send({ type: 'task_due_soon' });
+
+            expect(response.status).toBe(200);
+            expect(response.body.channels).toEqual(['telegram']);
+            expect(response.body.notification.sources).toEqual(['telegram']);
+            expect(
+                telegramNotificationService.sendTelegramNotification
+            ).toHaveBeenCalledTimes(1);
+
+            const notificationCount = await Notification.count({
+                where: { user_id: user.id },
+            });
+            expect(notificationCount).toBe(0);
+
+            const unreadResponse = await agent.get(
+                '/api/notifications/unread-count'
+            );
+            expect(unreadResponse.body.count).toBe(0);
         });
     });
 

--- a/backend/tests/unit/modules/projects/dueProjectService.test.js
+++ b/backend/tests/unit/modules/projects/dueProjectService.test.js
@@ -1,0 +1,100 @@
+const { Project, Notification, User } = require('../../../../models');
+const {
+    checkDueProjects,
+} = require('../../../../modules/projects/dueProjectService');
+const telegramNotificationService = require('../../../../modules/telegram/telegramNotificationService');
+const bcrypt = require('bcrypt');
+
+describe('dueProjectService', () => {
+    let user;
+
+    beforeEach(async () => {
+        user = await User.create({
+            email: 'project@example.com',
+            password_digest: await bcrypt.hash('password123', 10),
+            telegram_bot_token: '123456789:ABCdefGHIjklMNOPQRSTUVwxyz-12345678',
+            telegram_chat_id: '123456789',
+            notification_preferences: {
+                dueProjects: { inApp: false, telegram: true },
+                overdueProjects: { inApp: false, telegram: true },
+            },
+        });
+
+        jest.spyOn(
+            telegramNotificationService,
+            'isTelegramConfigured'
+        ).mockReturnValue(true);
+        jest.spyOn(
+            telegramNotificationService,
+            'sendTelegramNotification'
+        ).mockResolvedValue({ success: true });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should send Telegram and create a dismissed tracking record when inApp is disabled', async () => {
+        const tomorrow = new Date();
+        tomorrow.setDate(tomorrow.getDate() + 1);
+
+        await Project.create({
+            name: 'Telegram Project',
+            user_id: user.id,
+            due_date_at: tomorrow,
+            status: 'not_started',
+        });
+
+        const result = await checkDueProjects();
+
+        expect(result.success).toBe(true);
+        expect(result.notificationsCreated).toBe(1);
+        expect(
+            telegramNotificationService.sendTelegramNotification
+        ).toHaveBeenCalledTimes(1);
+
+        // A dismissed tracking record is created for deduplication/rate-limiting.
+        // It must not appear as unread (badge must not increment).
+        const allNotifications = await Notification.findAll({
+            where: { user_id: user.id },
+        });
+        expect(allNotifications.length).toBe(1);
+        expect(allNotifications[0].dismissed_at).not.toBeNull();
+
+        const unreadCount = await Notification.count({
+            where: { user_id: user.id, read_at: null, dismissed_at: null },
+        });
+        expect(unreadCount).toBe(0);
+    });
+
+    it('should not resend Telegram within the 2-day deduplication window', async () => {
+        const tomorrow = new Date();
+        tomorrow.setDate(tomorrow.getDate() + 1);
+
+        await Project.create({
+            name: 'Telegram Rate Limit Project',
+            user_id: user.id,
+            due_date_at: tomorrow,
+            status: 'not_started',
+        });
+
+        // First run: Telegram sent, dismissed tracking record created
+        await checkDueProjects();
+
+        const sendTelegramSpy = jest.spyOn(
+            telegramNotificationService,
+            'sendTelegramNotification'
+        );
+        sendTelegramSpy.mockClear();
+
+        // Second run within 2-day window: dismissed record found, skip
+        await checkDueProjects();
+
+        expect(sendTelegramSpy).not.toHaveBeenCalled();
+
+        const allNotifications = await Notification.findAll({
+            where: { user_id: user.id },
+        });
+        expect(allNotifications.length).toBe(1);
+    });
+});

--- a/backend/tests/unit/modules/tasks/deferredTaskService.test.js
+++ b/backend/tests/unit/modules/tasks/deferredTaskService.test.js
@@ -1,0 +1,97 @@
+const { Task, Notification, User } = require('../../../../models');
+const {
+    checkDeferredTasks,
+} = require('../../../../modules/tasks/deferredTaskService');
+const telegramNotificationService = require('../../../../modules/telegram/telegramNotificationService');
+const bcrypt = require('bcrypt');
+
+describe('deferredTaskService', () => {
+    let user;
+
+    beforeEach(async () => {
+        user = await User.create({
+            email: 'deferred@example.com',
+            password_digest: await bcrypt.hash('password123', 10),
+            telegram_bot_token: '123456789:ABCdefGHIjklMNOPQRSTUVwxyz-12345678',
+            telegram_chat_id: '123456789',
+            notification_preferences: {
+                deferUntil: { inApp: false, telegram: true },
+            },
+        });
+
+        jest.spyOn(
+            telegramNotificationService,
+            'isTelegramConfigured'
+        ).mockReturnValue(true);
+        jest.spyOn(
+            telegramNotificationService,
+            'sendTelegramNotification'
+        ).mockResolvedValue({ success: true });
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('should send Telegram and create a dismissed tracking record when inApp is disabled', async () => {
+        const now = new Date();
+
+        await Task.create({
+            name: 'Deferred Telegram Only',
+            user_id: user.id,
+            defer_until: now,
+            status: Task.STATUS.NOT_STARTED,
+        });
+
+        const result = await checkDeferredTasks();
+
+        expect(result.success).toBe(true);
+        expect(result.notificationsCreated).toBe(1);
+        expect(
+            telegramNotificationService.sendTelegramNotification
+        ).toHaveBeenCalledTimes(1);
+
+        // A dismissed tracking record is created for deduplication/rate-limiting.
+        // It must not appear as unread (badge must not increment).
+        const allNotifications = await Notification.findAll({
+            where: { user_id: user.id },
+        });
+        expect(allNotifications.length).toBe(1);
+        expect(allNotifications[0].dismissed_at).not.toBeNull();
+
+        const unreadCount = await Notification.count({
+            where: { user_id: user.id, read_at: null, dismissed_at: null },
+        });
+        expect(unreadCount).toBe(0);
+    });
+
+    it('should not resend Telegram within the 24-hour deduplication window', async () => {
+        const now = new Date();
+
+        await Task.create({
+            name: 'Deferred Telegram Rate Limit',
+            user_id: user.id,
+            defer_until: now,
+            status: Task.STATUS.NOT_STARTED,
+        });
+
+        // First run: Telegram sent, tracking record created and dismissed
+        await checkDeferredTasks();
+
+        const sendTelegramSpy = jest.spyOn(
+            telegramNotificationService,
+            'sendTelegramNotification'
+        );
+        sendTelegramSpy.mockClear();
+
+        // Second run within the same day: dismissed record found, skip
+        await checkDeferredTasks();
+
+        expect(sendTelegramSpy).not.toHaveBeenCalled();
+
+        const allNotifications = await Notification.findAll({
+            where: { user_id: user.id },
+        });
+        expect(allNotifications.length).toBe(1);
+    });
+});

--- a/backend/tests/unit/modules/tasks/dueTaskService.test.js
+++ b/backend/tests/unit/modules/tasks/dueTaskService.test.js
@@ -388,6 +388,55 @@ describe('dueTaskService', () => {
                 });
                 expect(notifications.length).toBe(1);
             });
+
+            it('should send Telegram and create a dismissed tracking record when inApp is disabled', async () => {
+                user.telegram_bot_token =
+                    '123456789:ABCdefGHIjklMNOPQRSTUVwxyz-12345678';
+                user.telegram_chat_id = '123456789';
+                user.notification_preferences = {
+                    dueTasks: { inApp: false, telegram: true },
+                    overdueTasks: { inApp: false, telegram: true },
+                };
+                await user.save();
+
+                const tomorrow = new Date();
+                tomorrow.setDate(tomorrow.getDate() + 1);
+
+                await Task.create({
+                    name: 'Telegram Only Task',
+                    user_id: user.id,
+                    due_date: tomorrow,
+                    status: Task.STATUS.NOT_STARTED,
+                });
+
+                const sendTelegramSpy = jest.spyOn(
+                    telegramNotificationService,
+                    'sendTelegramNotification'
+                );
+
+                const result = await checkDueTasks();
+
+                expect(result.success).toBe(true);
+                expect(result.notificationsCreated).toBe(1);
+                expect(sendTelegramSpy).toHaveBeenCalledTimes(1);
+
+                // A dismissed tracking record is created for deduplication/rate-limiting.
+                // It must not appear as unread so the badge is not incremented.
+                const allNotifications = await Notification.findAll({
+                    where: { user_id: user.id },
+                });
+                expect(allNotifications.length).toBe(1);
+                expect(allNotifications[0].dismissed_at).not.toBeNull();
+
+                const unreadCount = await Notification.count({
+                    where: {
+                        user_id: user.id,
+                        read_at: null,
+                        dismissed_at: null,
+                    },
+                });
+                expect(unreadCount).toBe(0);
+            });
         });
     });
 });

--- a/frontend/components/Notifications/NotificationsDropdown.tsx
+++ b/frontend/components/Notifications/NotificationsDropdown.tsx
@@ -87,6 +87,19 @@ const NotificationsDropdown: React.FC<NotificationsDropdownProps> = ({
     }, []);
 
     useEffect(() => {
+        const handleNotificationCreated = () => fetchUnreadCount();
+        window.addEventListener(
+            'notificationCreated',
+            handleNotificationCreated
+        );
+        return () =>
+            window.removeEventListener(
+                'notificationCreated',
+                handleNotificationCreated
+            );
+    }, []);
+
+    useEffect(() => {
         if (isOpen) {
             fetchNotifications();
         }
@@ -214,7 +227,9 @@ const NotificationsDropdown: React.FC<NotificationsDropdownProps> = ({
     const handleNotificationClick = (notification: Notification) => {
         if (notification.data?.taskUid) {
             setIsOpen(false);
-            navigate(`/task/${notification.data.taskUid}`, { state: { from: location.pathname + location.search } });
+            navigate(`/task/${notification.data.taskUid}`, {
+                state: { from: location.pathname + location.search },
+            });
         } else if (notification.data?.projectUid) {
             setIsOpen(false);
             navigate(`/project/${notification.data.projectUid}`);

--- a/frontend/components/Profile/tabs/NotificationsTab.tsx
+++ b/frontend/components/Profile/tabs/NotificationsTab.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next';
 import {
     BellIcon,
     BellAlertIcon,
+    CheckCircleIcon,
+    ExclamationCircleIcon,
     ExclamationTriangleIcon,
     FolderIcon,
     FolderOpenIcon,
@@ -126,7 +128,10 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({
     const [selectedTestType, setSelectedTestType] =
         React.useState<string>('task_due_soon');
     const [testLoading, setTestLoading] = React.useState<boolean>(false);
-    const [testMessage, setTestMessage] = React.useState<string>('');
+    const [testResult, setTestResult] = React.useState<{
+        ok: boolean;
+        text: string;
+    } | null>(null);
 
     // Fetch profile data to check telegram configuration
     React.useEffect(() => {
@@ -166,37 +171,74 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({
         onChange(updatedPreferences);
     };
 
+    // Human-readable labels for each notification channel key.
+    // Extend this map when new channels are added on the backend.
+    const CHANNEL_LABELS: Record<string, string> = {
+        inApp: t('notifications.channels.inApp', 'In-app'),
+        telegram: 'Telegram',
+        email: t('notifications.channels.email', 'Email'),
+        push: t('notifications.channels.push', 'Push'),
+    };
+
     const handleTestNotification = async () => {
         setTestLoading(true);
-        setTestMessage('');
+        setTestResult(null);
 
         try {
             const response = await fetch('/api/test-notifications/trigger', {
                 method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ type: selectedTestType }),
             });
 
             const data = await response.json();
 
-            if (response.ok) {
-                const sources = data.notification.sources;
-                const sourcesList =
-                    sources.length > 0 ? sources.join(', ') : 'in-app only';
-                setTestMessage(`✅ Test notification sent! (${sourcesList})`);
-            } else {
-                setTestMessage(`❌ Failed: ${data.error}`);
+            if (!response.ok) {
+                setTestResult({
+                    ok: false,
+                    text: data.error || 'Request failed',
+                });
+                return;
+            }
+
+            const channels: string[] = data.channels ?? [];
+
+            if (channels.length === 0) {
+                setTestResult({
+                    ok: false,
+                    text: t(
+                        'notifications.test.noChannels',
+                        'No notification channels enabled for this type.'
+                    ),
+                });
+                return;
+            }
+
+            const channelList = channels
+                .map((c) => CHANNEL_LABELS[c] ?? c)
+                .join(', ');
+            setTestResult({
+                ok: true,
+                text: t(
+                    'notifications.test.sent',
+                    'Test notification sent ({{channels}})',
+                    { channels: channelList }
+                ),
+            });
+
+            if (data.notification?.id) {
+                window.dispatchEvent(new CustomEvent('notificationCreated'));
             }
         } catch (error) {
-            setTestMessage(
-                `❌ Error: ${error.message || 'Failed to send test'}`
-            );
+            setTestResult({
+                ok: false,
+                text:
+                    error instanceof Error
+                        ? error.message
+                        : 'Failed to send test',
+            });
         } finally {
             setTestLoading(false);
-            // Clear message after 5 seconds
-            setTimeout(() => setTestMessage(''), 5000);
         }
     };
 
@@ -433,9 +475,20 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({
                         )}
                     </button>
                 </div>
-                {testMessage && (
-                    <div className="mt-3 p-2 text-sm text-purple-900 dark:text-purple-100 bg-purple-100 dark:bg-purple-900/40 rounded">
-                        {testMessage}
+                {testResult && (
+                    <div
+                        className={`mt-3 p-2 text-sm rounded flex items-center gap-2 ${
+                            testResult.ok
+                                ? 'text-green-800 dark:text-green-200 bg-green-50 dark:bg-green-900/30'
+                                : 'text-red-800 dark:text-red-200 bg-red-50 dark:bg-red-900/30'
+                        }`}
+                    >
+                        {testResult.ok ? (
+                            <CheckCircleIcon className="w-4 h-4 flex-shrink-0" />
+                        ) : (
+                            <ExclamationCircleIcon className="w-4 h-4 flex-shrink-0" />
+                        )}
+                        {testResult.text}
                     </div>
                 )}
             </div>

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1340,7 +1340,9 @@
       "title": "Test Notifications",
       "description": "Send a test notification to see how it appears in-app and on enabled channels (Telegram, etc.)",
       "send": "Send Test",
-      "sending": "Sending..."
+      "sending": "Sending...",
+      "noChannels": "No notification channels enabled for this type.",
+      "sent": "Test notification sent ({{channels}})"
     },
     "info": {
       "title": "Note:",


### PR DESCRIPTION
 ## Description                                                                                                                                                                                                    
                                                            
  Adds the missing `POST /api/test-notifications/trigger` endpoint (fixes #1072) and fixes several related notification bugs:                                                                                       
   
  - `inApp` was incorrectly treated as a global on/off switch instead of controlling only the in-app bell and badge. All three scheduled notification services (`dueTaskService`, `deferredTaskService`,            
  `dueProjectService`) now evaluate `inApp` and `telegram` independently.
  - Telegram-only sends (inApp=false, telegram=true) now create a dismissed tracking record so the cron job (running every 5-15 min) cannot spam Telegram repeatedly for the same overdue item.                     
  - The test notification endpoint now verifies Telegram is actually configured before claiming it was sent, and returns an explicit `channels[]` array so the client always knows what was delivered.              
  - The notification badge no longer stays stale after sending a test notification.                                                                                                                                 
                                                                                                                                                                                                                    
  ## Type of Change                                                                                                                                                                                                 
                                                                                                                                                                                                                    
  - [x] Bug fix (fixes an issue)                            
  - [x] New feature (adds functionality)

  ## Related Issues

  Fixes #1072                                                                                                                                                                                                       
   
  ## Testing                                                                                                                                                                                                        
                                                            
  **How did you test this?**

  - Sent test notifications with all channel combinations (inApp only, Telegram only, both, neither) and verified the feedback message, badge counter, and bell entries matched expectations.                       
  - Verified Telegram-only cron runs create exactly one dismissed tracking record and do not resend Telegram on subsequent runs within the deduplication window.
  - Added unit tests for `deferredTaskService` and `dueProjectService` Telegram-only paths, and updated existing `dueTaskService` and integration tests.                                                            
                                                                                                                                                                                                                    
  **Commands run:**                                                                                                                                                                                                 
                                                                                                                                                                                                                    
  - [x] `npm run pre-push` (linting + formatting + tests)                                                                                                                                                           
  - [x] Tested manually in browser
  - [ ] Tested on mobile (if UI changes)                                                                                                                                                                            
                                                            
  ## Checklist

  - [x] This is not an AI slop crap, I know what I am doing
  - [x] Code follows project style guidelines
  - [x] Self-reviewed my own code                                                                                                                                                                                   
  - [x] Added/updated tests (if applicable)
  - [ ] Updated documentation (if needed)                                                                                                                                                                           
  - [ ] Database migrations included and tested (if applicable)
  - [x] Translation keys added manually (couldn't find sync)
                                                                                                                                                                                                                    
