### PR TITLE
fix: Add CSRF token to project image upload request

### DIFF
--- a/frontend/components/Project/BannerEditModal.tsx
+++ b/frontend/components/Project/BannerEditModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { getPresetBanners, PresetBanner } from '../../utils/bannersService';
 import { getApiPath, getAssetPath } from '../../config/paths';
+import { getCsrfToken } from '../../utils/csrfService';
 
 interface BannerEditModalProps {
     isOpen: boolean;
@@ -93,6 +94,9 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
             const response = await fetch(getApiPath('upload/project-image'), {
                 method: 'POST',
                 credentials: 'include',
+                headers: {
+                    'x-csrf-token': await getCsrfToken(),
+                },
                 body: formData,
             });
 


### PR DESCRIPTION
## Summary

Fixes #1117 - Project image upload now includes CSRF token header to prevent "CSRF token missing" 500 errors.

## Changes

- Added import for `getCsrfToken` from `csrfService` in [BannerEditModal.tsx](frontend/components/Project/BannerEditModal.tsx)
- Added `x-csrf-token` header to the project image upload fetch request in `handleImageUpload()` function

This fix mirrors the pattern used in other upload endpoints (like task attachments in `attachmentsService.ts`).

## Test plan

- [x] Build passes (TypeScript compilation and webpack)
- [x] Linter passes without errors
- [ ] Manually tested: Upload project image successfully without CSRF error

## Technical details

The issue was that the multipart upload request to `/api/upload/project-image` wasn't including the CSRF token header that lusca's `checkCsrf` middleware expects. This is the same pattern that was fixed in previous issues (#1044, #1065, #1091).

The fix adds:
```typescript
headers: {
    'x-csrf-token': await getCsrfToken(),
},
```

to the fetch request, matching the pattern in `attachmentsService.ts` and other authenticated endpoints.