### PR TITLE
Include CSRF token when setting project task to in progress

### DIFF
--- a/frontend/components/Project/ProjectDetails.tsx
+++ b/frontend/components/Project/ProjectDetails.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { getCsrfToken } from '../../utils/csrfService';
 import {
     MagnifyingGlassIcon,
     EllipsisHorizontalCircleIcon,
@@ -323,7 +324,10 @@ const ProjectDetails: React.FC = () => {
         }
         const response = await fetch(getApiPath(`task/${updatedTask.uid}`), {
             method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+                'Content-Type': 'application/json',
+                'x-csrf-token': await getCsrfToken(),
+            },
             credentials: 'include',
             body: JSON.stringify(updatedTask),
         });


### PR DESCRIPTION
## Description

When a task in a project is set to `In progress` the app will fail and show and error message because the CSRF token is not included in the request. This PR fixes this.


## Type of Change

- [X] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

None

## Testing

**How did you test this?**

<!-- Describe your testing steps -->

**Commands run:**

- [X] `npm run pre-push` (linting + formatting + tests)
- [X] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Checklist

- [X] This is not an AI slop crap, I know what I am doing
- [X] Code follows project style guidelines
- [X] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)
