### PR TITLE
fix(caldav): make iOS autodiscovery RFC-compliant end-to-end

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -67,7 +67,9 @@ app.use(
         filter: (req, res) => {
             if (
                 req.path.startsWith('/caldav/') ||
-                req.path.startsWith('/.well-known/caldav')
+                req.path.startsWith('/.well-known/caldav') ||
+                (req.method === 'PROPFIND' &&
+                    (req.path === '/' || req.path === '/principals/'))
             ) {
                 return false;
             }

--- a/backend/modules/caldav/routes.js
+++ b/backend/modules/caldav/routes.js
@@ -19,8 +19,33 @@ const { requireAuth } = require('../../middleware/auth');
 
 const router = express.Router();
 
-router.get('/.well-known/caldav', handleWellKnown);
+// GET redirects to /caldav/ per RFC 6764; PROPFIND returns root discovery for iOS accountsd
+router.all('/.well-known/caldav', (req, res, next) => {
+    if (req.method === 'GET') return handleWellKnown(req, res, next);
+    if (req.method !== 'PROPFIND') return next();
+    xmlParser(req, res, () =>
+        caldavAuth(req, res, () => handleRootPropfind(req, res, next))
+    );
+});
 
+// iOS accountsd probes PROPFIND / and PROPFIND /principals/ during account setup and refresh.
+// Gate on PROPFIND only — running caldavAuth on GET / would send WWW-Authenticate: Basic
+// and replace the web app login page with a browser Basic-Auth prompt.
+router.all('/', (req, res, next) => {
+    if (req.method !== 'PROPFIND') return next();
+    xmlParser(req, res, () =>
+        caldavAuth(req, res, () => handleRootPropfind(req, res, next))
+    );
+});
+
+router.all('/principals/', (req, res, next) => {
+    if (req.method !== 'PROPFIND') return next();
+    xmlParser(req, res, () =>
+        caldavAuth(req, res, () => handleRootPropfind(req, res, next))
+    );
+});
+
+router.options('/caldav/:username/', xmlParser, caldavAuth, handleOptions);
 router.options(
     '/caldav/:username/tasks/',
     xmlParser,

--- a/backend/modules/caldav/webdav/propfind.js
+++ b/backend/modules/caldav/webdav/propfind.js
@@ -101,6 +101,12 @@ async function buildCalendarResponse(username, userId, propfindRequest) {
         },
         'D:getcontenttype': 'text/calendar; charset=utf-8',
         'C:getctag': ctag,
+        'D:current-user-principal': {
+            'D:href': `/caldav/${encodeURIComponent(username)}/`,
+        },
+        'D:principal-URL': {
+            'D:href': `/caldav/${encodeURIComponent(username)}/`,
+        },
         'D:current-user-privilege-set': {
             'D:privilege': [
                 { 'D:read': '' },


### PR DESCRIPTION
## Description

Fixes iOS CalDAV autodiscovery spinning forever at \"Verifying\" when entering only the host URL. Based on tcpdump analysis of iOS `accountsd` behaviour (from issue comments), three concrete gaps were found and fixed.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1136

## Root Cause & Changes

**1. Collection PROPFIND missing `current-user-principal`** ([propfind.js](backend/modules/caldav/webdav/propfind.js))

`buildCalendarResponse()` didn't include `current-user-principal` or `principal-URL`. iOS's first PROPFIND on `/caldav/<user>/tasks/` requests `<current-user-principal/>` to anchor discovery — without it, accountsd retries 3× then aborts. Both properties now point to `/caldav/<user>/`.

**2. No OPTIONS route on the principal path** ([routes.js](backend/modules/caldav/routes.js))

After following the principal link, iOS sends `OPTIONS /caldav/<user>/` and expects WebDAV capability headers (`DAV:`, `Allow: PROPFIND …`). Only `/caldav/:username/tasks/` had an OPTIONS route, so the principal path fell through to Express's default `Allow: GET,HEAD` and iOS reset the connection. Added `router.options('/caldav/:username/', …)`.

**3. PROPFIND on root discovery paths returned 404** ([routes.js](backend/modules/caldav/routes.js), [app.js](backend/app.js))

iOS `accountsd` probes `PROPFIND /`, `PROPFIND /principals/`, and `PROPFIND /.well-known/caldav` during both initial setup and account refresh. All were 404. Now routed to `handleRootPropfind`.

Critically, the handlers are **method-gated** (`if (req.method !== 'PROPFIND') return next()`): running `caldavAuth` on `GET /` would send `WWW-Authenticate: Basic` over the whole web app and replace the login page with a browser Basic-Auth prompt. The `/.well-known/caldav` `GET` redirect is preserved alongside the new `PROPFIND` handler. Response compression is also excluded for these paths, consistent with the existing CalDAV path exclusion.

## Testing

- All 163 CalDAV tests pass (`npx jest --config backend/jest.config.js --testPathPattern="caldav"`)
- Full lint passes (`npm run lint`)
- Manual verification: `GET /.well-known/caldav` still redirects to `/caldav/` (web app unaffected); `GET /` still serves the React app

## Checklist

- [x] Code follows the existing conventions
- [x] Self-reviewed the changes
- [x] Tests pass locally
- [x] No new JSDoc comments added
- [x] Lint passes