### PR TITLE
fix(migrations): handle double-encoded JSON in notification preferences

### DIFF
--- a/backend/migrations/20251209000001-add-telegram-to-notification-preferences.js
+++ b/backend/migrations/20251209000001-add-telegram-to-notification-preferences.js
@@ -9,34 +9,54 @@ module.exports = {
         );
 
         for (const user of users) {
-            const prefs = user.notification_preferences;
-
-            if (prefs.dueTasks) {
-                prefs.dueTasks.telegram = false;
-            }
-            if (prefs.overdueTasks) {
-                prefs.overdueTasks.telegram = false;
-            }
-            if (prefs.dueProjects) {
-                prefs.dueProjects.telegram = false;
-            }
-            if (prefs.overdueProjects) {
-                prefs.overdueProjects.telegram = false;
-            }
-            if (prefs.deferUntil) {
-                prefs.deferUntil.telegram = false;
-            }
-
-            // Update the user's preferences
-            await queryInterface.sequelize.query(
-                'UPDATE users SET notification_preferences = :prefs WHERE id = :id',
-                {
-                    replacements: {
-                        prefs: JSON.stringify(prefs),
-                        id: user.id,
-                    },
+            let prefs = user.notification_preferences;
+            if (typeof prefs === 'string') {
+                try {
+                    prefs = JSON.parse(prefs);
+                } catch {
+                    continue;
                 }
-            );
+            }
+
+            let needsUpdate = false;
+            if (prefs.dueTasks && prefs.dueTasks.telegram === undefined) {
+                prefs.dueTasks.telegram = false;
+                needsUpdate = true;
+            }
+            if (
+                prefs.overdueTasks &&
+                prefs.overdueTasks.telegram === undefined
+            ) {
+                prefs.overdueTasks.telegram = false;
+                needsUpdate = true;
+            }
+            if (prefs.dueProjects && prefs.dueProjects.telegram === undefined) {
+                prefs.dueProjects.telegram = false;
+                needsUpdate = true;
+            }
+            if (
+                prefs.overdueProjects &&
+                prefs.overdueProjects.telegram === undefined
+            ) {
+                prefs.overdueProjects.telegram = false;
+                needsUpdate = true;
+            }
+            if (prefs.deferUntil && prefs.deferUntil.telegram === undefined) {
+                prefs.deferUntil.telegram = false;
+                needsUpdate = true;
+            }
+
+            if (needsUpdate) {
+                await queryInterface.sequelize.query(
+                    'UPDATE users SET notification_preferences = :prefs WHERE id = :id',
+                    {
+                        replacements: {
+                            prefs: JSON.stringify(prefs),
+                            id: user.id,
+                        },
+                    }
+                );
+            }
         }
 
         await safeChangeColumn(
@@ -90,33 +110,54 @@ module.exports = {
         );
 
         for (const user of users) {
-            const prefs = user.notification_preferences;
-
-            if (prefs.dueTasks) {
-                delete prefs.dueTasks.telegram;
-            }
-            if (prefs.overdueTasks) {
-                delete prefs.overdueTasks.telegram;
-            }
-            if (prefs.dueProjects) {
-                delete prefs.dueProjects.telegram;
-            }
-            if (prefs.overdueProjects) {
-                delete prefs.overdueProjects.telegram;
-            }
-            if (prefs.deferUntil) {
-                delete prefs.deferUntil.telegram;
-            }
-
-            await queryInterface.sequelize.query(
-                'UPDATE users SET notification_preferences = :prefs WHERE id = :id',
-                {
-                    replacements: {
-                        prefs: JSON.stringify(prefs),
-                        id: user.id,
-                    },
+            let prefs = user.notification_preferences;
+            if (typeof prefs === 'string') {
+                try {
+                    prefs = JSON.parse(prefs);
+                } catch {
+                    continue;
                 }
-            );
+            }
+
+            let needsUpdate = false;
+            if (prefs.dueTasks && prefs.dueTasks.telegram !== undefined) {
+                delete prefs.dueTasks.telegram;
+                needsUpdate = true;
+            }
+            if (
+                prefs.overdueTasks &&
+                prefs.overdueTasks.telegram !== undefined
+            ) {
+                delete prefs.overdueTasks.telegram;
+                needsUpdate = true;
+            }
+            if (prefs.dueProjects && prefs.dueProjects.telegram !== undefined) {
+                delete prefs.dueProjects.telegram;
+                needsUpdate = true;
+            }
+            if (
+                prefs.overdueProjects &&
+                prefs.overdueProjects.telegram !== undefined
+            ) {
+                delete prefs.overdueProjects.telegram;
+                needsUpdate = true;
+            }
+            if (prefs.deferUntil && prefs.deferUntil.telegram !== undefined) {
+                delete prefs.deferUntil.telegram;
+                needsUpdate = true;
+            }
+
+            if (needsUpdate) {
+                await queryInterface.sequelize.query(
+                    'UPDATE users SET notification_preferences = :prefs WHERE id = :id',
+                    {
+                        replacements: {
+                            prefs: JSON.stringify(prefs),
+                            id: user.id,
+                        },
+                    }
+                );
+            }
         }
 
         await safeChangeColumn(

--- a/backend/migrations/20260509000001-ensure-notification-preferences.js
+++ b/backend/migrations/20260509000001-ensure-notification-preferences.js
@@ -67,6 +67,14 @@ module.exports = {
                     prefs = {};
                 }
             }
+            // Handle double-encoded JSON caused by bug in 20251209000001
+            if (typeof prefs === 'string') {
+                try {
+                    prefs = JSON.parse(prefs);
+                } catch {
+                    prefs = {};
+                }
+            }
             let needsUpdate = false;
 
             // Check if all required keys exist


### PR DESCRIPTION
## Description

Fixes a chain of migration bugs that prevented v1.1.0 from starting when upgrading from an older installation.

**Root cause:** `20251209000001-add-telegram-to-notification-preferences.js` queries users via raw SQL, which returns the `notification_preferences` column as a raw string in SQLite — not a parsed object. The migration then called `JSON.stringify()` on that string value, double-encoding the JSON for every user row and storing corrupt data back to the database.

**Effect:** When `20260509000001-ensure-notification-preferences.js` ran next, one `JSON.parse()` still yielded a string (not an object), causing it to throw `Cannot create property 'dueTasks' on string`. Since Sequelize CLI stops on migration failure, `20260602000001-add-reminder-at-to-tasks.js` never ran, so the `reminder_at` column was never added. The app started anyway (startup script swallows migration errors) but crashed on any task query with `SQLITE_ERROR: no such column: Task.reminder_at`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1167

## Changes

### `20251209000001-add-telegram-to-notification-preferences.js`
- Parse `notification_preferences` string with `JSON.parse()` before accessing object properties
- Only write the UPDATE query when a `telegram` key was actually missing (skip if already up-to-date)
- Same fix applied to the `down()` migration

### `20260509000001-ensure-notification-preferences.js`
- Add a second `JSON.parse()` pass after the first, to repair already double-encoded values left by the bug in `20251209000001`
- For affected users: this migration previously failed (not in SequelizeMeta), so it will retry automatically on next startup with the fix applied, unblocking `20260602000001` and adding the `reminder_at` column

## Testing

- `npm run lint` — passes
- `npm test` — 2 pre-existing failures unrelated to these changes (403 vs 401 access control in tags/notes tests)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I ran `npm run lint` before submitting