### PR TITLE
fix(caldav): exclude CalDAV routes from compression middleware

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -62,7 +62,19 @@ app.use(
                 : false,
     })
 );
-app.use(compression());
+app.use(
+    compression({
+        filter: (req, res) => {
+            if (
+                req.path.startsWith('/caldav/') ||
+                req.path.startsWith('/.well-known/caldav')
+            ) {
+                return false;
+            }
+            return compression.filter(req, res);
+        },
+    })
+);
 app.use(morgan('combined'));
 
 // CORS configuration


### PR DESCRIPTION
## Description

iOS CalDAV clients advertise `accept-encoding: gzip, deflate, br` but cannot reliably decompress Brotli-encoded CalDAV XML responses. The Express `compression()` middleware was applying Brotli to all routes including `/caldav/*`, causing iOS to discard the response and report an SSL/connection failure.

The fix adds a custom `filter` function to `compression()` that skips compression for `/caldav/` and `/.well-known/caldav` paths, while leaving the rest of the app compressed as before.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1144

## Testing

- Start the backend and confirm CalDAV endpoints (`/caldav/`, `/.well-known/caldav`) return uncompressed XML (no `Content-Encoding` header).
- Confirm regular app routes still receive compressed responses.
- Re-test iOS CalDAV onboarding.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `npm run lint` and all checks pass
- [x] I have tested this change manually

## Additional Notes

Root cause identified by reporter via tcpdump: responses were `Content-Encoding: br` with binary body instead of XML. Vikunja (the comparison Go server) worked because it does not compress CalDAV routes.