### PR TITLE
feat(tags): pinned tags with quick-access chips in tag input

### DIFF
--- a/backend/migrations/20260619000001-add-pinned-to-tags.js
+++ b/backend/migrations/20260619000001-add-pinned-to-tags.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const tableDesc = await queryInterface.describeTable('tags');
+        if (!tableDesc.pinned) {
+            await queryInterface.addColumn('tags', 'pinned', {
+                type: Sequelize.BOOLEAN,
+                allowNull: false,
+                defaultValue: false,
+            });
+        }
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeColumn('tags', 'pinned');
+    },
+};

--- a/backend/models/tag.js
+++ b/backend/models/tag.js
@@ -33,6 +33,11 @@ module.exports = (sequelize) => {
                 allowNull: false,
                 defaultValue: 'user',
             },
+            pinned: {
+                type: DataTypes.BOOLEAN,
+                allowNull: false,
+                defaultValue: false,
+            },
         },
         {
             tableName: 'tags',

--- a/backend/modules/tags/controller.js
+++ b/backend/modules/tags/controller.js
@@ -58,11 +58,11 @@ const tagsController = {
     async update(req, res, next) {
         try {
             const { identifier } = req.params;
-            const { name } = req.body;
+            const { name, pinned } = req.body;
             const tag = await tagsService.update(
                 req.currentUser.id,
                 identifier,
-                name
+                { name, pinned }
             );
             res.json(tag);
         } catch (error) {

--- a/backend/modules/tags/repository.js
+++ b/backend/modules/tags/repository.js
@@ -15,7 +15,23 @@ class TagsRepository extends BaseRepository {
     async findAllByUser(userId) {
         return this.model.findAll({
             where: { user_id: userId },
-            attributes: ['id', 'uid', 'name', 'tag_type'],
+            attributes: [
+                'id',
+                'uid',
+                'name',
+                'tag_type',
+                'pinned',
+                [
+                    sequelize.literal(`(
+                        SELECT COUNT(*) FROM tasks_tags WHERE tasks_tags.tag_id = "Tag"."id"
+                    ) + (
+                        SELECT COUNT(*) FROM notes_tags WHERE notes_tags.tag_id = "Tag"."id"
+                    ) + (
+                        SELECT COUNT(*) FROM projects_tags WHERE projects_tags.tag_id = "Tag"."id"
+                    )`),
+                    'usage_count',
+                ],
+            ],
             order: [[sequelize.fn('LOWER', sequelize.col('name')), 'ASC']],
         });
     }
@@ -38,7 +54,7 @@ class TagsRepository extends BaseRepository {
     async findByUid(userId, uid) {
         return this.model.findOne({
             where: { user_id: userId, uid },
-            attributes: ['id', 'uid', 'name', 'tag_type'],
+            attributes: ['id', 'uid', 'name', 'tag_type', 'pinned'],
         });
     }
 

--- a/backend/modules/tags/service.js
+++ b/backend/modules/tags/service.js
@@ -18,6 +18,8 @@ class TagsService {
             uid: tag.uid,
             name: tag.name,
             tag_type: tag.tag_type,
+            pinned: tag.pinned,
+            usage_count: Number(tag.get('usage_count') ?? 0),
         }));
     }
 
@@ -44,6 +46,7 @@ class TagsService {
             uid: tag.uid,
             name: tag.name,
             tag_type: tag.tag_type,
+            pinned: tag.pinned,
         };
     }
 
@@ -69,9 +72,9 @@ class TagsService {
     }
 
     /**
-     * Update a tag's name.
+     * Update a tag's name and/or pinned state.
      */
-    async update(userId, identifier, newName) {
+    async update(userId, identifier, { name, pinned } = {}) {
         const decodedIdentifier = decodeURIComponent(identifier);
         const tag = await tagsRepository.findByIdentifier(
             userId,
@@ -82,31 +85,41 @@ class TagsService {
             throw new NotFoundError('Tag not found');
         }
 
-        if (tag.tag_type === 'system') {
-            throw new ForbiddenError('System tags cannot be renamed');
-        }
+        const updates = {};
 
-        const validatedName = validateTagName(newName);
-
-        // Check for name conflict if changing name
-        if (validatedName !== tag.name) {
-            const exists = await tagsRepository.nameExists(
-                userId,
-                validatedName,
-                tag.id
-            );
-            if (exists) {
-                throw new ConflictError(
-                    `A tag with the name "${validatedName}" already exists.`
-                );
+        if (name !== undefined) {
+            if (tag.tag_type === 'system') {
+                // Silently ignore name field for system tags — the form always sends it
+            } else {
+                const validatedName = validateTagName(name);
+                if (validatedName !== tag.name) {
+                    const exists = await tagsRepository.nameExists(
+                        userId,
+                        validatedName,
+                        tag.id
+                    );
+                    if (exists) {
+                        throw new ConflictError(
+                            `A tag with the name "${validatedName}" already exists.`
+                        );
+                    }
+                    updates.name = validatedName;
+                }
             }
         }
 
-        await tagsRepository.update(tag, { name: validatedName });
+        if (pinned !== undefined) {
+            updates.pinned = Boolean(pinned);
+        }
+
+        if (Object.keys(updates).length > 0) {
+            await tagsRepository.update(tag, updates);
+        }
 
         return {
             id: tag.id,
-            name: tag.name,
+            name: updates.name ?? tag.name,
+            pinned: updates.pinned !== undefined ? updates.pinned : tag.pinned,
         };
     }
 

--- a/frontend/components/Project/ProjectItem.tsx
+++ b/frontend/components/Project/ProjectItem.tsx
@@ -261,8 +261,8 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
         <div
             className={`${
                 viewMode === 'cards'
-                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-gray-300 dark:hover:border-gray-600 transition-[border-color] duration-150 ease-in-out'
-                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-gray-300 dark:hover:border-gray-600 transition-[border-color] duration-150 ease-in-out'
+                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-blue-300 dark:hover:border-blue-700 transition-[border-color] duration-150 ease-in-out'
+                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-blue-300 dark:hover:border-blue-700 transition-[border-color] duration-150 ease-in-out'
             }`}
             style={{
                 minHeight: viewMode === 'cards' ? '260px' : 'auto',

--- a/frontend/components/Project/ProjectItem.tsx
+++ b/frontend/components/Project/ProjectItem.tsx
@@ -261,8 +261,8 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
         <div
             className={`${
                 viewMode === 'cards'
-                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-blue-600 dark:hover:border-blue-950 transition-[border-color] duration-150 ease-in-out'
-                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-blue-600 dark:hover:border-blue-950 transition-[border-color] duration-150 ease-in-out'
+                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-blue-600 dark:hover:border-blue-900 transition-[border-color] duration-150 ease-in-out'
+                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-blue-600 dark:hover:border-blue-900 transition-[border-color] duration-150 ease-in-out'
             }`}
             style={{
                 minHeight: viewMode === 'cards' ? '260px' : 'auto',

--- a/frontend/components/Project/ProjectItem.tsx
+++ b/frontend/components/Project/ProjectItem.tsx
@@ -261,8 +261,8 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
         <div
             className={`${
                 viewMode === 'cards'
-                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-blue-600 dark:hover:border-blue-500 transition-[border-color] duration-150 ease-in-out'
-                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-blue-600 dark:hover:border-blue-500 transition-[border-color] duration-150 ease-in-out'
+                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-blue-600 dark:hover:border-blue-800 transition-[border-color] duration-150 ease-in-out'
+                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-blue-600 dark:hover:border-blue-800 transition-[border-color] duration-150 ease-in-out'
             }`}
             style={{
                 minHeight: viewMode === 'cards' ? '260px' : 'auto',

--- a/frontend/components/Project/ProjectItem.tsx
+++ b/frontend/components/Project/ProjectItem.tsx
@@ -261,8 +261,8 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
         <div
             className={`${
                 viewMode === 'cards'
-                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-blue-300 dark:hover:border-blue-700 transition-[border-color] duration-150 ease-in-out'
-                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-blue-300 dark:hover:border-blue-700 transition-[border-color] duration-150 ease-in-out'
+                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-blue-600 dark:hover:border-blue-500 transition-[border-color] duration-150 ease-in-out'
+                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-blue-600 dark:hover:border-blue-500 transition-[border-color] duration-150 ease-in-out'
             }`}
             style={{
                 minHeight: viewMode === 'cards' ? '260px' : 'auto',

--- a/frontend/components/Project/ProjectItem.tsx
+++ b/frontend/components/Project/ProjectItem.tsx
@@ -261,8 +261,8 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
         <div
             className={`${
                 viewMode === 'cards'
-                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-blue-600 dark:hover:border-blue-800 transition-[border-color] duration-150 ease-in-out'
-                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-blue-600 dark:hover:border-blue-800 transition-[border-color] duration-150 ease-in-out'
+                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-blue-600 dark:hover:border-blue-950 transition-[border-color] duration-150 ease-in-out'
+                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-blue-600 dark:hover:border-blue-950 transition-[border-color] duration-150 ease-in-out'
             }`}
             style={{
                 minHeight: viewMode === 'cards' ? '260px' : 'auto',

--- a/frontend/components/Project/ProjectItem.tsx
+++ b/frontend/components/Project/ProjectItem.tsx
@@ -261,8 +261,8 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
         <div
             className={`${
                 viewMode === 'cards'
-                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group'
-                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group'
+                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-gray-300 dark:hover:border-gray-600 transition-[border-color] duration-150 ease-in-out'
+                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-gray-300 dark:hover:border-gray-600 transition-[border-color] duration-150 ease-in-out'
             }`}
             style={{
                 minHeight: viewMode === 'cards' ? '260px' : 'auto',

--- a/frontend/components/Project/ProjectItem.tsx
+++ b/frontend/components/Project/ProjectItem.tsx
@@ -261,8 +261,8 @@ const ProjectItem: React.FC<ProjectItemProps> = ({
         <div
             className={`${
                 viewMode === 'cards'
-                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group border border-transparent hover:border-blue-600 dark:hover:border-blue-900 transition-[border-color] duration-150 ease-in-out'
-                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group border border-transparent hover:border-blue-600 dark:hover:border-blue-900 transition-[border-color] duration-150 ease-in-out'
+                    ? 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-col group ring-1 ring-transparent hover:ring-blue-600 dark:hover:ring-blue-900 transition-shadow duration-150 ease-in-out'
+                    : 'bg-gray-50 dark:bg-gray-900 rounded-lg shadow-md relative flex flex-row items-center p-4 group ring-1 ring-transparent hover:ring-blue-600 dark:hover:ring-blue-900 transition-shadow duration-150 ease-in-out'
             }`}
             style={{
                 minHeight: viewMode === 'cards' ? '260px' : 'auto',

--- a/frontend/components/Project/ProjectModal.tsx
+++ b/frontend/components/Project/ProjectModal.tsx
@@ -90,7 +90,6 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
         }
     }, [isOpen]);
 
-    // Load tags only when user actually interacts with tag input to prevent refresh
     const handleTagInputFocus = () => {
         if (!tagsStore.hasLoaded && !tagsStore.isLoading) {
             tagsStore.loadTags();
@@ -392,6 +391,10 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
 
     const toggleSection = useCallback(
         (section: keyof typeof expandedSections) => {
+            // Load tags eagerly when the tags section is opened so quick-access chips appear
+            if (section === 'tags' && !tagsStore.hasLoaded && !tagsStore.isLoading) {
+                tagsStore.loadTags();
+            }
             setExpandedSections((prev) => {
                 const newExpanded = {
                     ...prev,

--- a/frontend/components/Tag/TagInput.tsx
+++ b/frontend/components/Tag/TagInput.tsx
@@ -187,15 +187,16 @@ const TagInput: React.FC<TagInputProps> = ({
         onTagsChange(updatedTags);
     };
 
-    // Compute quick-access tags: pinned first, then fall back to top used
+    // Compute quick-access tags: pinned first, then top 5 by usage (alphabetical when tied)
     const quickTags = (() => {
         const unselected = availableTags.filter((t) => !tags.includes(t.name));
         const pinned = unselected.filter((t) => t.pinned);
         if (pinned.length > 0) return pinned.slice(0, MAX_QUICK_TAGS);
+        // Sort by usage desc; backend already returns alphabetical order so ties stay sorted
         const byUsage = [...unselected].sort(
             (a, b) => (b.usage_count ?? 0) - (a.usage_count ?? 0)
         );
-        return byUsage.slice(0, MAX_QUICK_TAGS).filter((t) => (t.usage_count ?? 0) > 0);
+        return byUsage.slice(0, MAX_QUICK_TAGS);
     })();
 
     return (

--- a/frontend/components/Tag/TagInput.tsx
+++ b/frontend/components/Tag/TagInput.tsx
@@ -224,9 +224,7 @@ const TagInput: React.FC<TagInputProps> = ({
 
             <div
                 ref={containerRef}
-                className={`flex flex-wrap items-start gap-2 border border-gray-300 dark:border-gray-900 bg-white dark:bg-gray-900 rounded-md px-2 min-h-[40px] ${
-                    tags.length > 3 ? 'py-3' : 'py-2'
-                }`}
+                className="flex flex-wrap items-center gap-2 border border-gray-300 dark:border-gray-900 bg-white dark:bg-gray-900 rounded-md px-2 min-h-[40px] py-2"
             >
                 {tags.length > 0 ? (
                     tags.map((tag, index) => (
@@ -245,9 +243,7 @@ const TagInput: React.FC<TagInputProps> = ({
                             </button>
                         </span>
                     ))
-                ) : (
-                    <span className="text-gray-400 text-xs"></span>
-                )}
+                ) : null}
 
                 <input
                     type="text"

--- a/frontend/components/Tag/TagInput.tsx
+++ b/frontend/components/Tag/TagInput.tsx
@@ -9,6 +9,8 @@ interface TagInputProps {
     onFocus?: () => void;
 }
 
+const MAX_QUICK_TAGS = 5;
+
 const TagInput: React.FC<TagInputProps> = ({
     initialTags,
     onTagsChange,
@@ -27,12 +29,8 @@ const TagInput: React.FC<TagInputProps> = ({
 
     // Update internal tags state when initialTags prop changes
     useEffect(() => {
-        // Always set tags to match initialTags, even if empty
         setTags(initialTags || []);
     }, [initialTags]);
-
-    // Remove this effect to prevent infinite loops
-    // onTagsChange is called directly in addNewTag, selectTag, and removeTag
 
     useEffect(() => {
         const handler = setTimeout(() => {
@@ -52,11 +50,9 @@ const TagInput: React.FC<TagInputProps> = ({
             setIsDropdownOpen(shouldOpen);
             setHighlightedIndex(-1);
 
-            // Auto-scroll to show dropdown when it opens
             if (shouldOpen) {
                 setTimeout(() => {
                     if (containerRef.current) {
-                        // Find the modal's scroll container
                         const modalScrollContainer =
                             containerRef.current.closest(
                                 '.absolute.inset-0.overflow-y-auto'
@@ -67,14 +63,12 @@ const TagInput: React.FC<TagInputProps> = ({
                             containerRef.current.closest('.overflow-y-auto');
 
                         if (modalScrollContainer) {
-                            // Get the position of the TagInput container relative to the scroll container
                             const containerRect =
                                 containerRef.current.getBoundingClientRect();
                             const scrollRect =
                                 modalScrollContainer.getBoundingClientRect();
 
-                            // Calculate how much to scroll to show the dropdown
-                            const dropdownHeight = 240; // max-h-60 = 240px
+                            const dropdownHeight = 240;
                             const neededSpace =
                                 containerRect.bottom -
                                 scrollRect.top +
@@ -83,14 +77,13 @@ const TagInput: React.FC<TagInputProps> = ({
 
                             if (neededSpace > availableSpace) {
                                 const scrollAmount =
-                                    neededSpace - availableSpace + 20; // 20px padding
+                                    neededSpace - availableSpace + 20;
                                 modalScrollContainer.scrollBy({
                                     top: scrollAmount,
                                     behavior: 'smooth',
                                 });
                             }
                         } else {
-                            // Fallback to scrollIntoView if modal container not found
                             containerRef.current.scrollIntoView({
                                 behavior: 'smooth',
                                 block: 'nearest',
@@ -155,7 +148,6 @@ const TagInput: React.FC<TagInputProps> = ({
                 addNewTag(inputValue.trim());
             }
         } else if (event.key === 'Backspace') {
-            // Remove the last tag if input is empty and there are tags
             if (inputValue === '' && tags.length > 0) {
                 event.preventDefault();
                 const updatedTags = tags.slice(0, -1);
@@ -195,8 +187,40 @@ const TagInput: React.FC<TagInputProps> = ({
         onTagsChange(updatedTags);
     };
 
+    // Compute quick-access tags: pinned first, then fall back to top used
+    const quickTags = (() => {
+        const unselected = availableTags.filter((t) => !tags.includes(t.name));
+        const pinned = unselected.filter((t) => t.pinned);
+        if (pinned.length > 0) return pinned.slice(0, MAX_QUICK_TAGS);
+        const byUsage = [...unselected].sort(
+            (a, b) => (b.usage_count ?? 0) - (a.usage_count ?? 0)
+        );
+        return byUsage.slice(0, MAX_QUICK_TAGS).filter((t) => (t.usage_count ?? 0) > 0);
+    })();
+
     return (
         <div className="space-y-2 relative">
+            {/* Quick-access tag chips */}
+            {quickTags.length > 0 && inputValue.trim() === '' && (
+                <div className="flex flex-wrap gap-1.5">
+                    {quickTags.map((tag) => (
+                        <button
+                            key={tag.uid ?? tag.name}
+                            type="button"
+                            onClick={() => selectTag(tag.name)}
+                            className="flex items-center gap-1 text-xs px-2 py-0.5 rounded border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 text-gray-600 dark:text-gray-400 hover:bg-blue-50 hover:border-blue-400 hover:text-blue-700 dark:hover:bg-blue-900/30 dark:hover:border-blue-600 dark:hover:text-blue-300 transition-colors duration-100"
+                            title={
+                                tag.pinned
+                                    ? t('tags.pinnedTag', 'Pinned tag')
+                                    : t('tags.frequentlyUsed', 'Frequently used')
+                            }
+                        >
+                            {tag.name}
+                        </button>
+                    ))}
+                </div>
+            )}
+
             <div
                 ref={containerRef}
                 className={`flex flex-wrap items-start gap-2 border border-gray-300 dark:border-gray-900 bg-white dark:bg-gray-900 rounded-md px-2 min-h-[40px] ${
@@ -283,7 +307,6 @@ const TagInput: React.FC<TagInputProps> = ({
                             )}
                         </button>
                     ))}
-                    {/* Option to add a new tag if no matches */}
                     {filteredTags.length === 0 && inputValue.trim() !== '' && (
                         <button
                             type="button"

--- a/frontend/components/Tag/TagModal.tsx
+++ b/frontend/components/Tag/TagModal.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Tag } from '../../entities/Tag';
 import { TrashIcon } from '@heroicons/react/24/outline';
+import { MapPinIcon } from '@heroicons/react/24/solid';
 import { useToast } from '../Shared/ToastContext';
 import { useTranslation } from 'react-i18next';
 import DiscardChangesDialog from '../Shared/DiscardChangesDialog';
@@ -146,12 +147,9 @@ const TagModal: React.FC<TagModalProps> = ({
     // Check if there are unsaved changes
     const hasUnsavedChanges = () => {
         if (!tag) {
-            // New tag - check if name has been filled
             return formData.name.trim() !== '';
         }
-
-        // Existing tag - compare with original
-        return formData.name !== tag.name;
+        return formData.name !== tag.name || formData.pinned !== tag.pinned;
     };
 
     // Use ref to store hasUnsavedChanges so it's always current in the event handler
@@ -220,7 +218,7 @@ const TagModal: React.FC<TagModalProps> = ({
                             >
                                 <fieldset>
                                     {/* Tag Title Section - Always Visible */}
-                                    <div className="px-4 pt-4 pb-4">
+                                    <div className="px-4 pt-4 pb-2">
                                         <input
                                             ref={nameInputRef}
                                             type="text"
@@ -241,6 +239,29 @@ const TagModal: React.FC<TagModalProps> = ({
                                             )}
                                             data-testid="tag-name-input"
                                         />
+                                    </div>
+                                    {/* Pinned toggle */}
+                                    <div className="px-4 pb-4">
+                                        <button
+                                            type="button"
+                                            onClick={() =>
+                                                setFormData((prev) => ({
+                                                    ...prev,
+                                                    pinned: !prev.pinned,
+                                                }))
+                                            }
+                                            className={`flex items-center gap-2 text-sm rounded-md px-3 py-1.5 transition-colors duration-150 ${
+                                                formData.pinned
+                                                    ? 'bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border border-blue-300 dark:border-blue-700'
+                                                    : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400 border border-gray-200 dark:border-gray-600 hover:bg-gray-200 dark:hover:bg-gray-600'
+                                            }`}
+                                            data-testid="tag-pin-toggle"
+                                        >
+                                            <MapPinIcon className="h-3.5 w-3.5" />
+                                            {formData.pinned
+                                                ? t('tags.pinned', 'Pinned for quick access')
+                                                : t('tags.pinTag', 'Pin for quick access')}
+                                        </button>
                                     </div>
                                 </fieldset>
                             </form>
@@ -269,26 +290,24 @@ const TagModal: React.FC<TagModalProps> = ({
                                 </button>
                             </div>
 
-                            {/* Right side: Save (hidden for system tags) */}
-                            {tag?.tag_type !== 'system' && (
-                                <button
-                                    type="button"
-                                    onClick={handleSubmit}
-                                    disabled={isSubmitting}
-                                    className={`px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 focus:outline-none transition duration-150 ease-in-out text-sm ${
-                                        isSubmitting
-                                            ? 'opacity-50 cursor-not-allowed'
-                                            : ''
-                                    }`}
-                                    data-testid="tag-save-button"
-                                >
-                                    {isSubmitting
-                                        ? t('modals.submitting', 'Submitting...')
-                                        : tag
-                                          ? t('modals.updateTag', 'Update Tag')
-                                          : t('modals.createTag', 'Create Tag')}
-                                </button>
-                            )}
+                            {/* Right side: Save */}
+                            <button
+                                type="button"
+                                onClick={handleSubmit}
+                                disabled={isSubmitting}
+                                className={`px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 focus:outline-none transition duration-150 ease-in-out text-sm ${
+                                    isSubmitting
+                                        ? 'opacity-50 cursor-not-allowed'
+                                        : ''
+                                }`}
+                                data-testid="tag-save-button"
+                            >
+                                {isSubmitting
+                                    ? t('modals.submitting', 'Submitting...')
+                                    : tag
+                                      ? t('modals.updateTag', 'Update Tag')
+                                      : t('modals.createTag', 'Create Tag')}
+                            </button>
                         </div>
                     </div>
                 </div>

--- a/frontend/components/Tags.tsx
+++ b/frontend/components/Tags.tsx
@@ -6,6 +6,7 @@ import {
     MagnifyingGlassIcon,
     PencilSquareIcon,
     LockClosedIcon,
+    MapPinIcon,
 } from '@heroicons/react/24/solid';
 import ConfirmDialog from './Shared/ConfirmDialog';
 import TagModal from './Tag/TagModal';
@@ -61,7 +62,9 @@ const Tags: React.FC = () => {
             if (tagData.uid) {
                 await updateTag(tagData.uid, tagData);
                 setTags(
-                    tags.map((tag) => (tag.uid === tagData.uid ? tagData : tag))
+                    tags.map((tag) =>
+                        tag.uid === tagData.uid ? { ...tag, ...tagData } : tag
+                    )
                 );
             } else {
                 const newTag = await createTag(tagData);
@@ -274,11 +277,34 @@ const Tags: React.FC = () => {
 
                                                 {/* Action buttons */}
                                                 <div className="flex space-x-2 flex-shrink-0 items-center">
-                                                    {tag.tag_type === 'system' ? (
-                                                        <LockClosedIcon
-                                                            className="h-3.5 w-3.5 text-gray-300 dark:text-gray-600"
-                                                            title="System tag"
+                                                    {tag.pinned && (
+                                                        <MapPinIcon
+                                                            className="h-3.5 w-3.5 text-blue-400 dark:text-blue-500"
+                                                            title={t('tags.pinned', 'Pinned for quick access')}
                                                         />
+                                                    )}
+                                                    {tag.tag_type === 'system' ? (
+                                                        <>
+                                                            <LockClosedIcon
+                                                                className="h-3.5 w-3.5 text-gray-300 dark:text-gray-600"
+                                                                title={t('tags.systemTag', 'System tag')}
+                                                            />
+                                                            <button
+                                                                onClick={() =>
+                                                                    handleEditTag(tag)
+                                                                }
+                                                                className={`text-gray-500 hover:text-blue-700 dark:hover:text-blue-300 focus:outline-none transition-opacity duration-200 ${
+                                                                    hoveredTagUid ===
+                                                                    tag.uid
+                                                                        ? 'opacity-100'
+                                                                        : 'opacity-0 pointer-events-none'
+                                                                }`}
+                                                                aria-label={`Edit ${tag.name}`}
+                                                                title={t('tags.editPinSetting', 'Edit pin setting')}
+                                                            >
+                                                                <PencilSquareIcon className="h-4 w-4" />
+                                                            </button>
+                                                        </>
                                                     ) : (
                                                         <>
                                                             <button

--- a/frontend/entities/Tag.ts
+++ b/frontend/entities/Tag.ts
@@ -3,4 +3,6 @@ export interface Tag {
     uid?: string;
     name: string;
     tag_type?: 'system' | 'user';
+    pinned?: boolean;
+    usage_count?: number;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,8 +42,10 @@ module.exports = {
         historyApiFallback: true,
         proxy: [
             {
-                context: ['/api', '/locales'],
-                target: backendUrl,
+                // HPM v3: use pathFilter + router so WDS calls createProxyMiddleware(options)
+                // instead of the v2 two-argument form createProxyMiddleware(context, options)
+                pathFilter: ['/api', '/locales'],
+                router: () => backendUrl,
                 changeOrigin: true,
                 secure: false,
                 cookieDomainRewrite: frontendCookieDomain,


### PR DESCRIPTION
## Description

Adds pinned tags with quick-access chips across all tag inputs (tasks, projects, notes), fixes the webpack dev server proxy for http-proxy-middleware v3, and adds a hover ring effect on project cards.

## Changes

### Pinned Tags / Quick-Access Chips
- DB migration: `pinned BOOLEAN DEFAULT false` on `tags` table
- Repository: `pinned` in attributes + `usage_count` subquery across junction tables
- Service/controller: `update()` accepts `{ name, pinned }`; system tags can be pinned but not renamed
- `Tag` entity: `pinned?: boolean`, `usage_count?: number`
- `TagInput`: quick-access chip row above the input — pinned tags first (up to 5), falls back to top-5 by usage count; always shows chips even when usage counts are all zero (alphabetical fallback)
- `TagModal`: "Pin for quick access" toggle; Save button shown for all tags including system tags
- `ProjectModal`: loads tags when the Tags section is opened (not just on input focus) so chips appear immediately
- `Tags` list page: blue pin icon on pinned tags; system tags get an edit button on hover for pin access
- Placeholder text vertically centered in tag input

### Webpack Proxy Fix
- Updated proxy config to use `pathFilter` + `router` (HPM v3 single-arg form) instead of `context` + `target` (HPM v2 two-arg form) — fixes startup crash after Dependabot upgraded http-proxy-middleware to v3

### Project Cards Hover Effect
- Subtle blue ring (`ring-1`) fades in/out on hover over project cards in both card and list view
- Uses `ring` (box-shadow) instead of `border` so corners align perfectly with the card's border-radius
- `ring-blue-600` light / `ring-blue-900` dark, `duration-150` fade

## Type of Change

- [x] New feature
- [x] Bug fix

## Testing

```bash
NODE_ENV=development npm run migration:run
npm start
```

- Pin a tag via Tags page → edit modal → "Pin for quick access"
- Open a task/project/note form → pinned tags appear as chips above the tag input
- Hover over project cards → blue ring fades in and out, corners aligned
- Dev server starts without proxy errors

## Checklist

- [x] Lint passes (`npm run lint`)
- [x] Migration is idempotent
- [x] Light and dark mode tested