### PR TITLE
fix(caldav): Add missing encryption keys and repository methods

### DIFF
--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -142,6 +142,12 @@ const config = {
         return val;
     })(),
 
+    // Encryption key for CalDAV credentials (falls back to SECRET_KEY or session secret)
+    encryptionKey: process.env.ENCRYPTION_KEY,
+
+    // Alternative encryption key (for backward compatibility)
+    secretKey: process.env.SECRET_KEY,
+
     // Rate limiting configuration
     rateLimiting: {
         // Disable rate limiting in test environment

--- a/backend/modules/caldav/repositories/sync-state-repository.js
+++ b/backend/modules/caldav/repositories/sync-state-repository.js
@@ -135,6 +135,46 @@ class SyncStateRepository extends BaseRepository {
             options
         );
     }
+
+    async getSyncStats(calendarId, options = {}) {
+        const syncStates = await this.findByCalendarId(calendarId, options);
+
+        const stats = {
+            total: syncStates.length,
+            synced: 0,
+            pending: 0,
+            conflict: 0,
+            error: 0,
+            lastSyncedAt: null,
+        };
+
+        syncStates.forEach((state) => {
+            if (state.sync_status === 'synced') stats.synced++;
+            else if (state.sync_status === 'pending') stats.pending++;
+            else if (state.sync_status === 'conflict') stats.conflict++;
+            else if (state.sync_status === 'error') stats.error++;
+
+            if (
+                state.last_synced_at &&
+                (!stats.lastSyncedAt ||
+                    state.last_synced_at > stats.lastSyncedAt)
+            ) {
+                stats.lastSyncedAt = state.last_synced_at;
+            }
+        });
+
+        return stats;
+    }
+
+    async deleteByCalendarId(calendarId, options = {}) {
+        const syncStates = await this.findByCalendarId(calendarId, options);
+
+        await Promise.all(
+            syncStates.map((state) => this.delete(state, options))
+        );
+
+        return syncStates.length;
+    }
 }
 
 module.exports = new SyncStateRepository();


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs in the CalDAV integration that prevented users from adding CalDAV calendars:

1. **Missing encryption key configuration**: The `ENCRYPTION_KEY` and `SECRET_KEY` environment variables were not being mapped in the config, causing encryption failures when storing CalDAV credentials
2. **Missing repository methods**: The `SyncStateRepository` was missing `getSyncStats()` and `deleteByCalendarId()` methods, causing the CalDAV page to crash

## Changes

### backend/config/config.js
- Added `encryptionKey` property mapped to `ENCRYPTION_KEY` env variable
- Added `secretKey` property mapped to `SECRET_KEY` env variable

### backend/modules/caldav/repositories/sync-state-repository.js
- Added `getSyncStats(calendarId)` method to return sync statistics (total, synced, pending, conflict, error counts)
- Added `deleteByCalendarId(calendarId)` method to clean up sync states when deleting calendars

## Test Plan

- Ran full test suite: 1518 tests passed
- Verified no new test failures related to these changes
- The fixes enable the encryption service to properly read the encryption key from environment variables
- The repository methods prevent crashes when accessing CalDAV pages

## Fixes

Fixes #1125