### PR TITLE
fix(csp): use dedicated UPGRADE_INSECURE_REQUESTS env var instead of COOKIE_SECURE

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -69,6 +69,13 @@ TUDUDI_TRUST_PROXY=true
 # NEVER enable this in actual production deployments with HTTPS
 # DISABLE_HSTS=false
 
+# Enable CSP upgrade-insecure-requests directive
+# When set to 'true', instructs browsers to upgrade all HTTP subresource URLs to HTTPS.
+# Only enable this if Tududi is served over HTTPS end-to-end (e.g., via a reverse proxy).
+# Enabling on a plain HTTP deployment will cause a blank page.
+# Default: disabled (null — directive omitted)
+# UPGRADE_INSECURE_REQUESTS=false
+
 # OIDC/SSO Configuration
 # See docs/10-oidc-sso.md for detailed setup instructions
 OIDC_ENABLED=false

--- a/backend/app.js
+++ b/backend/app.js
@@ -49,7 +49,9 @@ app.use(
                 mediaSrc: ["'self'"],
                 frameSrc: ["'none'"],
                 upgradeInsecureRequests:
-                    process.env.COOKIE_SECURE === 'true' ? [] : null,
+                    process.env.UPGRADE_INSECURE_REQUESTS === 'true'
+                        ? []
+                        : null,
             },
         },
         hsts:


### PR DESCRIPTION
## Description

Follow-up to #1175. The previous fix gated the `upgrade-insecure-requests` CSP directive on `COOKIE_SECURE === 'true'`, but those two settings have different semantics: `COOKIE_SECURE` controls session cookie behavior, not whether the site is served over HTTPS to the browser. This was flagged by automated security review.

This PR introduces a dedicated `UPGRADE_INSECURE_REQUESTS=true` env var to explicitly opt into the CSP directive. The default remains `null` (directive omitted), which preserves the blank-page fix from #1175 while removing the confusing coupling.

Documents the new variable in `.env.example` alongside `DISABLE_HSTS`.

## Type of Change

- [x] Bug fix

## Related Issues

Related to #1172, follow-up to #1175

## Testing

```
npm run lint  # clean
```

Behavior unchanged from #1175 for all HTTP deployments. HTTPS users who want the directive can now set `UPGRADE_INSECURE_REQUESTS=true`.

## Checklist

- [x] Code follows project conventions
- [x] Lint passes
- [x] Related issue linked