### PR TITLE
Fix: Enable subtask expansion on Today page

### DIFF
--- a/frontend/components/Task/TaskList.tsx
+++ b/frontend/components/Task/TaskList.tsx
@@ -14,6 +14,7 @@ interface TaskListProps {
     onToggleToday?: (taskId: number, task?: Task) => Promise<void>;
     showCompletedTasks?: boolean;
     isInCompletedSection?: boolean;
+    isUpcomingView?: boolean;
 }
 
 const TaskList: React.FC<TaskListProps> = ({
@@ -26,6 +27,7 @@ const TaskList: React.FC<TaskListProps> = ({
     onToggleToday,
     showCompletedTasks = false,
     isInCompletedSection = false,
+    isUpcomingView = false,
 }) => {
     // Conditionally filter tasks based on showCompletedTasks prop
     const filteredTasks = showCompletedTasks
@@ -57,6 +59,8 @@ const TaskList: React.FC<TaskListProps> = ({
                             hideProjectName={hideProjectName}
                             onToggleToday={onToggleToday}
                             isInCompletedSection={isInCompletedSection}
+                            isUpcomingView={isUpcomingView}
+                            showCompletedTasks={showCompletedTasks}
                         />
                     </div>
                 ))


### PR DESCRIPTION
## Description

This PR fixes the missing subtask expand/collapse functionality on the Today page. Previously, tasks with subtasks displayed on the Today page did not show the expand icon that allows users to view their subtasks, even though this functionality worked correctly in other views (Upcoming, All Tasks, Project views).

The root cause was that the `TaskList` component wasn't passing the `isUpcomingView` and `showCompletedTasks` props to the `TaskItem` component, which are required for the subtask expansion logic to work properly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

Fixes #1094

## Changes Made

- Added `isUpcomingView` prop to `TaskListProps` interface
- Updated `TaskList` component to accept and pass `isUpcomingView` and `showCompletedTasks` props to `TaskItem`
- This enables the subtask expand/collapse icon to appear on the Today page, consistent with other task views

## Testing

- [x] Verified linting passes (`npm run lint`)
- [x] Confirmed the fix aligns subtask behavior across all views (Today, Upcoming, All Tasks)
- [x] No breaking changes to existing functionality

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A - simple prop passing)
- [x] I have made corresponding changes to the documentation (N/A - no docs needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (N/A - UI fix)
- [x] New and existing unit tests pass locally with my changes (N/A - no tests affected)
- [x] Any dependent changes have been merged and published in downstream modules (N/A)

## Additional Notes

This is a minimal fix that only modifies the prop passing in `TaskList.tsx`. The `TaskItem` component already had all the necessary logic to handle subtask expansion - it just wasn't receiving the required props when used in the Today page context.