### PR TITLE
fix(caldav): Add error handling to CalDAV API routes

### DIFF
--- a/backend/modules/caldav/api/calendar-controller.js
+++ b/backend/modules/caldav/api/calendar-controller.js
@@ -4,142 +4,73 @@ const SyncStateRepository = require('../repositories/sync-state-repository');
 const { uid } = require('../../../utils/uid');
 
 class CalendarController {
-    async listCalendars(req, res) {
-        const userId = req.currentUser.id;
+    async listCalendars(req, res, next) {
+        try {
+            const userId = req.currentUser.id;
 
-        const calendars = await CalendarRepository.findByUserId(userId);
+            const calendars = await CalendarRepository.findByUserId(userId);
 
-        const calendarsWithStats = await Promise.all(
-            calendars.map(async (calendar) => {
-                const stats = await SyncStateRepository.getSyncStats(
-                    calendar.id
-                );
-                return {
-                    ...calendar.toJSON(),
-                    stats,
-                };
-            })
-        );
+            const calendarsWithStats = await Promise.all(
+                calendars.map(async (calendar) => {
+                    const stats = await SyncStateRepository.getSyncStats(
+                        calendar.id
+                    );
+                    return {
+                        ...calendar.toJSON(),
+                        stats,
+                    };
+                })
+            );
 
-        res.json(calendarsWithStats);
+            res.json(calendarsWithStats);
+        } catch (error) {
+            next(error);
+        }
     }
 
-    async getCalendar(req, res) {
-        const { id } = req.params;
-        const userId = req.currentUser.id;
+    async getCalendar(req, res, next) {
+        try {
+            const { id } = req.params;
+            const userId = req.currentUser.id;
 
-        const calendar = await CalendarRepository.findById(id);
+            const calendar = await CalendarRepository.findById(id);
 
-        if (!calendar) {
-            throw new AppError('Calendar not found', 404);
+            if (!calendar) {
+                throw new AppError('Calendar not found', 404);
+            }
+
+            if (calendar.user_id !== userId) {
+                throw new AppError('Unauthorized access to calendar', 403);
+            }
+
+            const stats = await SyncStateRepository.getSyncStats(calendar.id);
+
+            res.json({
+                ...calendar.toJSON(),
+                stats,
+            });
+        } catch (error) {
+            next(error);
         }
-
-        if (calendar.user_id !== userId) {
-            throw new AppError('Unauthorized access to calendar', 403);
-        }
-
-        const stats = await SyncStateRepository.getSyncStats(calendar.id);
-
-        res.json({
-            ...calendar.toJSON(),
-            stats,
-        });
     }
 
-    async createCalendar(req, res) {
-        const userId = req.currentUser.id;
-        const {
-            name,
-            description,
-            color,
-            enabled = true,
-            sync_direction = 'bidirectional',
-            sync_interval_minutes = 15,
-            conflict_resolution = 'last_write_wins',
-        } = req.body;
+    async createCalendar(req, res, next) {
+        try {
+            const userId = req.currentUser.id;
+            const {
+                name,
+                description,
+                color,
+                enabled = true,
+                sync_direction = 'bidirectional',
+                sync_interval_minutes = 15,
+                conflict_resolution = 'last_write_wins',
+            } = req.body;
 
-        if (!name) {
-            throw new AppError('Calendar name is required', 400);
-        }
+            if (!name) {
+                throw new AppError('Calendar name is required', 400);
+            }
 
-        const validDirections = ['bidirectional', 'pull', 'push'];
-        if (!validDirections.includes(sync_direction)) {
-            throw new AppError(
-                `Invalid sync direction. Must be one of: ${validDirections.join(', ')}`,
-                400
-            );
-        }
-
-        const validResolutions = [
-            'last_write_wins',
-            'local_wins',
-            'remote_wins',
-            'manual',
-        ];
-        if (!validResolutions.includes(conflict_resolution)) {
-            throw new AppError(
-                `Invalid conflict resolution. Must be one of: ${validResolutions.join(', ')}`,
-                400
-            );
-        }
-
-        if (
-            !Number.isInteger(sync_interval_minutes) ||
-            sync_interval_minutes < 1 ||
-            sync_interval_minutes > 1440
-        ) {
-            throw new AppError(
-                'Sync interval must be between 1 and 1440 minutes',
-                400
-            );
-        }
-
-        const calendar = await CalendarRepository.create({
-            uid: uid(),
-            user_id: userId,
-            name,
-            description: description || null,
-            color: color || null,
-            enabled,
-            sync_direction,
-            sync_interval_minutes,
-            conflict_resolution,
-        });
-
-        res.status(201).json(calendar);
-    }
-
-    async updateCalendar(req, res) {
-        const { id } = req.params;
-        const userId = req.currentUser.id;
-
-        const calendar = await CalendarRepository.findById(id);
-
-        if (!calendar) {
-            throw new AppError('Calendar not found', 404);
-        }
-
-        if (calendar.user_id !== userId) {
-            throw new AppError('Unauthorized access to calendar', 403);
-        }
-
-        const {
-            name,
-            description,
-            color,
-            enabled,
-            sync_direction,
-            sync_interval_minutes,
-            conflict_resolution,
-        } = req.body;
-
-        const updates = {};
-
-        if (name !== undefined) updates.name = name;
-        if (description !== undefined) updates.description = description;
-        if (color !== undefined) updates.color = color;
-        if (enabled !== undefined) updates.enabled = enabled;
-        if (sync_direction !== undefined) {
             const validDirections = ['bidirectional', 'pull', 'push'];
             if (!validDirections.includes(sync_direction)) {
                 throw new AppError(
@@ -147,22 +78,7 @@ class CalendarController {
                     400
                 );
             }
-            updates.sync_direction = sync_direction;
-        }
-        if (sync_interval_minutes !== undefined) {
-            if (
-                !Number.isInteger(sync_interval_minutes) ||
-                sync_interval_minutes < 1 ||
-                sync_interval_minutes > 1440
-            ) {
-                throw new AppError(
-                    'Sync interval must be between 1 and 1440 minutes',
-                    400
-                );
-            }
-            updates.sync_interval_minutes = sync_interval_minutes;
-        }
-        if (conflict_resolution !== undefined) {
+
             const validResolutions = [
                 'last_write_wins',
                 'local_wins',
@@ -175,36 +91,140 @@ class CalendarController {
                     400
                 );
             }
-            updates.conflict_resolution = conflict_resolution;
+
+            if (
+                !Number.isInteger(sync_interval_minutes) ||
+                sync_interval_minutes < 1 ||
+                sync_interval_minutes > 1440
+            ) {
+                throw new AppError(
+                    'Sync interval must be between 1 and 1440 minutes',
+                    400
+                );
+            }
+
+            const calendar = await CalendarRepository.create({
+                uid: uid(),
+                user_id: userId,
+                name,
+                description: description || null,
+                color: color || null,
+                enabled,
+                sync_direction,
+                sync_interval_minutes,
+                conflict_resolution,
+            });
+
+            res.status(201).json(calendar);
+        } catch (error) {
+            next(error);
         }
-
-        const updatedCalendar = await CalendarRepository.update(
-            calendar,
-            updates
-        );
-
-        res.json(updatedCalendar);
     }
 
-    async deleteCalendar(req, res) {
-        const { id } = req.params;
-        const userId = req.currentUser.id;
+    async updateCalendar(req, res, next) {
+        try {
+            const { id } = req.params;
+            const userId = req.currentUser.id;
 
-        const calendar = await CalendarRepository.findById(id);
+            const calendar = await CalendarRepository.findById(id);
 
-        if (!calendar) {
-            throw new AppError('Calendar not found', 404);
+            if (!calendar) {
+                throw new AppError('Calendar not found', 404);
+            }
+
+            if (calendar.user_id !== userId) {
+                throw new AppError('Unauthorized access to calendar', 403);
+            }
+
+            const {
+                name,
+                description,
+                color,
+                enabled,
+                sync_direction,
+                sync_interval_minutes,
+                conflict_resolution,
+            } = req.body;
+
+            const updates = {};
+
+            if (name !== undefined) updates.name = name;
+            if (description !== undefined) updates.description = description;
+            if (color !== undefined) updates.color = color;
+            if (enabled !== undefined) updates.enabled = enabled;
+            if (sync_direction !== undefined) {
+                const validDirections = ['bidirectional', 'pull', 'push'];
+                if (!validDirections.includes(sync_direction)) {
+                    throw new AppError(
+                        `Invalid sync direction. Must be one of: ${validDirections.join(', ')}`,
+                        400
+                    );
+                }
+                updates.sync_direction = sync_direction;
+            }
+            if (sync_interval_minutes !== undefined) {
+                if (
+                    !Number.isInteger(sync_interval_minutes) ||
+                    sync_interval_minutes < 1 ||
+                    sync_interval_minutes > 1440
+                ) {
+                    throw new AppError(
+                        'Sync interval must be between 1 and 1440 minutes',
+                        400
+                    );
+                }
+                updates.sync_interval_minutes = sync_interval_minutes;
+            }
+            if (conflict_resolution !== undefined) {
+                const validResolutions = [
+                    'last_write_wins',
+                    'local_wins',
+                    'remote_wins',
+                    'manual',
+                ];
+                if (!validResolutions.includes(conflict_resolution)) {
+                    throw new AppError(
+                        `Invalid conflict resolution. Must be one of: ${validResolutions.join(', ')}`,
+                        400
+                    );
+                }
+                updates.conflict_resolution = conflict_resolution;
+            }
+
+            const updatedCalendar = await CalendarRepository.update(
+                calendar,
+                updates
+            );
+
+            res.json(updatedCalendar);
+        } catch (error) {
+            next(error);
         }
+    }
 
-        if (calendar.user_id !== userId) {
-            throw new AppError('Unauthorized access to calendar', 403);
+    async deleteCalendar(req, res, next) {
+        try {
+            const { id } = req.params;
+            const userId = req.currentUser.id;
+
+            const calendar = await CalendarRepository.findById(id);
+
+            if (!calendar) {
+                throw new AppError('Calendar not found', 404);
+            }
+
+            if (calendar.user_id !== userId) {
+                throw new AppError('Unauthorized access to calendar', 403);
+            }
+
+            await SyncStateRepository.deleteByCalendarId(calendar.id);
+
+            await CalendarRepository.delete(calendar);
+
+            res.status(204).send();
+        } catch (error) {
+            next(error);
         }
-
-        await SyncStateRepository.deleteByCalendarId(calendar.id);
-
-        await CalendarRepository.delete(calendar);
-
-        res.status(204).send();
     }
 }
 

--- a/backend/modules/caldav/api/remote-calendar-controller.js
+++ b/backend/modules/caldav/api/remote-calendar-controller.js
@@ -69,190 +69,105 @@ function validateCalDAVUrl(urlString) {
 }
 
 class RemoteCalendarController {
-    async listRemoteCalendars(req, res) {
-        const userId = req.currentUser.id;
+    async listRemoteCalendars(req, res, next) {
+        try {
+            const userId = req.currentUser.id;
 
-        const remoteCalendars =
-            await RemoteCalendarRepository.findByUserId(userId);
+            const remoteCalendars =
+                await RemoteCalendarRepository.findByUserId(userId);
 
-        const sanitizedCalendars = remoteCalendars.map((rc) => {
-            const json = rc.toJSON();
+            const sanitizedCalendars = remoteCalendars.map((rc) => {
+                const json = rc.toJSON();
+                delete json.password_encrypted;
+                return json;
+            });
+
+            res.json(sanitizedCalendars);
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async getRemoteCalendar(req, res, next) {
+        try {
+            const { id } = req.params;
+            const userId = req.currentUser.id;
+
+            const remoteCalendar = await RemoteCalendarRepository.findById(id);
+
+            if (!remoteCalendar) {
+                throw new AppError('Remote calendar not found', 404);
+            }
+
+            if (remoteCalendar.user_id !== userId) {
+                throw new AppError(
+                    'Unauthorized access to remote calendar',
+                    403
+                );
+            }
+
+            const json = remoteCalendar.toJSON();
             delete json.password_encrypted;
-            return json;
-        });
 
-        res.json(sanitizedCalendars);
+            res.json(json);
+        } catch (error) {
+            next(error);
+        }
     }
 
-    async getRemoteCalendar(req, res) {
-        const { id } = req.params;
-        const userId = req.currentUser.id;
+    async createRemoteCalendar(req, res, next) {
+        try {
+            const userId = req.currentUser.id;
+            const {
+                local_calendar_id,
+                name,
+                server_url,
+                calendar_path,
+                username,
+                password,
+                auth_type = 'basic',
+                enabled = true,
+                sync_direction = 'bidirectional',
+            } = req.body;
 
-        const remoteCalendar = await RemoteCalendarRepository.findById(id);
+            if (
+                !local_calendar_id ||
+                !name ||
+                !server_url ||
+                !calendar_path ||
+                !username ||
+                !password
+            ) {
+                throw new AppError(
+                    'Missing required fields: local_calendar_id, name, server_url, calendar_path, username, password',
+                    400
+                );
+            }
 
-        if (!remoteCalendar) {
-            throw new AppError('Remote calendar not found', 404);
-        }
+            const localCalendar =
+                await CalendarRepository.findById(local_calendar_id);
+            if (!localCalendar) {
+                throw new AppError('Local calendar not found', 404);
+            }
 
-        if (remoteCalendar.user_id !== userId) {
-            throw new AppError('Unauthorized access to remote calendar', 403);
-        }
+            if (localCalendar.user_id !== userId) {
+                throw new AppError(
+                    'Unauthorized access to local calendar',
+                    403
+                );
+            }
 
-        const json = remoteCalendar.toJSON();
-        delete json.password_encrypted;
+            const existing =
+                await RemoteCalendarRepository.findByLocalCalendarId(
+                    local_calendar_id
+                );
+            if (existing) {
+                throw new AppError(
+                    'Remote calendar already configured for this local calendar',
+                    409
+                );
+            }
 
-        res.json(json);
-    }
-
-    async createRemoteCalendar(req, res) {
-        const userId = req.currentUser.id;
-        const {
-            local_calendar_id,
-            name,
-            server_url,
-            calendar_path,
-            username,
-            password,
-            auth_type = 'basic',
-            enabled = true,
-            sync_direction = 'bidirectional',
-        } = req.body;
-
-        if (
-            !local_calendar_id ||
-            !name ||
-            !server_url ||
-            !calendar_path ||
-            !username ||
-            !password
-        ) {
-            throw new AppError(
-                'Missing required fields: local_calendar_id, name, server_url, calendar_path, username, password',
-                400
-            );
-        }
-
-        const localCalendar =
-            await CalendarRepository.findById(local_calendar_id);
-        if (!localCalendar) {
-            throw new AppError('Local calendar not found', 404);
-        }
-
-        if (localCalendar.user_id !== userId) {
-            throw new AppError('Unauthorized access to local calendar', 403);
-        }
-
-        const existing =
-            await RemoteCalendarRepository.findByLocalCalendarId(
-                local_calendar_id
-            );
-        if (existing) {
-            throw new AppError(
-                'Remote calendar already configured for this local calendar',
-                409
-            );
-        }
-
-        const validAuthTypes = ['basic', 'bearer'];
-        if (!validAuthTypes.includes(auth_type)) {
-            throw new AppError(
-                `Invalid auth type. Must be one of: ${validAuthTypes.join(', ')}`,
-                400
-            );
-        }
-
-        const validDirections = ['bidirectional', 'pull', 'push'];
-        if (!validDirections.includes(sync_direction)) {
-            throw new AppError(
-                `Invalid sync direction. Must be one of: ${validDirections.join(', ')}`,
-                400
-            );
-        }
-
-        const baseUrl = server_url.replace(/\/$/, '');
-        const path = calendar_path.startsWith('/')
-            ? calendar_path
-            : `/${calendar_path}`;
-        const fullUrl = `${baseUrl}${path}`;
-
-        validateCalDAVUrl(fullUrl);
-
-        const passwordEncrypted = encryptionService.encrypt(password);
-
-        const remoteCalendar = await RemoteCalendarRepository.create({
-            user_id: userId,
-            local_calendar_id,
-            name,
-            server_url: baseUrl,
-            calendar_path: path,
-            username,
-            password_encrypted: passwordEncrypted,
-            auth_type,
-            enabled,
-            sync_direction,
-        });
-
-        const json = remoteCalendar.toJSON();
-        delete json.password_encrypted;
-
-        res.status(201).json(json);
-    }
-
-    async updateRemoteCalendar(req, res) {
-        const { id } = req.params;
-        const userId = req.currentUser.id;
-
-        const remoteCalendar = await RemoteCalendarRepository.findById(id);
-
-        if (!remoteCalendar) {
-            throw new AppError('Remote calendar not found', 404);
-        }
-
-        if (remoteCalendar.user_id !== userId) {
-            throw new AppError('Unauthorized access to remote calendar', 403);
-        }
-
-        const {
-            name,
-            server_url,
-            calendar_path,
-            username,
-            password,
-            auth_type,
-            enabled,
-            sync_direction,
-        } = req.body;
-
-        const updates = {};
-
-        if (name !== undefined) updates.name = name;
-
-        const newServerUrl =
-            server_url !== undefined ? server_url.replace(/\/$/, '') : null;
-        const newCalendarPath =
-            calendar_path !== undefined
-                ? calendar_path.startsWith('/')
-                    ? calendar_path
-                    : `/${calendar_path}`
-                : null;
-
-        if (newServerUrl || newCalendarPath) {
-            const finalServerUrl = newServerUrl || remoteCalendar.server_url;
-            const finalCalendarPath =
-                newCalendarPath || remoteCalendar.calendar_path;
-            const fullUrl = `${finalServerUrl}${finalCalendarPath}`;
-
-            validateCalDAVUrl(fullUrl);
-
-            if (newServerUrl) updates.server_url = newServerUrl;
-            if (newCalendarPath) updates.calendar_path = newCalendarPath;
-        }
-
-        if (username !== undefined) updates.username = username;
-        if (password !== undefined) {
-            updates.password_encrypted = encryptionService.encrypt(password);
-        }
-        if (auth_type !== undefined) {
             const validAuthTypes = ['basic', 'bearer'];
             if (!validAuthTypes.includes(auth_type)) {
                 throw new AppError(
@@ -260,10 +175,7 @@ class RemoteCalendarController {
                     400
                 );
             }
-            updates.auth_type = auth_type;
-        }
-        if (enabled !== undefined) updates.enabled = enabled;
-        if (sync_direction !== undefined) {
+
             const validDirections = ['bidirectional', 'pull', 'push'];
             if (!validDirections.includes(sync_direction)) {
                 throw new AppError(
@@ -271,52 +183,174 @@ class RemoteCalendarController {
                     400
                 );
             }
-            updates.sync_direction = sync_direction;
+
+            const baseUrl = server_url.replace(/\/$/, '');
+            const path = calendar_path.startsWith('/')
+                ? calendar_path
+                : `/${calendar_path}`;
+            const fullUrl = `${baseUrl}${path}`;
+
+            validateCalDAVUrl(fullUrl);
+
+            const passwordEncrypted = encryptionService.encrypt(password);
+
+            const remoteCalendar = await RemoteCalendarRepository.create({
+                user_id: userId,
+                local_calendar_id,
+                name,
+                server_url: baseUrl,
+                calendar_path: path,
+                username,
+                password_encrypted: passwordEncrypted,
+                auth_type,
+                enabled,
+                sync_direction,
+            });
+
+            const json = remoteCalendar.toJSON();
+            delete json.password_encrypted;
+
+            res.status(201).json(json);
+        } catch (error) {
+            next(error);
         }
-
-        const updatedRemoteCalendar = await RemoteCalendarRepository.update(
-            remoteCalendar,
-            updates
-        );
-
-        const json = updatedRemoteCalendar.toJSON();
-        delete json.password_encrypted;
-
-        res.json(json);
     }
 
-    async deleteRemoteCalendar(req, res) {
-        const { id } = req.params;
-        const userId = req.currentUser.id;
-
-        const remoteCalendar = await RemoteCalendarRepository.findById(id);
-
-        if (!remoteCalendar) {
-            throw new AppError('Remote calendar not found', 404);
-        }
-
-        if (remoteCalendar.user_id !== userId) {
-            throw new AppError('Unauthorized access to remote calendar', 403);
-        }
-
-        await RemoteCalendarRepository.delete(remoteCalendar);
-
-        res.status(204).send();
-    }
-
-    async testConnection(req, res) {
-        const userId = req.currentUser.id;
-        const { server_url, calendar_path, username, password, auth_type } =
-            req.body;
-
-        if (!server_url || !calendar_path || !username || !password) {
-            throw new AppError(
-                'Missing required fields: server_url, calendar_path, username, password',
-                400
-            );
-        }
-
+    async updateRemoteCalendar(req, res, next) {
         try {
+            const { id } = req.params;
+            const userId = req.currentUser.id;
+
+            const remoteCalendar = await RemoteCalendarRepository.findById(id);
+
+            if (!remoteCalendar) {
+                throw new AppError('Remote calendar not found', 404);
+            }
+
+            if (remoteCalendar.user_id !== userId) {
+                throw new AppError(
+                    'Unauthorized access to remote calendar',
+                    403
+                );
+            }
+
+            const {
+                name,
+                server_url,
+                calendar_path,
+                username,
+                password,
+                auth_type,
+                enabled,
+                sync_direction,
+            } = req.body;
+
+            const updates = {};
+
+            if (name !== undefined) updates.name = name;
+
+            const newServerUrl =
+                server_url !== undefined ? server_url.replace(/\/$/, '') : null;
+            const newCalendarPath =
+                calendar_path !== undefined
+                    ? calendar_path.startsWith('/')
+                        ? calendar_path
+                        : `/${calendar_path}`
+                    : null;
+
+            if (newServerUrl || newCalendarPath) {
+                const finalServerUrl =
+                    newServerUrl || remoteCalendar.server_url;
+                const finalCalendarPath =
+                    newCalendarPath || remoteCalendar.calendar_path;
+                const fullUrl = `${finalServerUrl}${finalCalendarPath}`;
+
+                validateCalDAVUrl(fullUrl);
+
+                if (newServerUrl) updates.server_url = newServerUrl;
+                if (newCalendarPath) updates.calendar_path = newCalendarPath;
+            }
+
+            if (username !== undefined) updates.username = username;
+            if (password !== undefined) {
+                updates.password_encrypted =
+                    encryptionService.encrypt(password);
+            }
+            if (auth_type !== undefined) {
+                const validAuthTypes = ['basic', 'bearer'];
+                if (!validAuthTypes.includes(auth_type)) {
+                    throw new AppError(
+                        `Invalid auth type. Must be one of: ${validAuthTypes.join(', ')}`,
+                        400
+                    );
+                }
+                updates.auth_type = auth_type;
+            }
+            if (enabled !== undefined) updates.enabled = enabled;
+            if (sync_direction !== undefined) {
+                const validDirections = ['bidirectional', 'pull', 'push'];
+                if (!validDirections.includes(sync_direction)) {
+                    throw new AppError(
+                        `Invalid sync direction. Must be one of: ${validDirections.join(', ')}`,
+                        400
+                    );
+                }
+                updates.sync_direction = sync_direction;
+            }
+
+            const updatedRemoteCalendar = await RemoteCalendarRepository.update(
+                remoteCalendar,
+                updates
+            );
+
+            const json = updatedRemoteCalendar.toJSON();
+            delete json.password_encrypted;
+
+            res.json(json);
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async deleteRemoteCalendar(req, res, next) {
+        try {
+            const { id } = req.params;
+            const userId = req.currentUser.id;
+
+            const remoteCalendar = await RemoteCalendarRepository.findById(id);
+
+            if (!remoteCalendar) {
+                throw new AppError('Remote calendar not found', 404);
+            }
+
+            if (remoteCalendar.user_id !== userId) {
+                throw new AppError(
+                    'Unauthorized access to remote calendar',
+                    403
+                );
+            }
+
+            await RemoteCalendarRepository.delete(remoteCalendar);
+
+            res.status(204).send();
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async testConnection(req, res, next) {
+        try {
+            const userId = req.currentUser.id;
+            const { server_url, calendar_path, username, password, auth_type } =
+                req.body;
+
+            if (!server_url || !calendar_path || !username || !password) {
+                throw new AppError(
+                    'Missing required fields: server_url, calendar_path, username, password',
+                    400
+                );
+            }
+
             const baseUrl = server_url.replace(/\/$/, '');
             const path = calendar_path.startsWith('/')
                 ? calendar_path
@@ -369,18 +403,22 @@ class RemoteCalendarController {
             });
         } catch (error) {
             if (error.response?.status === 401) {
-                throw new AppError('Authentication failed', 401);
+                return next(new AppError('Authentication failed', 401));
             }
 
             if (error.response?.status === 404) {
-                throw new AppError('Calendar path not found', 404);
+                return next(new AppError('Calendar path not found', 404));
             }
 
             if (error.code === 'ENOTFOUND' || error.code === 'ECONNREFUSED') {
-                throw new AppError('Unable to reach server', 503);
+                return next(new AppError('Unable to reach server', 503));
             }
 
-            throw new AppError(`Connection test failed: ${error.message}`, 500);
+            if (error instanceof AppError) {
+                return next(error);
+            }
+
+            next(new AppError(`Connection test failed: ${error.message}`, 500));
         }
     }
 }

--- a/backend/modules/caldav/api/sync-controller.js
+++ b/backend/modules/caldav/api/sync-controller.js
@@ -6,66 +6,114 @@ const CalendarRepository = require('../repositories/calendar-repository');
 const SyncStateRepository = require('../repositories/sync-state-repository');
 
 class SyncController {
-    async syncCalendar(req, res) {
-        const { id } = req.params;
-        const userId = req.currentUser.id;
-        const { direction = 'bidirectional', dryRun = false } = req.body;
+    async syncCalendar(req, res, next) {
+        try {
+            const { id } = req.params;
+            const userId = req.currentUser.id;
+            const { direction = 'bidirectional', dryRun = false } = req.body;
 
-        const calendar = await CalendarRepository.findById(id);
+            const calendar = await CalendarRepository.findById(id);
 
-        if (!calendar) {
-            throw new AppError('Calendar not found', 404);
+            if (!calendar) {
+                throw new AppError('Calendar not found', 404);
+            }
+
+            if (calendar.user_id !== userId) {
+                throw new AppError('Unauthorized access to calendar', 403);
+            }
+
+            const result = await syncEngine.syncCalendar(calendar.id, userId, {
+                direction,
+                dryRun,
+            });
+
+            res.json(result);
+        } catch (error) {
+            next(error);
         }
-
-        if (calendar.user_id !== userId) {
-            throw new AppError('Unauthorized access to calendar', 403);
-        }
-
-        const result = await syncEngine.syncCalendar(calendar.id, userId, {
-            direction,
-            dryRun,
-        });
-
-        res.json(result);
     }
 
-    async syncAllCalendars(req, res) {
-        const userId = req.currentUser.id;
-        const { force = false, dryRun = false } = req.body;
+    async syncAllCalendars(req, res, next) {
+        try {
+            const userId = req.currentUser.id;
+            const { force = false, dryRun = false } = req.body;
 
-        const result = await syncScheduler.syncUserCalendars(userId, {
-            force,
-            dryRun,
-        });
+            const result = await syncScheduler.syncUserCalendars(userId, {
+                force,
+                dryRun,
+            });
 
-        res.json(result);
+            res.json(result);
+        } catch (error) {
+            next(error);
+        }
     }
 
-    async getSyncStatus(req, res) {
-        const { id } = req.params;
-        const userId = req.currentUser.id;
+    async getSyncStatus(req, res, next) {
+        try {
+            const { id } = req.params;
+            const userId = req.currentUser.id;
 
-        const calendar = await CalendarRepository.findById(id);
+            const calendar = await CalendarRepository.findById(id);
 
-        if (!calendar) {
-            throw new AppError('Calendar not found', 404);
+            if (!calendar) {
+                throw new AppError('Calendar not found', 404);
+            }
+
+            if (calendar.user_id !== userId) {
+                throw new AppError('Unauthorized access to calendar', 403);
+            }
+
+            const status = await syncEngine.getSyncStatus(calendar.id, userId);
+
+            res.json(status);
+        } catch (error) {
+            next(error);
         }
-
-        if (calendar.user_id !== userId) {
-            throw new AppError('Unauthorized access to calendar', 403);
-        }
-
-        const status = await syncEngine.getSyncStatus(calendar.id, userId);
-
-        res.json(status);
     }
 
-    async listConflicts(req, res) {
-        const userId = req.currentUser.id;
-        const { calendarId } = req.query;
+    async listConflicts(req, res, next) {
+        try {
+            const userId = req.currentUser.id;
+            const { calendarId } = req.query;
 
-        let conflicts;
-        if (calendarId) {
+            let conflicts;
+            if (calendarId) {
+                const calendar = await CalendarRepository.findById(calendarId);
+
+                if (!calendar) {
+                    throw new AppError('Calendar not found', 404);
+                }
+
+                if (calendar.user_id !== userId) {
+                    throw new AppError('Unauthorized access to calendar', 403);
+                }
+
+                conflicts = await SyncStateRepository.findConflicts(calendarId);
+            } else {
+                conflicts =
+                    await SyncStateRepository.findConflictsByUser(userId);
+            }
+
+            res.json(conflicts);
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async getConflict(req, res, next) {
+        try {
+            const { taskId } = req.params;
+            const userId = req.currentUser.id;
+            const { calendarId } = req.query;
+
+            if (!calendarId) {
+                throw new AppError(
+                    'calendarId query parameter is required',
+                    400
+                );
+            }
+
             const calendar = await CalendarRepository.findById(calendarId);
 
             if (!calendar) {
@@ -76,94 +124,78 @@ class SyncController {
                 throw new AppError('Unauthorized access to calendar', 403);
             }
 
-            conflicts = await SyncStateRepository.findConflicts(calendarId);
-        } else {
-            conflicts = await SyncStateRepository.findConflictsByUser(userId);
-        }
-
-        res.json(conflicts);
-    }
-
-    async getConflict(req, res) {
-        const { taskId } = req.params;
-        const userId = req.currentUser.id;
-        const { calendarId } = req.query;
-
-        if (!calendarId) {
-            throw new AppError('calendarId query parameter is required', 400);
-        }
-
-        const calendar = await CalendarRepository.findById(calendarId);
-
-        if (!calendar) {
-            throw new AppError('Calendar not found', 404);
-        }
-
-        if (calendar.user_id !== userId) {
-            throw new AppError('Unauthorized access to calendar', 403);
-        }
-
-        const conflict = await SyncStateRepository.findByTaskAndCalendar(
-            taskId,
-            calendarId
-        );
-
-        if (!conflict || conflict.sync_status !== 'conflict') {
-            throw new AppError('No conflict found for this task', 404);
-        }
-
-        res.json(conflict);
-    }
-
-    async resolveConflict(req, res) {
-        const { taskId } = req.params;
-        const userId = req.currentUser.id;
-        const { calendarId, resolution } = req.body;
-
-        if (!calendarId) {
-            throw new AppError('calendarId is required', 400);
-        }
-
-        if (!resolution) {
-            throw new AppError('resolution is required', 400);
-        }
-
-        const validResolutions = ['local', 'remote'];
-        if (!validResolutions.includes(resolution)) {
-            throw new AppError(
-                `Invalid resolution. Must be one of: ${validResolutions.join(', ')}`,
-                400
+            const conflict = await SyncStateRepository.findByTaskAndCalendar(
+                taskId,
+                calendarId
             );
+
+            if (!conflict || conflict.sync_status !== 'conflict') {
+                throw new AppError('No conflict found for this task', 404);
+            }
+
+            res.json(conflict);
+        } catch (error) {
+            next(error);
         }
-
-        const calendar = await CalendarRepository.findById(calendarId);
-
-        if (!calendar) {
-            throw new AppError('Calendar not found', 404);
-        }
-
-        if (calendar.user_id !== userId) {
-            throw new AppError('Unauthorized access to calendar', 403);
-        }
-
-        const mergePhase = new MergePhase();
-        const resolvedTask = await mergePhase.resolveConflict(
-            taskId,
-            calendarId,
-            resolution
-        );
-
-        res.json({
-            success: true,
-            task: resolvedTask,
-            resolution,
-        });
     }
 
-    async getSchedulerStatus(req, res) {
-        const status = syncScheduler.getStatus();
+    async resolveConflict(req, res, next) {
+        try {
+            const { taskId } = req.params;
+            const userId = req.currentUser.id;
+            const { calendarId, resolution } = req.body;
 
-        res.json(status);
+            if (!calendarId) {
+                throw new AppError('calendarId is required', 400);
+            }
+
+            if (!resolution) {
+                throw new AppError('resolution is required', 400);
+            }
+
+            const validResolutions = ['local', 'remote'];
+            if (!validResolutions.includes(resolution)) {
+                throw new AppError(
+                    `Invalid resolution. Must be one of: ${validResolutions.join(', ')}`,
+                    400
+                );
+            }
+
+            const calendar = await CalendarRepository.findById(calendarId);
+
+            if (!calendar) {
+                throw new AppError('Calendar not found', 404);
+            }
+
+            if (calendar.user_id !== userId) {
+                throw new AppError('Unauthorized access to calendar', 403);
+            }
+
+            const mergePhase = new MergePhase();
+            const resolvedTask = await mergePhase.resolveConflict(
+                taskId,
+                calendarId,
+                resolution
+            );
+
+            res.json({
+                success: true,
+                task: resolvedTask,
+                resolution,
+            });
+        } catch (error) {
+            next(error);
+        }
+    }
+
+    async getSchedulerStatus(req, res, next) {
+        try {
+            const status = syncScheduler.getStatus();
+
+            res.json(status);
+        } catch (error) {
+            next(error);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Added try-catch blocks to all async route handlers in CalDAV API controllers
- Ensures errors are properly caught and passed to Express error middleware
- Fixes JSON parsing errors during CalDAV calendar creation

## Problem
When creating a CalDAV calendar connection, users encountered the error:
```
Unexpected token '<', "<!DOCTYPE "... is not valid JSON
```

This occurred because async route handlers in the CalDAV controllers were throwing `AppError` exceptions without try-catch blocks. Without proper error handling, Express couldn't catch these errors and they weren't passed to the error middleware, resulting in HTML error pages instead of JSON responses.

## Solution
Added try-catch blocks with `next(error)` calls to all async route handlers in:
- `calendar-controller.js` (5 handlers)
- `remote-calendar-controller.js` (6 handlers)
- `sync-controller.js` (7 handlers)

Now all errors are properly:
1. Caught by the try-catch block
2. Passed to Express error middleware via `next(error)`
3. Serialized as JSON with appropriate HTTP status codes
4. Returned to the frontend as expected

## Testing
- Ran `npm run lint` successfully
- All CalDAV API routes now follow the same error handling pattern as other modules (e.g., tasks)

Fixes #1121

🤖 Generated with [Claude Code](https://claude.com/claude-code)