### PR TITLE
Corrected localization file path in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -252,7 +252,7 @@ tududi supports multiple languages via i18next.
 ### Adding/Updating Translations
 
 1. **Add keys to English** (source of truth):
-   `frontend/locales/en/translation.json`
+   `public/locales/en/translation.json`
 
 2. **Sync translations**
    ```bash


### PR DESCRIPTION
Changed the location of the localization file to reflect current directory

## Description

It seems that the localization files are stored in "public" and not in "frontend"

## Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [x] Documentation/Translation update

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [ ] Code follows project style guidelines
- [x] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [x] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

Did not run the mandatory formatting / testing steps since the only affected file is a markdown document
