### PR TITLE
fix(migration): Parse JSON string before property access in notification preferences migration

### DIFF
--- a/backend/migrations/20260509000001-ensure-notification-preferences.js
+++ b/backend/migrations/20260509000001-ensure-notification-preferences.js
@@ -59,7 +59,14 @@ module.exports = {
 
         let updatedCount = 0;
         for (const user of usersWithPrefs) {
-            const prefs = user.notification_preferences;
+            let prefs = user.notification_preferences;
+            if (typeof prefs === 'string') {
+                try {
+                    prefs = JSON.parse(prefs);
+                } catch {
+                    prefs = {};
+                }
+            }
             let needsUpdate = false;
 
             // Check if all required keys exist


### PR DESCRIPTION
<!--
Thank you for contributing to tududi!

Before submitting:
1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
2. Run: npm run pre-push (linting, formatting, tests)
3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
4. Delete sections that don't apply to your PR
-->

## Description

<!-- What does this PR do? Why is this change needed? -->

SQLite returns JSON columns as raw strings when queried via raw SQL (queryInterface.sequelize.query). The migration was treating the value as an already-parsed object, causing a TypeError when attempting to set properties on the string primitive.

Fixes: `ERROR: Cannot create property 'dueTasks' on string '{"dueTasks":...}'`

## Type of Change

- [x] Bug fix (fixes an issue)

## Testing

**How did you test this?**

<!-- Describe your testing steps -->

Running on my home server.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [x] Tested on mobile (if UI changes)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [x] Updated documentation (if needed)
- [x] Database migrations included and tested (if applicable)
- [x] Translation keys added and synced (if applicable)