### PR TITLE
fix(caldav): cannot delete CalDAV calendars

### DIFF
--- a/backend/modules/caldav/api/calendar-controller.js
+++ b/backend/modules/caldav/api/calendar-controller.js
@@ -219,7 +219,7 @@ class CalendarController {
 
             await SyncStateRepository.deleteByCalendarId(calendar.id);
 
-            await CalendarRepository.delete(calendar);
+            await CalendarRepository.destroy(calendar);
 
             res.status(204).send();
         } catch (error) {

--- a/backend/modules/caldav/api/remote-calendar-controller.js
+++ b/backend/modules/caldav/api/remote-calendar-controller.js
@@ -330,7 +330,7 @@ class RemoteCalendarController {
                 );
             }
 
-            await RemoteCalendarRepository.delete(remoteCalendar);
+            await RemoteCalendarRepository.destroy(remoteCalendar);
 
             res.status(204).send();
         } catch (error) {


### PR DESCRIPTION
## Description

CalDAV calendar deletion was broken because the controllers called `.delete()` on repository instances, but `BaseRepository` only exposes `.destroy()` for deletion. This caused a `TypeError: CalendarRepository.delete is not a function` error whenever a user tried to delete a calendar.

Fixed in both the local calendar controller and the remote calendar controller.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1169

## Testing

- Verified the method name against `BaseRepository` — `destroy(instance)` is the correct method
- Checked all other `.delete()` calls in the CalDAV module; the one in `task-handlers.js` calls a separate `taskRepository` that has its own custom `delete` method, so it is unaffected

**Commands run:**
```
npm run lint
```

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] Linting passes

## Additional Notes

Both `calendar-controller.js` and `remote-calendar-controller.js` had the same typo. The fix is a straightforward one-line change in each file.