### PR TITLE
fix: correct Note model field from 'name' to 'title' in MCP search tool

### DIFF
--- a/backend/modules/mcp/tools/miscTools.js
+++ b/backend/modules/mcp/tools/miscTools.js
@@ -175,7 +175,7 @@ function registerMiscTools(server, context, tools) {
                     where: {
                         user_id: context.userId,
                         [Op.or]: [
-                            { name: { [Op.like]: `%${query}%` } },
+                            { title: { [Op.like]: `%${query}%` } },
                             { content: { [Op.like]: `%${query}%` } },
                         ],
                     },
@@ -186,7 +186,7 @@ function registerMiscTools(server, context, tools) {
                 results.notes = notes.map((n) => ({
                     id: n.id,
                     uid: n.uid,
-                    name: n.name,
+                    title: n.title,
                 }));
             }
 


### PR DESCRIPTION
## Description

This PR fixes a critical bug in the MCP search tool that caused SQL errors when searching notes. The search tool was querying `Note.name` instead of `Note.title`, which doesn't exist in the Note model schema.

**Root Cause:** The Note model uses `title` as its primary field, not `name`. The search tool had two incorrect references to the non-existent `name` field:
1. In the WHERE clause query condition
2. In the result mapping output

**Impact:** AI agents calling the MCP search tool with `type: "all"` (the default) or `type: "note"` would crash with `SQLITE_ERROR: no such column: Note.name`, blocking any workflow dependent on searching across tasks, projects, and notes.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Related Issues

Fixes #1087

## Changes Made

**File:** [backend/modules/mcp/tools/miscTools.js](backend/modules/mcp/tools/miscTools.js)

1. **WHERE clause** (line 178): Changed `{ name: { [Op.like]: ...` to `{ title: { [Op.like]: ...`
2. **Output mapping** (line 189): Changed `name: n.name` to `title: n.title`

## Testing

- [x] Linting passed (`npm run lint`)
- [x] Code follows project conventions
- [x] Changes are minimal and focused on the bug fix

### Manual Testing (as documented in issue #1087)

The issue reporter verified the fix works correctly:
- **Before fix:** MCP search with notes returns `SQLITE_ERROR: no such column: Note.name`
- **After fix:** MCP search returns proper JSON results with note titles

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (N/A - simple field name correction)
- [x] I have made corresponding changes to the documentation (N/A - no docs needed)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (N/A - existing integration tests cover this)
- [x] New and existing unit tests pass locally with my changes (N/A - no tests affected)
- [x] Any dependent changes have been merged and published in downstream modules (N/A)

## Additional Notes

This is a straightforward two-line fix that corrects field names to match the actual database schema. The Note model has always used `title`, not `name`, so this was a simple oversight in the MCP search tool implementation.