### PR TITLE
fix(csp): disable upgrade-insecure-requests for plain HTTP deployments

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -49,7 +49,7 @@ app.use(
                 mediaSrc: ["'self'"],
                 frameSrc: ["'none'"],
                 upgradeInsecureRequests:
-                    process.env.DISABLE_HSTS === 'true' ? null : [],
+                    process.env.COOKIE_SECURE === 'true' ? [] : null,
             },
         },
         hsts:


### PR DESCRIPTION
## Description

Users upgrading from v1.0.0 to v1.1.0 see a blank page when accessing Tududi directly over HTTP (no reverse proxy). The login screen never loads.

**Root cause:** v1.1.0 introduced a full Content Security Policy via Helmet, including the `upgrade-insecure-requests` directive. This tells browsers to silently upgrade all HTTP sub-resource requests (JS, CSS, API calls) to HTTPS. For deployments without HTTPS — i.e., direct IP access — those upgraded requests fail with no errors shown, leaving a blank page.

v1.0.0 had `contentSecurityPolicy: false` so this directive was never sent.

**Fix:** Only enable `upgrade-insecure-requests` when `COOKIE_SECURE=true`, which is the explicit opt-in for HTTPS deployments. All other deployments get `null` (directive omitted), which is safe and matches v1.0.0 behavior.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #1172

## Testing

1. Start Tududi without `COOKIE_SECURE=true` (plain HTTP)
2. Visit the web interface — login page loads correctly
3. Set `COOKIE_SECURE=true` — `upgrade-insecure-requests` is included in CSP for HTTPS deployments

```
npm test  # 1530 tests pass
npm run lint  # clean
```

## Checklist

- [x] Code follows project conventions
- [x] Tests pass
- [x] Lint passes
- [x] Related issue linked

## Additional Notes

The `DISABLE_HSTS` env var is unaffected — HSTS and `upgrade-insecure-requests` are now independently controlled, which is semantically correct since they serve different purposes.