### PR TITLE
fix(oidc): resolve user from session in link callback

### DIFF
--- a/backend/modules/oidc/controller.js
+++ b/backend/modules/oidc/controller.js
@@ -3,6 +3,7 @@ const provisioningService = require('./provisioningService');
 const oidcIdentityService = require('./oidcIdentityService');
 const providerConfig = require('./providerConfig');
 const auditService = require('./auditService');
+const { User } = require('../../models');
 
 async function listProviders(req, res) {
     try {
@@ -43,7 +44,20 @@ async function handleCallback(req, res) {
         const result = await oidcService.handleCallback(slug, req.query);
 
         if (result.linkMode) {
-            if (!req.currentUser) {
+            // OIDC routes run before the global requireAuth middleware so
+            // req.currentUser is never set here; resolve from the session instead.
+            const sessionUserId = req.session && req.session.userId;
+            if (!sessionUserId) {
+                return res.redirect(
+                    '/login?error=' +
+                        encodeURIComponent(
+                            'Authentication required to link account'
+                        )
+                );
+            }
+
+            const linkUser = await User.findByPk(sessionUserId);
+            if (!linkUser) {
                 return res.redirect(
                     '/login?error=' +
                         encodeURIComponent(
@@ -53,12 +67,12 @@ async function handleCallback(req, res) {
             }
 
             await provisioningService.linkIdentityToUser(
-                req.currentUser.id,
+                linkUser.id,
                 slug,
                 result.claims
             );
 
-            await auditService.logOidcLinked(req.currentUser.id, slug, req);
+            await auditService.logOidcLinked(linkUser.id, slug, req);
 
             return res.redirect('/profile/security?success=linked');
         }


### PR DESCRIPTION
## Description

When a logged-in user tries to link an OIDC provider from their profile (/profile/security → "Link Pocket ID"), the callback always failed with "Authentication required to link account" and redirected to /login.

**Root cause:** OIDC routes (`/api/oidc/*`) are registered in `app.js` *before* the global `requireAuth` middleware, so `req.currentUser` is never populated for any OIDC route. The `handleCallback` controller checked `req.currentUser` to identify the user to link to, but that field is always `undefined` here — even when the user has a valid browser session.

**Fix:** In the link-mode branch of `handleCallback`, resolve the user from `req.session.userId` directly (which is set during normal login and available on all routes since the session middleware runs globally), instead of relying on `req.currentUser`.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1174

## Testing

**How did you test this?**

Traced the full callback flow through `app.js` route ordering, `controller.js`, and the session middleware to confirm the session is available but `req.currentUser` is not.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code

## Additional Notes

The only test failure (`oauth.test.js: authenticates a valid JWT and allows access`) is pre-existing on `main` and unrelated to this change.