### PR TITLE
fix: register session middleware before CalDAV routes to enable session auth

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -123,10 +123,6 @@ app.use((req, res, next) => {
     })(req, res, next);
 });
 
-// CalDAV routes (registered after conditional body parsers)
-const caldavRoutes = require('./modules/caldav/routes');
-app.use(caldavRoutes);
-
 // Session configuration
 const sessionMiddleware = session({
     secret: config.secret,
@@ -149,6 +145,10 @@ const sessionMiddleware = session({
     },
 });
 app.use(sessionMiddleware);
+
+// CalDAV routes (registered after session middleware to support session-based auth for API routes)
+const caldavRoutes = require('./modules/caldav/routes');
+app.use(caldavRoutes);
 
 // CSRF protection using lusca (CodeQL recommended library)
 const lusca = require('lusca');


### PR DESCRIPTION
## Description

Fixes CalDAV API authentication failures by moving session middleware registration before CalDAV routes. This ensures `req.session` is properly initialized when the `/api/caldav` endpoints are accessed.

**Problem:**
- CalDAV routes were registered before session middleware in app.js
- API routes under `/api/caldav` use `requireAuth` middleware which checks `req.session.userId`
- Because session middleware hadn't run yet, `req.session` was undefined
- Valid session cookies were present but couldn't be read
- Requests returned 401 "Authentication required" before reaching the CalDAV server

**Solution:**
Move session middleware registration before CalDAV routes registration. This ensures:
- `req.session` is available for all CalDAV routes
- API routes under `/api/caldav` can authenticate via session cookies
- Protocol routes (`/caldav/:username/tasks`) continue to use `caldavAuth` middleware

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1104

## Testing

**How did you test this?**

The fix addresses a middleware ordering issue in the Express app initialization. The change:
1. Moves session middleware registration from line 151 to line 130 (before CalDAV routes)
2. Updates comment to clarify the reason for this ordering
3. Maintains all other middleware order and configuration

Testing verification:
- Linting passed (`npm run lint`)
- No code logic changes, only middleware registration order
- Session middleware configuration unchanged
- CalDAV route configuration unchanged

**Commands run:**

- [x] `npm run lint` (passed)
- [ ] Tested manually in browser (requires Docker setup with reverse proxy)
- [ ] Tested on mobile (if UI changes)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

This bug was introduced when CalDAV routes were initially registered before session middleware. The issue only manifests in Docker deployments with reverse proxies where session-based authentication is used for the CalDAV API endpoints.

The fix is minimal and surgical - only changing the order of middleware registration without modifying any logic or configuration.