### PR TITLE
fix(caldav): preserve VALARM on round-trip and fix defer_until UTC offset display

### DIFF
--- a/backend/migrations/20260602000001-add-reminder-at-to-tasks.js
+++ b/backend/migrations/20260602000001-add-reminder-at-to-tasks.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const tableDescription = await queryInterface.describeTable('tasks');
+        if (!tableDescription.reminder_at) {
+            await queryInterface.addColumn('tasks', 'reminder_at', {
+                type: Sequelize.DATE,
+                allowNull: true,
+                defaultValue: null,
+            });
+        }
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeColumn('tasks', 'reminder_at');
+    },
+};

--- a/backend/models/task.js
+++ b/backend/models/task.js
@@ -28,6 +28,10 @@ module.exports = (sequelize) => {
                 type: DataTypes.DATE,
                 allowNull: true,
             },
+            reminder_at: {
+                type: DataTypes.DATE,
+                allowNull: true,
+            },
             priority: {
                 type: DataTypes.INTEGER,
                 allowNull: true,

--- a/backend/modules/caldav/icalendar/vtodo-parser.js
+++ b/backend/modules/caldav/icalendar/vtodo-parser.js
@@ -21,6 +21,7 @@ async function parseVTODOToTask(vtodoString) {
             note: null,
             due_date: null,
             defer_until: null,
+            reminder_at: null,
             completed_at: null,
             status: 0,
             priority: 0,
@@ -147,6 +148,23 @@ async function parseVTODOToTask(vtodoString) {
         const order = vtodo.getFirstPropertyValue('x-tududi-order');
         if (order) {
             task.order = parseInt(order, 10);
+        }
+
+        const valarm = vtodo.getFirstSubcomponent('valarm');
+        if (valarm) {
+            const triggerProp = valarm.getFirstProperty('trigger');
+            if (triggerProp) {
+                const valueParam = triggerProp.getParameter('value');
+                if (valueParam && valueParam.toUpperCase() === 'DATE-TIME') {
+                    const triggerVal = triggerProp.getFirstValue();
+                    if (
+                        triggerVal &&
+                        typeof triggerVal.toJSDate === 'function'
+                    ) {
+                        task.reminder_at = triggerVal.toJSDate();
+                    }
+                }
+            }
         }
 
         return task;

--- a/backend/modules/caldav/icalendar/vtodo-serializer.js
+++ b/backend/modules/caldav/icalendar/vtodo-serializer.js
@@ -162,6 +162,27 @@ function serializeTaskToVTODO(task, options = {}) {
         }
     }
 
+    if (task.reminder_at) {
+        try {
+            const valarm = new ICAL.Component('valarm');
+            valarm.addPropertyWithValue('action', 'DISPLAY');
+            valarm.addPropertyWithValue('description', 'Reminder');
+
+            const triggerTime = ICAL.Time.fromJSDate(
+                new Date(task.reminder_at),
+                true
+            );
+            const triggerProp = new ICAL.Property('trigger');
+            triggerProp.resetType('date-time');
+            triggerProp.setValue(triggerTime);
+            valarm.addProperty(triggerProp);
+
+            vtodo.addSubcomponent(valarm);
+        } catch (error) {
+            console.error('Error formatting reminder_at:', error);
+        }
+    }
+
     comp.addSubcomponent(vtodo);
 
     return comp.toString();

--- a/frontend/components/Task/TaskDetails/TaskDeferUntilCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskDeferUntilCard.tsx
@@ -4,6 +4,7 @@ import { ClockIcon } from '@heroicons/react/24/outline';
 import TaskDeferUntilSection from '../TaskForm/TaskDeferUntilSection';
 import { Task } from '../../../entities/Task';
 import {
+    formatDateByCountry,
     formatDateTimeByCountry,
     getUserTimezone,
 } from '../../../utils/dateUtils';
@@ -34,47 +35,89 @@ const TaskDeferUntilCard: React.FC<TaskDeferUntilCardProps> = ({
         const date = new Date(deferUntil);
         if (Number.isNaN(date.getTime())) return null;
 
-        // Format datetime based on user's timezone-derived country
         const timezone = getUserTimezone();
         const country = getCountryFromTimezone(timezone);
-        const formattedDateTime = formatDateTimeByCountry(date, country);
 
-        const now = new Date();
-        const diffMs = date.getTime() - now.getTime();
-        const diffMins = Math.round(diffMs / (1000 * 60));
-        const diffHours = Math.round(diffMs / (1000 * 60 * 60));
-        const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+        // A value stored as UTC midnight came from a CalDAV DATE-only field.
+        // Display it without a time component to avoid spurious offset noise
+        // (e.g. UTC+2 would otherwise show "02:00").
+        const isDateOnly =
+            date.getUTCHours() === 0 &&
+            date.getUTCMinutes() === 0 &&
+            date.getUTCSeconds() === 0 &&
+            date.getUTCMilliseconds() === 0;
 
+        let formattedDateTime: string;
         let relativeText = '';
-        if (diffMins < 0) {
-            if (diffDays < -1) {
+
+        if (isDateOnly) {
+            formattedDateTime = formatDateByCountry(date, country);
+
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
+            const target = new Date(date);
+            target.setUTCHours(0, 0, 0, 0);
+            const diffDays = Math.round(
+                (target.getTime() - today.getTime()) / (1000 * 60 * 60 * 24)
+            );
+
+            if (diffDays === 0) {
+                relativeText = t('dateIndicators.today', 'today');
+            } else if (diffDays === 1) {
+                relativeText = t('dateIndicators.tomorrow', 'tomorrow');
+            } else if (diffDays === -1) {
+                relativeText = t('dateIndicators.yesterday', 'yesterday');
+            } else if (diffDays > 0) {
+                relativeText = t('task.inDays', 'in {{count}} days', {
+                    count: diffDays,
+                });
+            } else {
                 relativeText = t('task.daysAgo', '{{count}} days ago', {
                     count: Math.abs(diffDays),
                 });
-            } else if (diffHours < -1) {
-                relativeText = t('task.hoursAgo', '{{count}} hours ago', {
-                    count: Math.abs(diffHours),
+            }
+        } else {
+            formattedDateTime = formatDateTimeByCountry(date, country);
+
+            const now = new Date();
+            const diffMs = date.getTime() - now.getTime();
+            const diffMins = Math.round(diffMs / (1000 * 60));
+            const diffHours = Math.round(diffMs / (1000 * 60 * 60));
+            const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+            if (diffMins < 0) {
+                if (diffDays < -1) {
+                    relativeText = t('task.daysAgo', '{{count}} days ago', {
+                        count: Math.abs(diffDays),
+                    });
+                } else if (diffHours < -1) {
+                    relativeText = t('task.hoursAgo', '{{count}} hours ago', {
+                        count: Math.abs(diffHours),
+                    });
+                } else {
+                    relativeText = t(
+                        'task.minutesAgo',
+                        '{{count}} minutes ago',
+                        { count: Math.abs(diffMins) }
+                    );
+                }
+            } else if (diffMins < 60) {
+                relativeText = t('task.inMinutes', 'in {{count}} minutes', {
+                    count: diffMins,
+                });
+            } else if (diffHours < 24) {
+                relativeText = t('task.inHours', 'in {{count}} hours', {
+                    count: diffHours,
                 });
             } else {
-                relativeText = t('task.minutesAgo', '{{count}} minutes ago', {
-                    count: Math.abs(diffMins),
+                relativeText = t('task.inDays', 'in {{count}} days', {
+                    count: diffDays,
                 });
             }
-        } else if (diffMins < 60) {
-            relativeText = t('task.inMinutes', 'in {{count}} minutes', {
-                count: diffMins,
-            });
-        } else if (diffHours < 24) {
-            relativeText = t('task.inHours', 'in {{count}} hours', {
-                count: diffHours,
-            });
-        } else {
-            relativeText = t('task.inDays', 'in {{count}} days', {
-                count: diffDays,
-            });
         }
 
-        return { formattedDateTime, relativeText, isPast: diffMs < 0 };
+        const isPast = date.getTime() < new Date().getTime();
+        return { formattedDateTime, relativeText, isPast };
     };
 
     return (

--- a/frontend/entities/Task.ts
+++ b/frontend/entities/Task.ts
@@ -11,6 +11,7 @@ export interface Task {
     priority?: PriorityType | number;
     due_date?: string;
     defer_until?: string;
+    reminder_at?: string;
     note?: string;
     tags?: Tag[];
     project_id?: number;


### PR DESCRIPTION
## Description

Fixes two CalDAV bugs reported in #1147 where Tududi was silently destroying user data during bidirectional iOS sync.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related Issues

Fixes #1147

## Changes

### Bug 1 — VALARM preservation (critical data loss fix)

iOS sends a `VALARM` inside the `VTODO` to represent a reminder. Tududi had no VALARM handling at all, so on every round-trip it stripped the alarm and wrote it back without — causing iOS to silently turn off the user's reminder.

- **`backend/models/task.js`** — added `reminder_at` (DATE, nullable) field
- **`backend/migrations/20260602000001-add-reminder-at-to-tasks.js`** — migration to add the column
- **`backend/modules/caldav/icalendar/vtodo-parser.js`** — parses `VALARM` subcomponent; extracts an absolute `TRIGGER;VALUE=DATE-TIME` into `reminder_at`
- **`backend/modules/caldav/icalendar/vtodo-serializer.js`** — emits a `VALARM` block (ACTION:DISPLAY, absolute TRIGGER) when `reminder_at` is set, so the alarm survives the round-trip
- **`frontend/entities/Task.ts`** — adds `reminder_at?: string` to the TypeScript interface

### Bug 2 — defer_until spurious 02:00 time offset

A CalDAV `DTSTART;VALUE=DATE:` (date-only) is stored as UTC midnight. The `TaskDeferUntilCard` component was unconditionally calling `formatDateTimeByCountry` (which appends `HH:mm`), producing e.g. `27/05/2026 02:00` in UTC+2 instead of the correct `27/05/2026`.

- **`frontend/components/Task/TaskDetails/TaskDeferUntilCard.tsx`** — detects when `defer_until` is UTC midnight (date-only CalDAV value) and uses `formatDateByCountry` + day-granularity relative text (today/tomorrow/N days), matching how `TaskDueDateCard` behaves.

## Testing

- `npm run lint` — passes
- `npm test` — 1530/1530 tests pass

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have run the linter and fixed any issues
- [x] I have run existing tests and they all pass
- [x] My changes do not introduce breaking changes