### PR TITLE
fix(tasks): allow defer until any time on the same day as due date

### DIFF
--- a/backend/modules/tasks/utils/validation.js
+++ b/backend/modules/tasks/utils/validation.js
@@ -125,9 +125,12 @@ function validateDeferUntilAndDueDate(
         return;
     }
 
-    // Not a recurring instance - apply strict validation
-    // Defer until must be before or equal to due date
-    if (deferDate > dueDateObj) {
+    // Not a recurring instance - apply strict validation.
+    // Due dates are date-only (no time picker), so treat them as end-of-day
+    // so that any defer_until time on the same calendar day is allowed.
+    const dueDateEndOfDay = new Date(dueDateObj);
+    dueDateEndOfDay.setUTCHours(23, 59, 59, 999);
+    if (deferDate > dueDateEndOfDay) {
         throw new Error('Defer until date cannot be after the due date.');
     }
 }

--- a/backend/tests/unit/utils/validation.test.js
+++ b/backend/tests/unit/utils/validation.test.js
@@ -139,6 +139,33 @@ describe('validation utils', () => {
                     validateDeferUntilAndDueDate('2026-03-10', '2026-03-10');
                 }).not.toThrow();
             });
+
+            it('should allow defer_until with a time on the same day as due_date', () => {
+                expect(() => {
+                    validateDeferUntilAndDueDate(
+                        '2026-03-10T23:00:00.000Z',
+                        '2026-03-10'
+                    );
+                }).not.toThrow();
+            });
+
+            it('should allow defer_until at noon on the same day as due_date', () => {
+                expect(() => {
+                    validateDeferUntilAndDueDate(
+                        '2026-03-10T12:00:00.000Z',
+                        '2026-03-10'
+                    );
+                }).not.toThrow();
+            });
+
+            it('should reject defer_until the day after due_date even at midnight', () => {
+                expect(() => {
+                    validateDeferUntilAndDueDate(
+                        '2026-03-11T00:00:00.000Z',
+                        '2026-03-10'
+                    );
+                }).toThrow('Defer until date cannot be after the due date.');
+            });
         });
 
         describe('recurring task instances', () => {

--- a/frontend/components/Task/TaskDetails.tsx
+++ b/frontend/components/Task/TaskDetails.tsx
@@ -328,7 +328,10 @@ const TaskDetails: React.FC = () => {
             const dueDate = new Date(editedDueDate);
 
             if (!isNaN(deferDate.getTime()) && !isNaN(dueDate.getTime())) {
-                if (deferDate > dueDate) {
+                // Due dates are date-only; allow defer until any time on the same calendar day
+                const dueDateEndOfDay = new Date(dueDate);
+                dueDateEndOfDay.setUTCHours(23, 59, 59, 999);
+                if (deferDate > dueDateEndOfDay) {
                     showErrorToast(
                         t(
                             'task.dueDateBeforeDeferError',
@@ -418,8 +421,10 @@ const TaskDetails: React.FC = () => {
                 // For recurring instances, skip strict frontend validation
                 // Backend will validate against parent's recurrence_end_date
                 if (!task.recurring_parent_id) {
-                    // Only validate for non-recurring tasks
-                    if (deferDate > dueDate) {
+                    // Due dates are date-only; allow any time on the same calendar day
+                    const dueDateEndOfDay = new Date(dueDate);
+                    dueDateEndOfDay.setUTCHours(23, 59, 59, 999);
+                    if (deferDate > dueDateEndOfDay) {
                         showErrorToast(
                             t(
                                 'task.deferAfterDueError',


### PR DESCRIPTION
## Description

Due dates in Tududi are date-only values stored as UTC midnight (e.g. `2026-06-10T00:00:00.000Z`). Defer Until values include a full datetime with a time component (e.g. `2026-06-10T22:00:00.000Z`).

When the validation compared these two values directly, any `defer_until` time on the *same calendar day* as the due date would fail with "Defer until date cannot be after the due date" — because any non-midnight time is technically after midnight UTC.

The fix treats the due date as **end-of-day** (`23:59:59.999 UTC`) for comparison purposes, so setting Defer Until to any time on the due date's calendar day is allowed.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #1173

## Testing

- Added 3 unit tests covering:
  - defer_until with a time at 11 PM on the same UTC day as the due date
  - defer_until at noon on the same UTC day as the due date
  - defer_until at midnight of the *day after* the due date (still rejected)
- All 31 unit tests in `validation.test.js` pass

```
npm test -- --testPathPattern="validation"
# Tests: 31 passed
```

## Checklist

- [x] Code follows project conventions
- [x] Tests added for the bug fix
- [x] `npm run lint` passes
- [x] No JSDoc comments added

## Additional Notes

The fix is applied in three places:
1. **Backend** `validation.js` — the authoritative validation used by both create and update routes
2. **Frontend** `TaskDetails.tsx` `handleSaveDeferUntil` — client-side guard before the API call
3. **Frontend** `TaskDetails.tsx` `handleSaveDueDate` — same guard when updating a due date that already has a defer until set