### PR TITLE
feat(sidebar): pin projects to the sidebar

### DIFF
--- a/frontend/components/Project/ProjectItem.tsx
+++ b/frontend/components/Project/ProjectItem.tsx
@@ -1,6 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { EllipsisVerticalIcon } from '@heroicons/react/24/solid';
+import {
+    EllipsisVerticalIcon,
+    StarIcon as StarIconSolid,
+} from '@heroicons/react/24/solid';
 import {
     PencilSquareIcon,
     TrashIcon,
@@ -12,6 +15,7 @@ import {
     XCircleIcon,
     ShareIcon,
     ExclamationTriangleIcon,
+    StarIcon,
 } from '@heroicons/react/24/outline';
 import { Project, ProjectStatus } from '../../entities/Project';
 import { useTranslation } from 'react-i18next';
@@ -21,6 +25,7 @@ import Tooltip from '../Shared/Tooltip';
 import { differenceInCalendarDays } from 'date-fns';
 import { listShares, ListSharesResponseRow } from '../../utils/sharesService';
 import { getApiPath } from '../../config/paths';
+import { getCsrfToken } from '../../utils/csrfService';
 
 interface ProjectItemProps {
     project: Project;
@@ -115,6 +120,8 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
 }) => {
     const { t } = useTranslation();
     const { showErrorToast } = useToast();
+    const [isPinned, setIsPinned] = useState(Boolean(project.pin_to_sidebar));
+    const [isPinSubmitting, setIsPinSubmitting] = useState(false);
     const currentUser = getCurrentUser();
     const isOwner =
         currentUser && (project as any).user_uid === currentUser.uid;
@@ -144,6 +151,10 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
         }
         return null;
     });
+
+    useEffect(() => {
+        setIsPinned(Boolean(project.pin_to_sidebar));
+    }, [project.pin_to_sidebar]);
 
     useEffect(() => {
         if (project.uid && projectShareCache.has(project.uid)) {
@@ -257,6 +268,53 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
         if (!namePart) return email;
         return namePart.charAt(0).toUpperCase() + namePart.slice(1);
     };
+
+    const togglePin = async (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+
+        if (isPinSubmitting) {
+            return;
+        }
+
+        if (!project.uid) {
+            console.error('Cannot pin project: UID is undefined.', project);
+            return;
+        }
+
+        const nextPinned = !isPinned;
+        setIsPinSubmitting(true);
+        try {
+            const response = await fetch(getApiPath(`project/${project.uid}`), {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-csrf-token': await getCsrfToken(),
+                },
+                credentials: 'include',
+                body: JSON.stringify({
+                    pin_to_sidebar: nextPinned,
+                }),
+            });
+
+            if (response.ok) {
+                setIsPinned(nextPinned);
+                window.dispatchEvent(new CustomEvent('projectUpdated'));
+            } else {
+                showErrorToast(
+                    t('errors.projectUpdateError', 'Failed to update project')
+                );
+            }
+        } catch (error) {
+            console.error('Error toggling project pin:', error);
+            showErrorToast(
+                t('errors.projectUpdateError', 'Failed to update project')
+            );
+        } finally {
+            setIsPinSubmitting(false);
+        }
+    };
+
     return (
         <div
             className={`${
@@ -292,135 +350,130 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
                             ) : (
                                 <div className="w-full h-full bg-gray-200 dark:bg-gray-700"></div>
                             )}
-                            <div className="absolute top-2 right-2 z-20 flex items-center space-x-2">
-                                {project.is_shared && (
-                                    <ShareIcon
-                                        className="h-4 w-4 text-green-400 drop-shadow-sm"
-                                        title={t(
-                                            'projectItem.sharedProject',
-                                            'Shared with team'
-                                        )}
-                                    />
-                                )}
-                                {(() => {
-                                    const { icon: StatusIcon } = getStatusIcon(
-                                        project.status
-                                    );
-                                    return (
-                                        <StatusIcon
-                                            className="h-4 w-4 text-white/80 drop-shadow-sm"
-                                            title={getStatusLabel(
-                                                project.status,
-                                                t
-                                            )}
-                                        />
-                                    );
-                                })()}
-                                <div className="relative dropdown-container">
-                                    <button
-                                        className="p-1.5 rounded-full bg-black/30 text-white hover:bg-black/60 focus:outline-none backdrop-blur-sm"
-                                        onClick={(e) => {
-                                            e.preventDefault();
-                                            e.stopPropagation();
-                                            const projectId = project.id;
-                                            if (projectId !== undefined) {
-                                                setActiveDropdown(
-                                                    activeDropdown === projectId
-                                                        ? null
-                                                        : projectId
-                                                );
-                                            }
-                                        }}
-                                        aria-label={t(
-                                            'projectItem.toggleDropdownMenu'
-                                        )}
-                                        data-testid={`project-dropdown-${project.id}`}
-                                    >
-                                        <EllipsisVerticalIcon className="h-5 w-5" />
-                                    </button>
-                                    {project.id !== undefined &&
-                                        activeDropdown === project.id && (
-                                            <div className="absolute right-0 mt-2 w-32 bg-white dark:bg-gray-800 shadow-lg rounded-md z-30">
-                                                <button
-                                                    onClick={(e) => {
-                                                        e.preventDefault();
-                                                        e.stopPropagation();
-                                                        if (!isOwner) {
-                                                            showErrorToast(
-                                                                t(
-                                                                    'errors.permissionDenied',
-                                                                    'Permission denied'
-                                                                )
-                                                            );
-                                                            setActiveDropdown(
-                                                                null
-                                                            );
-                                                            return;
-                                                        }
-                                                        handleEditProject(
-                                                            project
-                                                        );
-                                                        setActiveDropdown(null);
-                                                    }}
-                                                    className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left"
-                                                    data-testid={`project-edit-${project.id}`}
-                                                >
-                                                    {t('projectItem.edit')}
-                                                </button>
-                                                {isOwner && (
-                                                    <button
-                                                        onClick={(e) => {
-                                                            e.preventDefault();
-                                                            e.stopPropagation();
-                                                            onOpenShare(
-                                                                project
-                                                            );
-                                                            setActiveDropdown(
-                                                                null
-                                                            );
-                                                        }}
-                                                        className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left"
-                                                    >
-                                                        {t(
-                                                            'projectItem.share',
-                                                            'Share'
-                                                        )}
-                                                    </button>
-                                                )}
-                                                <button
-                                                    onClick={(e) => {
-                                                        e.preventDefault();
-                                                        e.stopPropagation();
-                                                        if (
-                                                            project.id ===
-                                                                undefined ||
-                                                            project.id === null
-                                                        ) {
-                                                            console.error(
-                                                                'Cannot delete project: Invalid ID',
-                                                                project
-                                                            );
-                                                            return;
-                                                        }
-                                                        setProjectToDelete(
-                                                            project
-                                                        );
-                                                        setIsConfirmDialogOpen(
-                                                            true
-                                                        );
-                                                        setActiveDropdown(null);
-                                                    }}
-                                                    className="block px-4 py-2 text-sm text-red-500 dark:text-red-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left"
-                                                    data-testid={`project-delete-${project.id}`}
-                                                >
-                                                    {t('projectItem.delete')}
-                                                </button>
-                                            </div>
-                                        )}
-                                </div>
-                            </div>
                         </div>
                     </Link>
+                    <div className="absolute top-2 right-2 z-20 flex items-center space-x-2">
+                        <button
+                            onClick={togglePin}
+                            disabled={isPinSubmitting}
+                            className={`${isPinned ? 'text-yellow-400' : 'text-white/80'} hover:text-yellow-300 focus:outline-none drop-shadow-sm disabled:cursor-not-allowed disabled:opacity-60`}
+                            aria-label={t('common.togglePin', 'Toggle pin')}
+                            title={t('common.togglePin', 'Toggle pin')}
+                        >
+                            {isPinned ? (
+                                <StarIconSolid className="h-4 w-4" />
+                            ) : (
+                                <StarIcon className="h-4 w-4" />
+                            )}
+                        </button>
+                        {project.is_shared && (
+                            <ShareIcon
+                                className="h-4 w-4 text-green-400 drop-shadow-sm"
+                                title={t(
+                                    'projectItem.sharedProject',
+                                    'Shared with team'
+                                )}
+                            />
+                        )}
+                        {(() => {
+                            const { icon: StatusIcon } = getStatusIcon(
+                                project.status
+                            );
+                            return (
+                                <StatusIcon
+                                    className="h-4 w-4 text-white/80 drop-shadow-sm"
+                                    title={getStatusLabel(project.status, t)}
+                                />
+                            );
+                        })()}
+                        <div className="relative dropdown-container">
+                            <button
+                                className="p-1.5 rounded-full bg-black/30 text-white hover:bg-black/60 focus:outline-none backdrop-blur-sm"
+                                onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    const projectId = project.id;
+                                    if (projectId !== undefined) {
+                                        setActiveDropdown(
+                                            activeDropdown === projectId
+                                                ? null
+                                                : projectId
+                                        );
+                                    }
+                                }}
+                                aria-label={t('projectItem.toggleDropdownMenu')}
+                                data-testid={`project-dropdown-${project.id}`}
+                            >
+                                <EllipsisVerticalIcon className="h-5 w-5" />
+                            </button>
+                            {project.id !== undefined &&
+                                activeDropdown === project.id && (
+                                    <div className="absolute right-0 mt-2 w-32 bg-white dark:bg-gray-800 shadow-lg rounded-md z-30">
+                                        <button
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                e.stopPropagation();
+                                                if (!isOwner) {
+                                                    showErrorToast(
+                                                        t(
+                                                            'errors.permissionDenied',
+                                                            'Permission denied'
+                                                        )
+                                                    );
+                                                    setActiveDropdown(null);
+                                                    return;
+                                                }
+                                                handleEditProject(project);
+                                                setActiveDropdown(null);
+                                            }}
+                                            className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left"
+                                            data-testid={`project-edit-${project.id}`}
+                                        >
+                                            {t('projectItem.edit')}
+                                        </button>
+                                        {isOwner && (
+                                            <button
+                                                onClick={(e) => {
+                                                    e.preventDefault();
+                                                    e.stopPropagation();
+                                                    onOpenShare(project);
+                                                    setActiveDropdown(null);
+                                                }}
+                                                className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left"
+                                            >
+                                                {t(
+                                                    'projectItem.share',
+                                                    'Share'
+                                                )}
+                                            </button>
+                                        )}
+                                        <button
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                e.stopPropagation();
+                                                if (
+                                                    project.id === undefined ||
+                                                    project.id === null
+                                                ) {
+                                                    console.error(
+                                                        'Cannot delete project: Invalid ID',
+                                                        project
+                                                    );
+                                                    return;
+                                                }
+                                                setProjectToDelete(project);
+                                                setIsConfirmDialogOpen(true);
+                                                setActiveDropdown(null);
+                                            }}
+                                            className="block px-4 py-2 text-sm text-red-500 dark:text-red-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left"
+                                            data-testid={`project-delete-${project.id}`}
+                                        >
+                                            {t('projectItem.delete')}
+                                        </button>
+                                    </div>
+                                )}
+                        </div>
+                    </div>
                 </div>
             )}
 
@@ -600,7 +653,26 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
                         {listTitleLink}
                     </div>
                     <div className="relative dropdown-container">
-                        <div className="flex items-center space-x-2 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+                        <div
+                            className={`flex items-center space-x-2 transition-opacity duration-300 ${
+                                isPinned
+                                    ? 'opacity-100'
+                                    : 'opacity-0 group-hover:opacity-100'
+                            }`}
+                        >
+                            <button
+                                onClick={togglePin}
+                                disabled={isPinSubmitting}
+                                className={`${isPinned ? 'text-yellow-500' : 'text-gray-500'} hover:text-yellow-600 dark:hover:text-yellow-400 transition-colors duration-200 disabled:cursor-not-allowed disabled:opacity-60`}
+                                aria-label={t('common.togglePin', 'Toggle pin')}
+                                title={t('common.togglePin', 'Toggle pin')}
+                            >
+                                {isPinned ? (
+                                    <StarIconSolid className="h-5 w-5" />
+                                ) : (
+                                    <StarIcon className="h-5 w-5" />
+                                )}
+                            </button>
                             <button
                                 onClick={(e) => {
                                     e.preventDefault();

--- a/frontend/components/Sidebar/SidebarProjects.tsx
+++ b/frontend/components/Sidebar/SidebarProjects.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Location } from 'react-router-dom';
 import { FolderIcon, PlusCircleIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
+import { getApiPath } from '../../config/paths';
+import { Project } from '../../entities/Project';
+import { createProjectUrl } from '../../utils/slugUtils';
 
 interface SidebarProjectsProps {
     handleNavClick: (path: string, title: string, icon: JSX.Element) => void;
@@ -16,6 +19,53 @@ const SidebarProjects: React.FC<SidebarProjectsProps> = ({
     openProjectModal,
 }) => {
     const { t } = useTranslation();
+    const [pinnedProjects, setPinnedProjects] = useState<Project[]>([]);
+
+    const getProjectPath = (project: Project) => {
+        if (project.uid) {
+            return createProjectUrl(project);
+        }
+
+        return project.id ? `/project/${project.id}` : '/projects';
+    };
+
+    const fetchPinnedProjects = async () => {
+        try {
+            const response = await fetch(
+                getApiPath('projects?pin_to_sidebar=true'),
+                {
+                    credentials: 'include',
+                }
+            );
+            if (response.ok) {
+                const data = await response.json();
+                const projects = Array.isArray(data)
+                    ? data
+                    : data.projects || [];
+                setPinnedProjects(
+                    [...projects].sort((a: Project, b: Project) =>
+                        a.name.localeCompare(b.name)
+                    )
+                );
+            }
+        } catch (error) {
+            console.error('Error fetching pinned projects:', error);
+        }
+    };
+
+    useEffect(() => {
+        fetchPinnedProjects();
+
+        const handleProjectUpdate = () => {
+            fetchPinnedProjects();
+        };
+
+        window.addEventListener('projectUpdated', handleProjectUpdate);
+        return () => {
+            window.removeEventListener('projectUpdated', handleProjectUpdate);
+        };
+    }, []);
+
     const isActiveProject = (path: string) => {
         return location.pathname === path
             ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white'
@@ -32,7 +82,7 @@ const SidebarProjects: React.FC<SidebarProjectsProps> = ({
                     onClick={() =>
                         handleNavClick(
                             '/projects',
-                            'Projects',
+                            t('sidebar.projects'),
                             <FolderIcon className="h-5 w-5 mr-2" />
                         )
                     }
@@ -47,12 +97,35 @@ const SidebarProjects: React.FC<SidebarProjectsProps> = ({
                             openProjectModal();
                         }}
                         className="text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
-                        aria-label="Add Project"
-                        title="Add Project"
+                        aria-label={t('sidebar.addProjectAriaLabel')}
+                        title={t('sidebar.addProjectTitle')}
                     >
                         <PlusCircleIcon className="h-5 w-5" />
                     </button>
                 </li>
+                {pinnedProjects.map((project, index) => {
+                    const path = getProjectPath(project);
+                    return (
+                        <li
+                            key={project.uid || project.id}
+                            className={`${index === 0 ? 'mt-2 ' : ''}flex justify-between items-center rounded-md px-4 py-1.5 text-sm cursor-pointer hover:text-black dark:hover:text-white ${isActiveProject(
+                                path
+                            )}`}
+                            onClick={() =>
+                                handleNavClick(
+                                    path,
+                                    project.name,
+                                    <FolderIcon className="h-5 w-5 mr-2" />
+                                )
+                            }
+                        >
+                            <span className="flex items-center truncate">
+                                <FolderIcon className="h-4 w-4 mr-2 flex-shrink-0" />
+                                <span className="truncate">{project.name}</span>
+                            </span>
+                        </li>
+                    );
+                })}
             </ul>
         </>
     );

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -25,7 +25,8 @@
     "discardChanges": "Discard changes?",
     "discardChangesMessage": "You have unsaved changes. Are you sure you want to discard them?",
     "no": "No, keep editing",
-    "yesDiscard": "Yes, discard"
+    "yesDiscard": "Yes, discard",
+    "togglePin": "Toggle pin"
   },
   "sidebar": {
     "dashboard": "Dashboard",

--- a/public/locales/jp/translation.json
+++ b/public/locales/jp/translation.json
@@ -25,7 +25,8 @@
     "yesDiscard": "はい、破棄する",
     "uploading": "アップロード中...",
     "refresh": "更新",
-    "unlinking": "リンク解除中..."
+    "unlinking": "リンク解除中...",
+    "togglePin": "ピン留めを切り替え"
   },
   "sidebar": {
     "dashboard": "ダッシュボード",


### PR DESCRIPTION
## Description

Adds the ability to pin projects so they appear as a list in the left sidebar — the same convenience the sidebar already provides for pinned Views. ("Pin projects to sidebar" is on the roadmap.)

The `Project` model already supports `pin_to_sidebar` (the update endpoint applies it and `GET /projects?pin_to_sidebar=true` filters by it), so this is **frontend-only**:

- `SidebarProjects` fetches and renders pinned projects under the existing "Projects" header, refreshing on a `projectUpdated` event (mirroring `SidebarViews`).
- A star toggle on `ProjectItem` PATCHes `pin_to_sidebar`, like `Views.togglePin` does for `is_pinned`. It is double-submit-guarded and surfaces a toast on failure.
- Sidebar links use the existing `createProjectUrl` helper (so the active highlight stays correct for non-ASCII project names too).

No backend changes, no new dependencies.

## Type of Change

- [x] New feature (adds functionality)

## Related

Discussed in #1179

## Testing

**How did you test this?**

- Pinned/unpinned projects from the Projects page and verified they appear/disappear in the sidebar live (via the `projectUpdated` event) and navigate to the correct project, including Japanese-named projects.
- Verified the pinned state persists across a full page reload.

**Commands run:**

- [x] `npm run pre-push` (lint + format)
- [x] Tested manually in browser
