### PR TITLE
fix(caldav): serialize DUE and DTSTART as VALUE=DATE to prevent iOS midnight reminders

### DIFF
--- a/backend/modules/caldav/icalendar/vtodo-serializer.js
+++ b/backend/modules/caldav/icalendar/vtodo-serializer.js
@@ -27,8 +27,14 @@ function serializeTaskToVTODO(task, options = {}) {
 
     if (task.due_date) {
         try {
-            const dueTime = ICAL.Time.fromJSDate(new Date(task.due_date), true);
-            vtodo.addPropertyWithValue('due', dueTime);
+            const d = new Date(task.due_date);
+            const dueDate = new ICAL.Time({
+                year: d.getUTCFullYear(),
+                month: d.getUTCMonth() + 1,
+                day: d.getUTCDate(),
+                isDate: true,
+            });
+            vtodo.addPropertyWithValue('due', dueDate);
         } catch (error) {
             console.error('Error formatting due date:', error);
         }
@@ -36,11 +42,14 @@ function serializeTaskToVTODO(task, options = {}) {
 
     if (task.defer_until) {
         try {
-            const startTime = ICAL.Time.fromJSDate(
-                new Date(task.defer_until),
-                true
-            );
-            vtodo.addPropertyWithValue('dtstart', startTime);
+            const d = new Date(task.defer_until);
+            const startDate = new ICAL.Time({
+                year: d.getUTCFullYear(),
+                month: d.getUTCMonth() + 1,
+                day: d.getUTCDate(),
+                isDate: true,
+            });
+            vtodo.addPropertyWithValue('dtstart', startDate);
         } catch (error) {
             console.error('Error formatting defer_until date:', error);
         }

--- a/backend/tests/integration/caldav-timezones.test.js
+++ b/backend/tests/integration/caldav-timezones.test.js
@@ -3,8 +3,8 @@ const vTodoSerializer = require('../../modules/caldav/icalendar/vtodo-serializer
 const vTodoParser = require('../../modules/caldav/icalendar/vtodo-parser');
 
 describe('CalDAV Timezone Handling', () => {
-    describe('UTC DateTime Conversion', () => {
-        it('should correctly convert local dates to UTC', async () => {
+    describe('DATE-only Serialization', () => {
+        it('should serialize due_date and defer_until as VALUE=DATE (no time)', async () => {
             const task = {
                 uid: 'tz-test-1',
                 name: 'Timezone Test',
@@ -19,10 +19,12 @@ describe('CalDAV Timezone Handling', () => {
             const vtodoComp = comp.getFirstSubcomponent('vtodo');
 
             const due = vtodoComp.getFirstPropertyValue('due');
-            expect(due.toICALString()).toBe('20260420T140000Z');
+            expect(due.isDate).toBe(true);
+            expect(due.toICALString()).toBe('20260420');
 
             const dtstart = vtodoComp.getFirstPropertyValue('dtstart');
-            expect(dtstart.toICALString()).toBe('20260420T100000Z');
+            expect(dtstart.isDate).toBe(true);
+            expect(dtstart.toICALString()).toBe('20260420');
         });
 
         it('should parse UTC dates from VTODO', async () => {
@@ -152,7 +154,8 @@ END:VCALENDAR`;
             const vtodoComp = comp.getFirstSubcomponent('vtodo');
 
             const due = vtodoComp.getFirstPropertyValue('due');
-            expect(due.toICALString()).toBe('20260420T140000Z');
+            expect(due.isDate).toBe(true);
+            expect(due.toICALString()).toBe('20260420');
 
             const rrule = vtodoComp.getFirstPropertyValue('rrule');
             expect(rrule.freq).toBe('DAILY');
@@ -289,7 +292,7 @@ END:VCALENDAR`;
             }).not.toThrow();
         });
 
-        it('should round-trip preserve UTC timestamps', async () => {
+        it('should round-trip preserve the calendar date (date-only, no time)', async () => {
             const originalTask = {
                 uid: 'roundtrip-tz-test',
                 name: 'Roundtrip Timezone Test',
@@ -300,9 +303,11 @@ END:VCALENDAR`;
             const vtodo = vTodoSerializer.serializeTaskToVTODO(originalTask);
             const parsedTask = await vTodoParser.parseVTODOToTask(vtodo);
 
-            expect(new Date(parsedTask.due_date).getTime()).toBe(
-                new Date(originalTask.due_date).getTime()
-            );
+            // Only the calendar date is preserved (VALUE=DATE, no time component)
+            const dueDate = new Date(parsedTask.due_date);
+            expect(dueDate.getUTCFullYear()).toBe(2026);
+            expect(dueDate.getUTCMonth()).toBe(3); // April
+            expect(dueDate.getUTCDate()).toBe(20);
         });
 
         it('should handle leap year dates correctly', async () => {

--- a/backend/tests/unit/modules/caldav/icalendar/round-trip.test.js
+++ b/backend/tests/unit/modules/caldav/icalendar/round-trip.test.js
@@ -27,12 +27,13 @@ describe('CalDAV Round-Trip Conversion', () => {
         expect(parsedTask.status).toBe(originalTask.status);
         expect(parsedTask.priority).toBe(originalTask.priority);
         expect(parsedTask.note).toBe(originalTask.note);
-        expect(parsedTask.due_date.getTime()).toBe(
-            originalTask.due_date.getTime()
-        );
-        expect(parsedTask.defer_until.getTime()).toBe(
-            originalTask.defer_until.getTime()
-        );
+        // due_date and defer_until are date-only — only the calendar date is preserved
+        expect(parsedTask.due_date.getUTCFullYear()).toBe(2026);
+        expect(parsedTask.due_date.getUTCMonth()).toBe(5); // June
+        expect(parsedTask.due_date.getUTCDate()).toBe(1);
+        expect(parsedTask.defer_until.getUTCFullYear()).toBe(2026);
+        expect(parsedTask.defer_until.getUTCMonth()).toBe(4); // May
+        expect(parsedTask.defer_until.getUTCDate()).toBe(25);
     });
 
     it('should preserve completed task data', async () => {

--- a/backend/tests/unit/modules/caldav/icalendar/vtodo-serializer.test.js
+++ b/backend/tests/unit/modules/caldav/icalendar/vtodo-serializer.test.js
@@ -75,18 +75,20 @@ describe('VTODO Serializer', () => {
         expect(vtodoString).toContain('DESCRIPTION:Test note');
     });
 
-    it('should include DUE date', async () => {
+    it('should include DUE date as VALUE=DATE (no time, no UTC shift)', async () => {
         const vtodoString = await serializeTaskToVTODO(basicTask);
-        expect(vtodoString).toContain('DUE:20260501T120000Z');
+        expect(vtodoString).toContain('DUE;VALUE=DATE:20260501');
+        expect(vtodoString).not.toContain('DUE:20260501T');
     });
 
-    it('should include DTSTART for defer_until', async () => {
+    it('should include DTSTART for defer_until as VALUE=DATE', async () => {
         const task = {
             ...basicTask,
             defer_until: new Date('2026-04-25T09:00:00Z'),
         };
         const vtodoString = await serializeTaskToVTODO(task);
-        expect(vtodoString).toContain('DTSTART:20260425T090000Z');
+        expect(vtodoString).toContain('DTSTART;VALUE=DATE:20260425');
+        expect(vtodoString).not.toContain('DTSTART:20260425T');
     });
 
     it('should include COMPLETED date for completed tasks', async () => {


### PR DESCRIPTION
## Description

Tasks in Tududi have date-only due dates — no time component. The VTODO serializer was emitting `DUE` and `DTSTART` as UTC datetimes (e.g. `DUE:20260527T235900Z`), which caused two problems on iOS:

1. iOS scheduled a timed reminder at 23:59 UTC instead of treating the task as all-day
2. For users in positive UTC offset timezones (e.g. Europe/Berlin at UTC+2), the UTC→local conversion shifted the reminder into the early morning of the *next* day

This PR fixes the serializer to emit `DUE;VALUE=DATE:20260527` (pure date, no time, no UTC). iOS then places the task in the all-day section of Calendar with no spurious timed alert.

The parser already handled `VALUE=DATE` correctly via the `due.isDate` branch, so the round-trip is consistent with no further changes needed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1146

## Testing

- Updated unit tests for `vtodo-serializer` to assert `DUE;VALUE=DATE:YYYYMMDD` format and that no datetime form appears
- Updated `round-trip` test to verify date components (year/month/day) are preserved rather than exact timestamps, since the time component is intentionally dropped
- Updated `caldav-timezones` integration tests to reflect `isDate=true` and date-only ICAL strings
- All 40 affected tests pass: `npm run backend:test -- --testPathPattern="vtodo-serializer|round-trip|caldav-timezones"`
- Linting passes: `npm run lint`

## Checklist

- [x] My code follows the existing code style
- [x] I have updated tests to cover the fix
- [x] All existing tests pass
- [x] No new warnings or errors introduced