### PR TITLE
fix(caldav): use prefix-agnostic XML node lookup to support iOS clients

### DIFF
--- a/backend/modules/caldav/webdav/utils.js
+++ b/backend/modules/caldav/webdav/utils.js
@@ -110,11 +110,9 @@ function parseCalendarQuery(xmlString) {
                     return resolve(parsedQuery);
                 }
 
-                const query =
-                    result['C:calendar-query'] || result['calendar-query'];
-                const filter = query?.['C:filter'] || query?.filter;
-                const compFilter =
-                    filter?.['C:comp-filter'] || filter?.['comp-filter'];
+                const query = findResultNode(result, 'calendar-query');
+                const filter = findResultNode(query, 'filter');
+                const compFilter = findResultNode(filter, 'comp-filter');
 
                 const parsedQuery = {
                     isMultiget: false,
@@ -129,8 +127,7 @@ function parseCalendarQuery(xmlString) {
                 };
 
                 if (compFilter) {
-                    const timeRange =
-                        compFilter['C:time-range'] || compFilter['time-range'];
+                    const timeRange = findResultNode(compFilter, 'time-range');
                     if (timeRange) {
                         parsedQuery.filters.timeRange = {
                             start: extractValue(timeRange.start),
@@ -138,13 +135,15 @@ function parseCalendarQuery(xmlString) {
                         };
                     }
 
-                    const propFilter =
-                        compFilter['C:prop-filter'] ||
-                        compFilter['prop-filter'];
+                    const propFilter = findResultNode(
+                        compFilter,
+                        'prop-filter'
+                    );
                     if (propFilter) {
-                        const textMatch =
-                            propFilter['C:text-match'] ||
-                            propFilter['text-match'];
+                        const textMatch = findResultNode(
+                            propFilter,
+                            'text-match'
+                        );
                         if (textMatch) {
                             parsedQuery.filters.textMatch = {
                                 property: extractValue(propFilter.name),
@@ -160,7 +159,7 @@ function parseCalendarQuery(xmlString) {
                     }
                 }
 
-                const prop = query?.['D:prop'] || query?.prop;
+                const prop = findResultNode(query, 'prop');
                 if (prop) {
                     parsedQuery.props = Object.keys(prop).map((key) =>
                         key.replace(/^[^:]+:/, '')
@@ -183,17 +182,21 @@ function parsePropfind(xmlString) {
             }
 
             try {
-                const propfind = result['D:propfind'] || result.propfind;
+                const propfind = findResultNode(result, 'propfind');
 
-                if (propfind['D:allprop'] || propfind.allprop) {
+                if (!propfind) {
                     return resolve({ type: 'allprop' });
                 }
 
-                if (propfind['D:propname'] || propfind.propname) {
+                if (findResultNode(propfind, 'allprop')) {
+                    return resolve({ type: 'allprop' });
+                }
+
+                if (findResultNode(propfind, 'propname')) {
                     return resolve({ type: 'propname' });
                 }
 
-                const prop = propfind['D:prop'] || propfind.prop;
+                const prop = findResultNode(propfind, 'prop');
                 if (prop) {
                     const requestedProps = Object.keys(prop).map((key) => {
                         const [namespace, name] = key.split(':').reverse();


### PR DESCRIPTION
## Description

PROPFIND and calendar-query REPORT parsers in `backend/modules/caldav/webdav/utils.js` were crashing when iOS clients sent CalDAV requests because the XML namespace prefix was different from the hardcoded `D:`/`C:` prefix the parser expected.

XML namespace prefixes are arbitrary — only the URI (e.g. `DAV:`) is significant. iOS uses a different prefix, so `xml2js` produced keys like `A:propfind` instead of `D:propfind`, causing `result['D:propfind'] || result.propfind` to return `undefined` and the subsequent property access to throw a `TypeError` → HTTP 400.

The fix replaces all direct prefix-based key lookups in both `parsePropfind()` and `parseCalendarQuery()` with the already-existing `findResultNode()` helper, which searches by local name regardless of what prefix the client used. A defensive null guard was also added to `parsePropfind()` so malformed/empty bodies fall back to `allprop` instead of crashing.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1135

## Testing

- All 1528 existing tests pass (`npm test`)
- Lint clean (`npm run lint`)

The existing `findResultNode()` helper (already used in the multiget branch of `parseCalendarQuery`) was the correct pattern — it was just inconsistently applied.

## Checklist

- [x] My code follows the project's coding style
- [x] I have run the linter and fixed any issues
- [x] Tests pass locally
- [x] This PR does not introduce new dependencies

## Additional Notes

The response **builder** is a separate `xml2js.Builder` instance and is unaffected — it still emits `D:`/`C:` prefixed XML, which is valid CalDAV.