### PR TITLE
fix(inbox): stay on inbox page after converting item to task

### DIFF
--- a/frontend/components/Inbox/InboxItems.tsx
+++ b/frontend/components/Inbox/InboxItems.tsx
@@ -267,7 +267,7 @@ const InboxItems: React.FC = () => {
         try {
             await createTaskAndHandleConversion(task, {
                 inboxItemUid,
-                navigateAfterCreate: true,
+                navigateAfterCreate: false,
             });
         } catch {
             // Errors are already reported via toast notifications


### PR DESCRIPTION
## Description

When converting an inbox item to a task, the app was redirecting the user to the newly created task's detail page. This breaks the process-inbox workflow — users should stay on the inbox to continue processing items. The success toast already provides a clickable link to the new task.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1170

## Testing

1. Open the Inbox page
2. Click an inbox item to expand it
3. Click the **Task** conversion button
4. Verify: user stays on inbox page
5. Verify: success toast appears with a link to the new task
6. Verify: inbox item is removed from the list (marked processed)

Commands run:
- `npm run lint` — passes clean

## Checklist

- [x] My code follows the project's code style
- [x] I have tested my changes manually
- [x] No new dependencies introduced