### PR TITLE
fix(cors): add x-csrf-token to CORS allowedHeaders

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -101,6 +101,7 @@ app.use(
             'Content-Type',
             'Accept',
             'X-Requested-With',
+            'x-csrf-token',
             'Depth',
             'If-Match',
             'If-None-Match',


### PR DESCRIPTION
## Description

The `x-csrf-token` header introduced in v1.1.0 for CSRF protection was missing from the CORS `allowedHeaders` list in `backend/app.js`. In reverse-proxy deployments (e.g. Pikapods), some browsers — notably Vivaldi — enforce CORS preflight checks even for requests that appear same-origin from the server's perspective. Because `x-csrf-token` was not listed as an allowed request header, these preflight responses did not include it in `Access-Control-Allow-Headers`, causing the browser to block the subsequent POST request entirely.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1185

## Testing

- The CORS `allowedHeaders` list now explicitly includes `x-csrf-token`, matching the header sent by the frontend on all state-changing requests.
- Lint passes: `npm run lint`
- No functional change for same-origin requests or other browsers; this unblocks browsers that enforce strict CORS preflight validation.

## Checklist

- [x] My code follows the existing code style
- [x] I have run the linter (`npm run lint`)
- [x] This change is backward-compatible

## Additional Notes

The root symptom was "Error creating task" in Vivaldi on Pikapods after upgrading to 1.1.0 — the version that introduced CSRF token requirements for POST requests. Chromium was unaffected because it is more lenient about CORS preflight headers for requests it considers same-origin. Adding `x-csrf-token` to `allowedHeaders` is the correct fix and good hygiene regardless.