### PR TITLE
fix(caldav): Validate Bearer tokens in CalDAV auth middleware

### DIFF
--- a/backend/modules/caldav/middleware/caldav-auth.js
+++ b/backend/modules/caldav/middleware/caldav-auth.js
@@ -1,23 +1,31 @@
 const bcrypt = require('bcrypt');
 const { User } = require('../../../models');
+const { findValidTokenByValue } = require('../../users/apiTokenService');
 
 async function caldavAuth(req, res, next) {
     try {
-        if (
-            req.session?.userId ||
-            req.headers.authorization?.startsWith('Bearer ')
-        ) {
-            if (req.session?.userId) {
-                const user = await User.findByPk(req.session.userId);
+        if (req.session?.userId) {
+            const user = await User.findByPk(req.session.userId);
+            if (user) {
+                req.currentUser = user;
+                return next();
+            }
+        }
+
+        if (req.headers.authorization?.startsWith('Bearer ')) {
+            const tokenValue = req.headers.authorization.slice(7);
+            const tokenRecord = await findValidTokenByValue(tokenValue);
+            if (tokenRecord) {
+                const user = await User.findByPk(tokenRecord.user_id);
                 if (user) {
                     req.currentUser = user;
                     return next();
                 }
             }
-
-            if (req.headers.authorization?.startsWith('Bearer ')) {
-                return next();
-            }
+            return res
+                .status(401)
+                .set('WWW-Authenticate', 'Basic realm="Tududi CalDAV"')
+                .json({ error: 'Invalid or expired token' });
         }
 
         const authHeader = req.headers.authorization;


### PR DESCRIPTION
## Description

Fixes a security vulnerability where the CalDAV authentication middleware accepted any `Authorization: Bearer <anything>` header without validation, bypassing authentication entirely and leaving `req.currentUser` undefined.

The root cause was a branch that called `next()` unconditionally for any Bearer token:
```js
if (req.headers.authorization?.startsWith('Bearer ')) {
    return next(); // ← no token validation at all
}
```

The fix validates Bearer tokens using the existing `apiTokenService.findValidTokenByValue()` function, loads the owning user, sets `req.currentUser`, and returns 401 for invalid/expired/unknown tokens.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1138

## Testing

- All 1528 existing tests pass (`npm test`)
- Auth flow tested manually: valid API token authenticates and sets `req.currentUser`; invalid/arbitrary Bearer strings now receive `401 Invalid or expired token`

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have tested my changes
- [x] All existing tests pass

## Additional Notes

The fix reuses the existing `findValidTokenByValue()` from `apiTokenService`, which handles prefix lookup, bcrypt comparison, revocation checks, and expiry checks. No new models or token types were needed.