### PR TITLE
fix(oidc): make OIDC_ENABLED check case-insensitive

### DIFF
--- a/backend/middleware/auth.js
+++ b/backend/middleware/auth.js
@@ -14,7 +14,7 @@ const getBearerToken = (req) => {
 // Sends a 401 and, when OIDC is enabled, sets WWW-Authenticate so OAuth2 clients
 // can discover the authorization server (RFC 9728).
 const unauthorized = (res, message) => {
-    if (process.env.OIDC_ENABLED === 'true') {
+    if ((process.env.OIDC_ENABLED || '').toLowerCase() === 'true') {
         const baseUrl = process.env.BASE_URL?.replace(/\/$/, ''); // trim trailing slash
         if (baseUrl) {
             res.set(
@@ -81,7 +81,7 @@ const requireAuth = async (req, res, next) => {
         }
 
         // OAuth2 JWT — validate via OIDC provider JWKS
-        if (process.env.OIDC_ENABLED === 'true') {
+        if ((process.env.OIDC_ENABLED || '').toLowerCase() === 'true') {
             let payload;
             try {
                 payload = await validateAccessToken(bearerToken);

--- a/backend/modules/oauth/protectedResource.js
+++ b/backend/modules/oauth/protectedResource.js
@@ -8,7 +8,10 @@
  */
 function handleProtectedResource(req, res) {
     const issuerUrl = process.env.OIDC_ISSUER_URL?.replace(/\/$/, ''); // trim trailing slash
-    if (!issuerUrl || process.env.OIDC_ENABLED !== 'true') {
+    if (
+        !issuerUrl ||
+        (process.env.OIDC_ENABLED || '').toLowerCase() !== 'true'
+    ) {
         return res.status(404).end();
     }
 

--- a/backend/modules/oidc/providerConfig.js
+++ b/backend/modules/oidc/providerConfig.js
@@ -6,6 +6,10 @@ function parseCommaSeparated(value) {
         .filter(Boolean);
 }
 
+function isEnvTrue(value) {
+    return (value || '').toLowerCase() === 'true';
+}
+
 function normalizeScope(scope) {
     if (!scope) return 'openid profile email';
 
@@ -22,7 +26,7 @@ function normalizeScope(scope) {
 }
 
 function loadProvidersFromEnv() {
-    if (process.env.OIDC_ENABLED !== 'true') {
+    if (!isEnvTrue(process.env.OIDC_ENABLED)) {
         console.log(
             'OIDC is disabled. Set OIDC_ENABLED=true to enable SSO authentication.'
         );
@@ -89,8 +93,8 @@ function loadProvidersFromEnv() {
         if (!provider.clientSecret) missingFields.push('OIDC_CLIENT_SECRET');
 
         if (missingFields.length > 0) {
-            console.error(
-                `Cannot load OIDC provider "${provider.name}": missing required fields: ${missingFields.join(', ')}`
+            console.log(
+                `[OIDC] Cannot load provider "${provider.name}": missing required fields: ${missingFields.join(', ')}`
             );
             return [];
         }
@@ -100,8 +104,8 @@ function loadProvidersFromEnv() {
     }
 
     if (providers.length === 0) {
-        console.warn(
-            'OIDC is enabled but no valid providers are configured. Please check your environment variables.'
+        console.log(
+            '[OIDC] Enabled but no valid providers configured. Check OIDC_PROVIDER_NAME, OIDC_ISSUER_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET.'
         );
     }
 
@@ -129,7 +133,7 @@ function getProvider(slug) {
 }
 
 function isOidcEnabled() {
-    return process.env.OIDC_ENABLED === 'true' && getAllProviders().length > 0;
+    return isEnvTrue(process.env.OIDC_ENABLED) && getAllProviders().length > 0;
 }
 
 function reloadProviders() {

--- a/backend/tests/unit/modules/oidc/providerConfig.test.js
+++ b/backend/tests/unit/modules/oidc/providerConfig.test.js
@@ -33,6 +33,46 @@ describe('OIDC Provider Configuration', () => {
         });
     });
 
+    describe('OIDC_ENABLED case-insensitivity', () => {
+        const validProvider = () => {
+            process.env.OIDC_PROVIDER_NAME = 'TestProvider';
+            process.env.OIDC_PROVIDER_SLUG = 'test';
+            process.env.OIDC_ISSUER_URL = 'https://idp.example.com';
+            process.env.OIDC_CLIENT_ID = 'client123';
+            process.env.OIDC_CLIENT_SECRET = 'secret123';
+        };
+
+        afterEach(() => {
+            delete process.env.OIDC_PROVIDER_NAME;
+            delete process.env.OIDC_PROVIDER_SLUG;
+            delete process.env.OIDC_ISSUER_URL;
+            delete process.env.OIDC_CLIENT_ID;
+            delete process.env.OIDC_CLIENT_SECRET;
+        });
+
+        it('should enable OIDC when OIDC_ENABLED is "True" (docker-compose v1 YAML boolean)', () => {
+            const consoleLogSpy = jest
+                .spyOn(console, 'log')
+                .mockImplementation();
+            validProvider();
+            process.env.OIDC_ENABLED = 'True';
+            providerConfig.reloadProviders();
+            expect(providerConfig.isOidcEnabled()).toBe(true);
+            consoleLogSpy.mockRestore();
+        });
+
+        it('should enable OIDC when OIDC_ENABLED is "TRUE"', () => {
+            const consoleLogSpy = jest
+                .spyOn(console, 'log')
+                .mockImplementation();
+            validProvider();
+            process.env.OIDC_ENABLED = 'TRUE';
+            providerConfig.reloadProviders();
+            expect(providerConfig.isOidcEnabled()).toBe(true);
+            consoleLogSpy.mockRestore();
+        });
+    });
+
     describe('single provider configuration', () => {
         it('should load single provider from .env', () => {
             process.env.OIDC_ENABLED = 'true';
@@ -174,8 +214,8 @@ describe('OIDC Provider Configuration', () => {
         });
 
         it('should return empty array if configuration is incomplete', () => {
-            const consoleErrorSpy = jest
-                .spyOn(console, 'error')
+            const consoleLogSpy = jest
+                .spyOn(console, 'log')
                 .mockImplementation();
 
             process.env.OIDC_ENABLED = 'true';
@@ -185,11 +225,11 @@ describe('OIDC Provider Configuration', () => {
             const providers = providerConfig.getAllProviders();
 
             expect(providers).toEqual([]);
-            expect(consoleErrorSpy).toHaveBeenCalledWith(
-                expect.stringContaining('Cannot load OIDC provider')
+            expect(consoleLogSpy).toHaveBeenCalledWith(
+                expect.stringContaining('Cannot load provider')
             );
 
-            consoleErrorSpy.mockRestore();
+            consoleLogSpy.mockRestore();
         });
     });
 
@@ -364,20 +404,20 @@ describe('OIDC Provider Configuration', () => {
         });
 
         it('should return false when no providers configured', () => {
-            const consoleWarnSpy = jest
-                .spyOn(console, 'warn')
+            const consoleLogSpy = jest
+                .spyOn(console, 'log')
                 .mockImplementation();
 
             process.env.OIDC_ENABLED = 'true';
             providerConfig.reloadProviders();
             expect(providerConfig.isOidcEnabled()).toBe(false);
-            expect(consoleWarnSpy).toHaveBeenCalledWith(
+            expect(consoleLogSpy).toHaveBeenCalledWith(
                 expect.stringContaining(
-                    'OIDC is enabled but no valid providers are configured'
+                    'Enabled but no valid providers configured'
                 )
             );
 
-            consoleWarnSpy.mockRestore();
+            consoleLogSpy.mockRestore();
         });
     });
 

--- a/frontend/components/Project/ProjectDetails.tsx
+++ b/frontend/components/Project/ProjectDetails.tsx
@@ -38,7 +38,6 @@ import IconSortDropdown from '../Shared/IconSortDropdown';
 import LoadingSpinner from '../Shared/LoadingSpinner';
 import { usePersistedModal } from '../../hooks/usePersistedModal';
 import { getApiPath } from '../../config/paths';
-import { getCsrfToken } from '../../utils/csrfService';
 import ProjectInsightsPanel from './ProjectInsightsPanel';
 import ProjectBanner from './ProjectBanner';
 import BannerEditModal from './BannerEditModal';


### PR DESCRIPTION
## Description

The OIDC login button does not appear for users who set `OIDC_ENABLED: true` (unquoted) in their Docker Compose file when using **docker-compose v1** (the legacy Python-based tool, still widely used).

**Root cause:** Docker Compose v1 uses PyYAML which converts unquoted YAML booleans to Python booleans (`True`/`False`), and then stringifies them as `"True"`/`"False"` (capital first letter) in container environment variables. The previous code checked `process.env.OIDC_ENABLED !== 'true'` with strict case-sensitive equality, so `"True"` would not match and OIDC would silently appear disabled — causing `GET /api/oidc/providers` to return an empty array and the login button never rendering.

Docker Compose v2 (Go-based) correctly stringifies booleans as lowercase `"true"`/`"false"`, so the issue only affected docker-compose v1 users.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #1161

## Changes

- Added `isEnvTrue()` helper in `providerConfig.js` that normalises the value with `.toLowerCase()` before comparing
- Applied the same case-insensitive check in `middleware/auth.js` and `modules/oauth/protectedResource.js` (all places where `OIDC_ENABLED` is read directly)
- Changed OIDC initialisation error/warn messages from `console.error`/`console.warn` to `console.log` so they always appear on Docker stdout (not hidden in stderr)
- Added regression tests for `"True"` and `"TRUE"` values of `OIDC_ENABLED`

## Testing

```bash
npm test -- --testPathPattern="providerConfig"
npm run lint
```

All tests pass. New tests explicitly cover docker-compose v1 behaviour.

## Checklist

- [x] Code follows project conventions
- [x] Tests added for the new behaviour
- [x] Linting passes
- [x] No breaking changes