### PR TITLE
fix(webpack): update proxy config for http-proxy-middleware v3

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -42,8 +42,10 @@ module.exports = {
         historyApiFallback: true,
         proxy: [
             {
-                context: ['/api', '/locales'],
-                target: backendUrl,
+                // HPM v3: use pathFilter + router so WDS calls createProxyMiddleware(options)
+                // instead of the v2 two-argument form createProxyMiddleware(context, options)
+                pathFilter: ['/api', '/locales'],
+                router: () => backendUrl,
                 changeOrigin: true,
                 secure: false,
                 cookieDomainRewrite: frontendCookieDomain,


### PR DESCRIPTION
## Description

Fixes the webpack-dev-server startup error introduced after the Dependabot security fix that upgraded `http-proxy-middleware` from v2 to v3 via `package.json` overrides.

**Root cause:** WDS 5.x calls `createProxyMiddleware(context, options)` (HPM v2 two-arg form) when a `target` property is present in the proxy config. HPM v3 removed the two-arg form — it received the context array as options and threw:

```
[HPM] Missing "target" option. Example: {target: "http://www.example.org"}
```

**Fix:** Replace `context` + `target` with `pathFilter` + `router` in the webpack proxy config. WDS's code falls through to its `proxyConfig.router` branch and calls `createProxyMiddleware(proxyConfig)` (the single-arg form HPM v3 expects). Proxy behaviour is identical — `pathFilter` replaces `context` for path matching, `router` provides the target URL.

## Type of Change

- [x] Bug fix

## Related Issues

Caused by the HPM v3 override added in #1201 (Dependabot security fixes).

## Testing

```bash
npm start  # frontend should start without proxy error on :8080
```
Verify `/api` requests are correctly proxied to `:3002`.

## Checklist

- [x] Code follows project conventions
- [x] Lint passes (`npm run lint`)
- [x] No behaviour change — same paths proxied to same backend URL