### PR TITLE
fix: Update task count display when tasks are created or deleted

### DIFF
--- a/frontend/components/Tasks.tsx
+++ b/frontend/components/Tasks.tsx
@@ -330,6 +330,7 @@ const Tasks: React.FC = () => {
             const newTask = event.detail;
             if (newTask) {
                 setTasks((prevTasks) => [newTask, ...prevTasks]);
+                setTotalCount((prevCount) => prevCount + 1);
             }
         };
 
@@ -358,6 +359,7 @@ const Tasks: React.FC = () => {
         try {
             const newTask = await createTask(taskData as Task);
             setTasks((prevTasks) => [newTask, ...prevTasks]);
+            setTotalCount((prevCount) => prevCount + 1);
 
             const taskLink = (
                 <span>
@@ -460,6 +462,7 @@ const Tasks: React.FC = () => {
                 setTasks((prevTasks) =>
                     prevTasks.filter((task) => task.uid !== taskUid)
                 );
+                setTotalCount((prevCount) => prevCount - 1);
             } else {
                 const errorData = await response.json();
                 console.error('Failed to delete task:', errorData.error);


### PR DESCRIPTION
## Summary
- Fixes visual bug where task count displayed incorrect totals (e.g., "7 of 1" instead of "7 of 7")
- Updates `totalCount` state when tasks are created or deleted locally on All Tasks page
- Three specific updates:
  - Increment `totalCount` in `handleTaskCreate` 
  - Increment `totalCount` in `taskCreated` event listener
  - Decrement `totalCount` in `handleTaskDelete`

## Test plan
- [x] Run existing backend pagination tests - all pass
- [x] Lint check passes
- [ ] Manual testing: Navigate to All Tasks page, add tasks, verify count displays correctly
- [ ] Manual testing: Delete tasks, verify count decrements correctly

Fixes #1032

🤖 Generated with [Claude Code](https://claude.com/claude-code)