### PR TITLE
fix(project): Add CSRF token to task status update in ProjectDetails

### DIFF
--- a/frontend/components/Project/ProjectDetails.tsx
+++ b/frontend/components/Project/ProjectDetails.tsx
@@ -37,6 +37,7 @@ import IconSortDropdown from '../Shared/IconSortDropdown';
 import LoadingSpinner from '../Shared/LoadingSpinner';
 import { usePersistedModal } from '../../hooks/usePersistedModal';
 import { getApiPath } from '../../config/paths';
+import { getCsrfToken } from '../../utils/csrfService';
 import ProjectInsightsPanel from './ProjectInsightsPanel';
 import ProjectBanner from './ProjectBanner';
 import BannerEditModal from './BannerEditModal';
@@ -323,7 +324,10 @@ const ProjectDetails: React.FC = () => {
         }
         const response = await fetch(getApiPath(`task/${updatedTask.uid}`), {
             method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
+            headers: {
+                'Content-Type': 'application/json',
+                'x-csrf-token': await getCsrfToken(),
+            },
             credentials: 'include',
             body: JSON.stringify(updatedTask),
         });


### PR DESCRIPTION
## Summary
Fixes #1134 - Adds missing CSRF token to task status update requests in ProjectDetails component.

## Problem
When updating a task's status from the project page (e.g., changing status via the status dropdown), the PATCH request to `/api/task/<task_id>` was failing with a "CSRF token missing" error (HTTP 500).

## Root Cause
The `handleTaskUpdate` function in [ProjectDetails.tsx:324-329](frontend/components/Project/ProjectDetails.tsx#L324-L329) was making a direct fetch call with headers that only included `Content-Type`, but not the `x-csrf-token` header required by the backend's CSRF middleware.

## Solution
- Added import for `getCsrfToken` from `csrfService.ts`
- Updated the fetch headers to include `x-csrf-token: await getCsrfToken()`
- This matches the pattern already used in other components like `ViewDetail.tsx` and `Tasks.tsx`

## Testing
- Linter passes with no errors
- Fix aligns with existing CSRF token handling patterns in the codebase

## Changes
- Modified: `frontend/components/Project/ProjectDetails.tsx`
  - Added `getCsrfToken` import
  - Updated `handleTaskUpdate` to include CSRF token in request headers