### PR TITLE
fix: replace 6-word limit with 150-character limit for project names

### DIFF
--- a/backend/models/project.js
+++ b/backend/models/project.js
@@ -23,17 +23,9 @@ module.exports = (sequelize) => {
                     notEmpty: {
                         msg: 'Project name is required',
                     },
-                    wordCount(value) {
-                        const MAX_WORDS = 6;
-                        const wordCount = value
-                            .trim()
-                            .split(/\s+/)
-                            .filter((word) => word.length > 0).length;
-                        if (wordCount > MAX_WORDS) {
-                            throw new Error(
-                                `Project name must be ${MAX_WORDS} words or less`
-                            );
-                        }
+                    len: {
+                        args: [1, 150],
+                        msg: 'Project name must be between 1 and 150 characters',
                     },
                 },
             },

--- a/frontend/components/Project/ProjectModal.tsx
+++ b/frontend/components/Project/ProjectModal.tsx
@@ -268,16 +268,12 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
             return;
         }
 
-        const MAX_WORDS = 6;
-        const wordCount = formData.name
-            .trim()
-            .split(/\s+/)
-            .filter((word) => word.length > 0).length;
-        if (wordCount > MAX_WORDS) {
+        const MAX_LENGTH = 150;
+        if (formData.name.trim().length > MAX_LENGTH) {
             setError(
                 t(
                     'errors.projectNameTooLong',
-                    `Project name must be ${MAX_WORDS} words or less`
+                    `Project name must be ${MAX_LENGTH} characters or less`
                 )
             );
             return;


### PR DESCRIPTION
## Description

Replaces the problematic 6-word limit validation with a 150-character limit for project names, addressing user feedback and implementing the original requirement from #971.

The 6-word limit was causing several issues:
- Small words like 'of', 'as', 'in' counted the same as large words
- Separators like ' - ' were being counted as words
- It didn't match the original character-based requirement from #971
- Users had to use awkward workarounds like underscores

This PR implements a simple character length validation (1-150 characters) on both frontend and backend, while keeping the existing UI truncation with line-clamp for display.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

Fixes #998
Related to #971 (original requirement)
Supersedes #972 (PR that introduced the 6-word limit)

## Testing

### Manual Testing
- [x] Create project with name under 150 characters - ✅ Works
- [x] Create project with name over 150 characters - ✅ Shows error
- [x] Edit existing project to exceed 150 characters - ✅ Shows error
- [x] Verify backend validation catches attempts to bypass frontend
- [x] Test that names with many small words now work (e.g., "Project for the organization of all of my tasks")
- [x] Test that names with separators work (e.g., "Q1 2026 - Planning - Strategy")

### Commands Run
```bash
npm run lint  # ✅ Passed
```

## Changes Made

### Backend (`backend/models/project.js`)
- Removed custom `wordCount` validator function
- Added Sequelize built-in `len` validator with range [1, 150]
- Updated error message to reflect character limit

### Frontend (`frontend/components/Project/ProjectModal.tsx`)
- Replaced word count validation logic with character length check
- Updated MAX_WORDS constant to MAX_LENGTH = 150
- Updated error message to reflect character limit

## Checklist

- [x] My code follows the project's code conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have run the linter and fixed any issues
- [x] My changes generate no new warnings
- [x] I have tested the changes locally
- [x] The changes work as expected

## Additional Notes

The UI already has proper line-clamping (`line-clamp-3`) in ProjectBanner.tsx from the original #972 PR, so long names will display correctly with ellipsis truncation. This PR only changes the validation layer to be more sensible and match the original requirement.