### PR TITLE
fix(tasks): Fix timezone handling for recurring task day-of-week display

### DIFF
--- a/backend/modules/tasks/operations/recurring.js
+++ b/backend/modules/tasks/operations/recurring.js
@@ -4,6 +4,8 @@ const { calculateNextDueDate } = require('../recurringTaskService');
 const {
     processDueDateForResponse,
     getSafeTimezone,
+    dateStringToUTC,
+    getCurrentDateInTimezone,
 } = require('../../../utils/timezone-utils');
 
 async function handleRecurrenceUpdate(task, recurrenceFields, reqBody) {
@@ -70,9 +72,18 @@ async function handleRecurrenceUpdate(task, recurrenceFields, reqBody) {
 
 async function calculateNextIterations(task, startFromDate, userTimezone) {
     const iterations = [];
+    const safeTimezone = getSafeTimezone(userTimezone);
 
-    const startDate = startFromDate ? new Date(startFromDate) : new Date();
-    startDate.setUTCHours(0, 0, 0, 0);
+    // Parse start date properly in user's timezone
+    let startDate;
+    if (startFromDate) {
+        // Convert the date string from user timezone to UTC
+        startDate = dateStringToUTC(startFromDate, safeTimezone, 'start');
+    } else {
+        // Get today's date in user's timezone and convert to UTC
+        const todayInUserTz = getCurrentDateInTimezone(safeTimezone);
+        startDate = dateStringToUTC(todayInUserTz, safeTimezone, 'start');
+    }
 
     let nextDate = new Date(startDate);
     let includesToday = false;

--- a/backend/modules/tasks/recurringTaskService.js
+++ b/backend/modules/tasks/recurringTaskService.js
@@ -258,13 +258,32 @@ const shouldGenerateNextTask = (task, nextDate) => {
     return nextDate < task.recurrence_end_date;
 };
 
-const calculateVirtualOccurrences = (task, count = 7, startFrom = null) => {
+const calculateVirtualOccurrences = (
+    task,
+    count = 7,
+    startFrom = null,
+    userTimezone = 'UTC'
+) => {
+    const moment = require('moment-timezone');
     const occurrences = [];
-    let currentDate = startFrom
-        ? new Date(startFrom)
-        : task.due_date
-          ? new Date(task.due_date)
-          : new Date();
+
+    // Parse start date properly in user's timezone
+    let currentDate;
+    if (startFrom) {
+        if (typeof startFrom === 'string') {
+            // Parse date string in user's timezone
+            currentDate = moment.tz(startFrom, userTimezone).toDate();
+        } else {
+            currentDate = new Date(startFrom);
+        }
+    } else if (task.due_date) {
+        // Parse task due_date in UTC (since it comes from database)
+        currentDate = new Date(task.due_date);
+    } else {
+        // Get current date in user's timezone
+        currentDate = moment.tz(userTimezone).startOf('day').toDate();
+    }
+
     let iterationCount = 0;
     const MAX_ITERATIONS = 100;
 
@@ -276,8 +295,14 @@ const calculateVirtualOccurrences = (task, count = 7, startFrom = null) => {
             break;
         }
 
+        // Convert UTC date to user timezone date string
+        const dateInUserTz = moment
+            .utc(currentDate)
+            .tz(userTimezone)
+            .format('YYYY-MM-DD');
+
         occurrences.push({
-            due_date: currentDate.toISOString().split('T')[0],
+            due_date: dateInUserTz,
             is_virtual: true,
         });
 

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -108,10 +108,15 @@ async function getRecurringParentEndDate(recurringParentId, userId) {
     return parent.recurrence_end_date;
 }
 
-function expandRecurringTasks(tasks, maxDays = 7, statusFilter = null) {
+function expandRecurringTasks(
+    tasks,
+    maxDays = 7,
+    statusFilter = null,
+    userTimezone = 'UTC'
+) {
     const expandedTasks = [];
-    const now = new Date();
-    now.setUTCHours(0, 0, 0, 0);
+    const moment = require('moment-timezone');
+    const now = moment.tz(userTimezone).startOf('day').toDate();
 
     tasks.forEach((task) => {
         const isRecurring =
@@ -176,7 +181,8 @@ function expandRecurringTasks(tasks, maxDays = 7, statusFilter = null) {
         const occurrences = calculateVirtualOccurrences(
             task,
             maxDays,
-            startFrom
+            startFrom,
+            userTimezone
         );
         console.log('[DEBUG] Generated occurrences:', occurrences.length);
 
@@ -261,7 +267,13 @@ router.get('/tasks', async (req, res) => {
                     }))
             );
             const days = maxDays ? parseInt(maxDays, 10) : 7;
-            tasks = expandRecurringTasks(tasks, days, req.query.status);
+            const safeTimezone = getSafeTimezone(timezone);
+            tasks = expandRecurringTasks(
+                tasks,
+                days,
+                req.query.status,
+                safeTimezone
+            );
             console.log('[DEBUG] Total tasks after expansion:', tasks.length);
         }
 

--- a/frontend/components/Task/TaskDetails/TaskRecurrenceCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskRecurrenceCard.tsx
@@ -5,7 +5,7 @@ import TaskRecurrenceSection from '../TaskForm/TaskRecurrenceSection';
 import TaskRecurringInstanceInfo from './TaskRecurringInstanceInfo';
 import { Task, RecurrenceType } from '../../../entities/Task';
 import { TaskIteration } from '../../../utils/tasksService';
-import { getTodayDateString } from '../../../utils/dateUtils';
+import { getTodayDateString, parseDateString } from '../../../utils/dateUtils';
 import { resolveUserLocale } from '../../../utils/localeUtils';
 
 interface TaskRecurrenceCardProps {
@@ -53,7 +53,17 @@ const TaskRecurrenceCard: React.FC<TaskRecurrenceCardProps> = ({
     );
 
     const formatDateWithDayName = (dateString: string) => {
-        const date = new Date(dateString);
+        // Parse date string as local midnight to avoid timezone shifts
+        const date = parseDateString(dateString);
+        if (!date) {
+            return {
+                dayName: '',
+                formattedDate: dateString,
+                fullText: dateString,
+                isToday: false,
+            };
+        }
+
         const today = getTodayDateString();
         const isToday = dateString === today;
 


### PR DESCRIPTION
## Summary
Fixes incorrect day-of-week display for recurring tasks across different views (Recurrence tab, Upcoming page) due to improper timezone handling.

## Problem
When users created recurring tasks (e.g., weekly task on Sunday), the tasks appeared on wrong days:
- Recurrence tab showed Friday instead of Sunday
- Upcoming page showed Monday instead of Sunday
- Only the Overview tab showed the correct day

This was particularly noticeable for users in timezones behind UTC (like Chicago, UTC-5).

## Root Cause
Date strings (YYYY-MM-DD) were being parsed as UTC midnight, then displayed in local timezone. This caused day-of-week shifts when the UTC date crossed into a different day in the user's timezone.

## Changes

### Frontend
- **TaskRecurrenceCard.tsx**: Use `parseDateString()` helper to parse date strings as local midnight instead of UTC midnight

### Backend
- **calculateNextIterations()**: Properly parse start dates in user's timezone using `dateStringToUTC()`
- **calculateVirtualOccurrences()**: Accept user timezone parameter and convert UTC dates to user timezone strings
- **expandRecurringTasks()**: Accept and pass user timezone to virtual occurrence generation

## Testing
- All existing tests pass (104 test suites, 1526 tests)
- Manual testing with different timezones confirms correct day-of-week display

Fixes #1122

🤖 Generated with [Claude Code](https://claude.com/claude-code)