### PR TITLE
fix(today-settings): add overflow hidden to metrics section

### DIFF
--- a/frontend/components/Task/TasksToday.tsx
+++ b/frontend/components/Task/TasksToday.tsx
@@ -1512,7 +1512,7 @@ const TasksToday: React.FC = () => {
                                                                 'down' && (
                                                                 <ArrowDownIcon className="h-3 w-3 text-red-500" />
                                                             )}
-                                                            <div className="absolute bottom-full left-1/2 transform -translate-x-1/2 mb-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-gray-700 rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-10">
+                                                            <div className="absolute bottom-full right-0 lg:left-1/2 lg:transform lg:-translate-x-1/2 mb-2 px-2 py-1 text-xs text-white bg-gray-900 dark:bg-gray-700 rounded opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none whitespace-nowrap z-10">
                                                                 {getTooltipText()}
                                                             </div>
                                                         </div>

--- a/frontend/components/Task/TasksToday.tsx
+++ b/frontend/components/Task/TasksToday.tsx
@@ -1366,7 +1366,7 @@ const TasksToday: React.FC = () => {
                         </div>
                     </div>
                 ) : todaySettings.showMetrics ? (
-                    <div className="mb-2 grid grid-cols-1 lg:grid-cols-3 gap-4">
+                    <div className="mb-2 grid grid-cols-1 lg:grid-cols-3 gap-4 overflow-x-hidden">
                         {/* Combined Task & Project Metrics */}
                         <div className="bg-white dark:bg-gray-900 rounded-lg shadow p-4">
                             <h3 className="text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">


### PR DESCRIPTION
Not having the overflow-x-hidden here caused the tooltip width to make the whole page scroll horizontally when the screen was smaller than `lg`.

## Description

The completion trend tooltip in `TasksToday` was causing the whole page content to scroll horizontally, so by setting the parent Metrics Section div overflow-x to hidden, the page no longer scrolls horizontally on small width viewports.
Also shifts the tooltip position on smaller screens to the left, so the text is always visible.


## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1082

## Testing

**How did you test this?**

Using browser's dev tools I set the viewport to where the grid only had one column and checked the width. Also tested on Safari on iOS.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [x] Tested on mobile (if UI changes)

## Screenshots

Before:
<img width="360" height="570" alt="EF64CAD7-295C-4296-8A77-59124A8E86C3_4_5005_c" src="https://github.com/user-attachments/assets/44f42c7d-b1ad-4631-b954-42db26efed07" />

After:
<img width="360" height="544" alt="3205943A-E4C8-411B-A85F-41CAFC5F3D10_4_5005_c" src="https://github.com/user-attachments/assets/fc374056-093b-44da-9049-4ab133595b39" />

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code

## Additional Notes

I was only changing tailwind classes here, but prettier was changing some sections in the file. I didn't commit them as to not pollute the commits/pr. But I'm unsure if I was supposed to leave them, even if in a separate commit.