### PR TITLE
fix(lint): Use backend eslint config in `lint-staged` for backend files

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
       "prettier --write"
     ],
     "backend/**/*.{js,ts}": [
-      "eslint --fix",
+      "eslint --config backend/eslint.config.js --fix",
       "prettier --write"
     ]
   }


### PR DESCRIPTION
<!--
Thank you for contributing to tududi!

Before submitting:
1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
2. Run: npm run pre-push (linting, formatting, tests)
3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
4. Delete sections that don't apply to your PR
-->

## Description

<!-- What does this PR do? Why is this change needed? -->

ESLint flat config does not cascade from subdirectory configs — only the root eslint.config.mjs is used when running from the project root. The backend/eslint.config.js was being silently ignored, causing lint-staged to apply TypeScript ESLint rules to CommonJS backend files.

Pass --config backend/eslint.config.js explicitly for backend files in lint-staged so the correct Node.js/CommonJS config is applied.

## Type of Change

- [x] Bug fix (fixes an issue)

## Testing

**How did you test this?**

<!-- Describe your testing steps -->

- Make a formatting change to a file under `backend/`
- Run `npm run pre-push`

Before this change it would complain about lots of stuff due to using the root config instead of the `backend/eslint.config.js`.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [x] Updated documentation (if needed)
- [x] Database migrations included and tested (if applicable)
- [x] Translation keys added and synced (if applicable)

## Additional Notes

<!-- Anything else reviewers should know? -->

This allows `pre-push` to be set as a git pre-commit hook