### PR TITLE
fix: initialize email service on startup to enable user registration

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -12,6 +12,7 @@ const {
     initializeTelegramPolling,
 } = require('./modules/telegram/telegramInitializer');
 const taskScheduler = require('./modules/tasks/taskScheduler');
+const { initializeEmailService } = require('./services/emailService');
 const { setConfig, getConfig } = require('./config/config');
 const config = getConfig();
 const API_VERSION = process.env.API_VERSION || 'v1';
@@ -379,6 +380,9 @@ async function startServer() {
     try {
         // Create session store table
         await sessionStore.sync();
+
+        // Initialize email service
+        initializeEmailService();
 
         // Initialize Telegram polling after database is ready
         await initializeTelegramPolling();


### PR DESCRIPTION
## Description

This PR fixes the issue where new users cannot register because verification emails fail to send. The root cause was that the email service transporter was never being initialized during server startup, so any attempt to send emails would fail with "Email transporter not initialized".

The fix adds the missing `initializeEmailService()` call in the `startServer` function in `app.js`, ensuring the email service is properly configured before the server starts accepting requests.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1090

## Testing

**How did you test this?**

1. Reviewed the email service initialization code in `backend/services/emailService.js`
2. Confirmed that `initializeEmailService()` was never being called in `backend/app.js`
3. Added the initialization call alongside other service initializations (Telegram, task scheduler, CalDAV)
4. Ran the test suite to ensure no regressions

**Commands run:**

- [x] `npm run lint` (linting passed)
- [x] `npm test` (1423 tests passed, 1 pre-existing timeout issue unrelated to this change)
- [ ] Tested manually in browser (would require SMTP configuration)
- [ ] Tested on mobile (if UI changes)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

The fix is minimal and surgical - it only adds the missing initialization call. The email service code itself was already correct; it just wasn't being initialized.

Users will now be able to register successfully when:
1. `ENABLE_EMAIL=true` is set
2. Valid SMTP credentials are provided via environment variables
3. `registration_enabled` setting is enabled in admin settings

If email is disabled or SMTP configuration is missing, the service will log appropriate warnings but won't crash.