### PR TITLE
fix(static): serve from dist when index.html exists, regardless of NODE_ENV

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 const cors = require('cors');
 const helmet = require('helmet');
 const compression = require('compression');
@@ -15,6 +16,8 @@ const taskScheduler = require('./modules/tasks/taskScheduler');
 const { initializeEmailService } = require('./services/emailService');
 const { setConfig, getConfig } = require('./config/config');
 const config = getConfig();
+const distIndexPath = path.join(__dirname, 'dist', 'index.html');
+const serveFromDist = config.production || fs.existsSync(distIndexPath);
 const API_VERSION = process.env.API_VERSION || 'v1';
 const API_BASE_PATH = `/api/${API_VERSION}`;
 
@@ -190,14 +193,14 @@ app.use((req, res, next) => {
 });
 
 // Static files
-if (config.production) {
+if (serveFromDist) {
     app.use(express.static(path.join(__dirname, 'dist')));
 } else {
     app.use(express.static('public'));
 }
 
 // Serve locales
-if (config.production) {
+if (serveFromDist) {
     app.use('/locales', express.static(path.join(__dirname, 'dist/locales')));
 } else {
     app.use(
@@ -350,7 +353,7 @@ app.get('*', (req, res) => {
         !req.path.startsWith('/api/') &&
         !req.path.match(/\.(js|css|png|jpg|jpeg|gif|ico|svg)$/)
     ) {
-        if (config.production) {
+        if (serveFromDist) {
             res.sendFile(path.join(__dirname, 'dist', 'index.html'));
         } else {
             res.sendFile(path.join(__dirname, '../public', 'index.html'));


### PR DESCRIPTION
## Description

When `NODE_ENV` is overridden to a non-production value in a Docker deployment (e.g. for debugging), the app previously tried to serve static files from the `public/` directory, which does not exist in the Docker image. This caused an `ENOENT: no such file or directory, stat '/app/public/index.html'` error and a white screen for all users.

The root fix: at startup, check whether `dist/index.html` actually exists on disk and use that as the authoritative signal for which directory to serve from. `NODE_ENV=production` is kept as a secondary signal for the case where `dist` hasn't been built yet (pure development mode).

This affects three places in `app.js`: the static middleware, the `/locales` static middleware, and the SPA catch-all route.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1184

## Testing

- Existing backend test suite passes (3 pre-existing flaky integration test failures unrelated to this change)
- Linting passes clean
- Logic: `serveFromDist = config.production || fs.existsSync(distIndexPath)` — Docker images always have `dist/index.html` built in, so they will always serve from `dist` regardless of `NODE_ENV`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [x] No new warnings introduced
- [x] Related issues are linked

## Additional Notes

The Dockerfile already sets `NODE_ENV=production` by default, but users can and do override it (e.g. `NODE_ENV=development` or `NODE_ENV=dev` in their docker-compose). This fix makes the app resilient to that override by detecting the built assets directly.