### PR TITLE
fix(notifications): include CSRF token in test notification request

### DIFF
--- a/frontend/components/Profile/tabs/NotificationsTab.tsx
+++ b/frontend/components/Profile/tabs/NotificationsTab.tsx
@@ -9,6 +9,7 @@ import {
     ClockIcon,
 } from '@heroicons/react/24/outline';
 import type { NotificationPreferences } from '../types';
+import { getCsrfToken } from '../../../utils/csrfService';
 
 interface NotificationsTabProps {
     isActive: boolean;
@@ -175,6 +176,7 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
+                    'x-csrf-token': await getCsrfToken(),
                 },
                 body: JSON.stringify({ type: selectedTestType }),
             });


### PR DESCRIPTION
The handleTestNotification fetch in NotificationsTab.tsx omitted the x-csrf-token header that every other authenticated POST in this codebase sends via getCsrfToken() (e.g. ProfileSettings, Tasks, TagDetails, SidebarViews, ViewDetail, UniversalSearch, AdminUsersPage). Without it, lusca's CSRF middleware rejects the request and the controller never runs — the user sees an opaque 500 ("Internal server error") instead of the test notification firing.

Backend route /test-notifications/trigger was added in #1047 (PR fixing issue #1002 for the same feature); this completes the fix on the frontend side.

<!--
Thank you for contributing to tududi!

Before submitting:
1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
2. Run: npm run pre-push (linting, formatting, tests)
3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
4. Delete sections that don't apply to your PR
-->

## Description

<!-- What does this PR do? Why is this change needed? -->


## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Backend route /test-notifications/trigger was added in #1047 (PR fixing issue #1002 for the same feature); this completes the fix on the frontend side.

Fixes #

## Testing

**How did you test this?**

<!-- Describe your testing steps -->

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Screenshots

<!-- If UI changes, add before/after screenshots. Delete this section if not applicable. -->


## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

<!-- Anything else reviewers should know? -->

