### PR TITLE
feat(kanban): add Kanban board with feature toggle and fix settings persistence

### DIFF
--- a/backend/migrations/20260619000002-add-kanban-enabled-to-users.js
+++ b/backend/migrations/20260619000002-add-kanban-enabled-to-users.js
@@ -1,0 +1,38 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface) {
+        const [users] = await queryInterface.sequelize.query(
+            `SELECT id, features FROM users WHERE features IS NOT NULL`
+        );
+
+        for (const user of users) {
+            let features;
+            try {
+                features =
+                    typeof user.features === 'string'
+                        ? JSON.parse(user.features)
+                        : user.features;
+            } catch {
+                features = {};
+            }
+
+            if (!('kanban_enabled' in features)) {
+                features.kanban_enabled = false;
+                await queryInterface.sequelize.query(
+                    'UPDATE users SET features = :features WHERE id = :id',
+                    {
+                        replacements: {
+                            features: JSON.stringify(features),
+                            id: user.id,
+                        },
+                    }
+                );
+            }
+        }
+    },
+
+    async down() {
+        // No rollback — removing a key from JSON is destructive and not needed
+    },
+};

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -135,6 +135,7 @@ module.exports = (sequelize) => {
                     next_task_suggestion_enabled: true,
                     pomodoro_enabled: true,
                     eisenhower_enabled: false,
+                    kanban_enabled: false,
                 },
             },
             today_settings: {

--- a/backend/modules/auth/service.js
+++ b/backend/modules/auth/service.js
@@ -138,6 +138,14 @@ class AuthService {
             });
             if (user) {
                 const admin = await isAdmin(user.uid);
+                let features = user.features;
+                if (features && typeof features === 'string') {
+                    try {
+                        features = JSON.parse(features);
+                    } catch {
+                        features = {};
+                    }
+                }
                 return {
                     user: {
                         uid: user.uid,
@@ -148,7 +156,7 @@ class AuthService {
                         appearance: user.appearance,
                         timezone: user.timezone,
                         avatar_image: user.avatar_image,
-                        features: user.features || {},
+                        features: features || {},
                         is_admin: admin,
                     },
                 };

--- a/backend/modules/users/service.js
+++ b/backend/modules/users/service.js
@@ -7,6 +7,7 @@ const FEATURE_KEYS = [
     'next_task_suggestion_enabled',
     'pomodoro_enabled',
     'eisenhower_enabled',
+    'kanban_enabled',
 ];
 
 function sanitizeFeatures(raw) {

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -28,6 +28,7 @@ import InboxItems from './components/Inbox/InboxItems';
 import Habits from './components/Habits/Habits';
 import HabitDetails from './components/Habits/HabitDetails';
 import EisenhowerMatrix from './components/Eisenhower/EisenhowerMatrix';
+import KanbanBoard from './components/Kanban/KanbanBoard';
 import { setCurrentUser as setUserInStorage } from './utils/userUtils';
 import { getApiPath, getLocalesPath } from './config/paths';
 import { useStore } from './store/useStore';
@@ -66,6 +67,9 @@ const App: React.FC = () => {
                 setUserInStorage(data.user);
                 useStore.getState().userSettingsStore.setEisenhowerEnabled(
                     data.user.features?.eisenhower_enabled === true
+                );
+                useStore.getState().userSettingsStore.setKanbanEnabled(
+                    data.user.features?.kanban_enabled === true
                 );
             } else {
                 setCurrentUser(null);
@@ -231,6 +235,7 @@ const App: React.FC = () => {
                                 }
                             />
                             <Route path="/eisenhower" element={<EisenhowerMatrix />} />
+                            <Route path="/kanban" element={<KanbanBoard />} />
                             <Route path="/inbox" element={<InboxItems />} />
                             <Route path="/habits" element={<Habits />} />
                             <Route

--- a/frontend/components/Kanban/KanbanBoard.tsx
+++ b/frontend/components/Kanban/KanbanBoard.tsx
@@ -1,0 +1,292 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useStore } from '../../store/useStore';
+import { getApiPath } from '../../config/paths';
+import { Task } from '../../entities/Task';
+import { Project } from '../../entities/Project';
+import TaskItem from '../Task/TaskItem';
+import { getCsrfToken } from '../../utils/csrfService';
+
+const COLUMN_STATUS: Record<string, number> = {
+    not_started: 0,
+    in_progress: 1,
+    waiting:     4,
+    done:        2,
+};
+
+const COLS = ['not_started', 'in_progress', 'waiting', 'done'] as const;
+type ColKey = (typeof COLS)[number];
+
+const getTaskColumn = (task: Task): ColKey | null => {
+    const s = task.status;
+    if (s === 'not_started' || s === 0 || s === 'planned' || s === 6) return 'not_started';
+    if (s === 'in_progress' || s === 1) return 'in_progress';
+    if (s === 'waiting' || s === 4) return 'waiting';
+    if (s === 'done' || s === 2) return 'done';
+    return null;
+};
+
+const KanbanBoard: React.FC = () => {
+    const { t } = useTranslation();
+    const projects: Project[] = useStore((state: any) => state.projectsStore.projects);
+
+    const [tasks, setTasks] = useState<Task[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const [draggingTaskId, setDraggingTaskId] = useState<number | null>(null);
+    const [dragOverCol, setDragOverCol] = useState<ColKey | null>(null);
+    const dragEnterCounters = useRef<Record<string, number>>({});
+
+    useEffect(() => {
+        const fetchTasks = async () => {
+            setLoading(true);
+            setError(null);
+            try {
+                const res = await fetch(
+                    getApiPath('tasks?client_side_filtering=true&limit=10000&offset=0')
+                );
+                if (!res.ok) throw new Error('Failed to fetch tasks');
+                const data = await res.json();
+                setTasks(data.tasks || []);
+            } catch (e) {
+                setError((e as Error).message);
+            } finally {
+                setLoading(false);
+            }
+        };
+        fetchTasks();
+    }, []);
+
+    const columns = useMemo(() => {
+        const filtered = tasks.filter((t) => {
+            const s = t.status;
+            return s !== 'archived' && s !== 3 && s !== 'cancelled' && s !== 5;
+        });
+
+        const result: Record<ColKey, Task[]> = {
+            not_started: [],
+            in_progress: [],
+            waiting:     [],
+            done:        [],
+        };
+
+        for (const task of filtered) {
+            const col = getTaskColumn(task);
+            if (col) result[col].push(task);
+        }
+        return result;
+    }, [tasks]);
+
+    const handleTaskUpdate = async (updatedTask: Task) => {
+        try {
+            const res = await fetch(getApiPath(`task/${updatedTask.uid}`), {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-csrf-token': await getCsrfToken(),
+                },
+                body: JSON.stringify(updatedTask),
+            });
+            if (res.ok) {
+                const saved = await res.json();
+                setTasks((prev) =>
+                    prev.map((t) => (t.id === updatedTask.id ? { ...t, ...saved } : t))
+                );
+            }
+        } catch (e) {
+            console.error('Error updating task:', e);
+        }
+    };
+
+    const handleTaskCompletionToggle = (updatedTask: Task) => {
+        setTasks((prev) =>
+            prev.map((t) => (t.id === updatedTask.id ? updatedTask : t))
+        );
+    };
+
+    const handleTaskDelete = async (taskUid: string) => {
+        try {
+            const res = await fetch(getApiPath(`task/${encodeURIComponent(taskUid)}`), {
+                method: 'DELETE',
+                headers: { 'x-csrf-token': await getCsrfToken() },
+            });
+            if (res.ok) {
+                setTasks((prev) => prev.filter((t) => t.uid !== taskUid));
+            }
+        } catch (e) {
+            console.error('Error deleting task:', e);
+        }
+    };
+
+    const moveTaskToCol = async (task: Task, targetCol: ColKey) => {
+        const newStatus = COLUMN_STATUS[targetCol];
+        const updatedTask: Task = { ...task, status: newStatus };
+        setTasks((prev) => prev.map((t) => (t.id === task.id ? updatedTask : t)));
+        await handleTaskUpdate(updatedTask);
+    };
+
+    const onDragStart = (e: React.DragEvent, task: Task) => {
+        setDraggingTaskId(task.id ?? null);
+        e.dataTransfer.effectAllowed = 'move';
+        e.dataTransfer.setData('text/plain', String(task.id));
+    };
+
+    const onDragEnd = () => {
+        setDraggingTaskId(null);
+        setDragOverCol(null);
+        dragEnterCounters.current = {};
+    };
+
+    const onColDragEnter = (e: React.DragEvent, col: ColKey) => {
+        e.preventDefault();
+        dragEnterCounters.current[col] = (dragEnterCounters.current[col] ?? 0) + 1;
+        setDragOverCol(col);
+    };
+
+    const onColDragOver = (e: React.DragEvent) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+    };
+
+    const onColDragLeave = (e: React.DragEvent, col: ColKey) => {
+        dragEnterCounters.current[col] = (dragEnterCounters.current[col] ?? 1) - 1;
+        if (dragEnterCounters.current[col] <= 0) {
+            dragEnterCounters.current[col] = 0;
+            setDragOverCol((prev) => (prev === col ? null : prev));
+        }
+    };
+
+    const onColDrop = async (e: React.DragEvent, col: ColKey) => {
+        e.preventDefault();
+        dragEnterCounters.current[col] = 0;
+        setDragOverCol(null);
+
+        if (draggingTaskId === null) return;
+        const task = tasks.find((t) => t.id === draggingTaskId);
+        if (!task) return;
+
+        if (getTaskColumn(task) === col) return;
+
+        await moveTaskToCol(task, col);
+        setDraggingTaskId(null);
+    };
+
+    const colConfig: Record<ColKey, { label: string; bg: string; dragOverBg: string; headerBg: string; headerColor: string }> = {
+        not_started: {
+            label: t('tasks.kanban.todo', 'To Do'),
+            bg: 'bg-gray-50 dark:bg-gray-900/20',
+            dragOverBg: 'bg-gray-100 dark:bg-gray-800/40',
+            headerBg: 'bg-gray-100 dark:bg-gray-800/60',
+            headerColor: 'text-gray-600 dark:text-gray-400',
+        },
+        in_progress: {
+            label: t('tasks.kanban.inProgress', 'In Progress'),
+            bg: 'bg-blue-50 dark:bg-blue-900/10',
+            dragOverBg: 'bg-blue-100 dark:bg-blue-900/20',
+            headerBg: 'bg-blue-100 dark:bg-blue-900/30',
+            headerColor: 'text-blue-700 dark:text-blue-400',
+        },
+        waiting: {
+            label: t('tasks.kanban.waiting', 'Waiting'),
+            bg: 'bg-yellow-50 dark:bg-yellow-900/10',
+            dragOverBg: 'bg-yellow-100 dark:bg-yellow-900/20',
+            headerBg: 'bg-yellow-100 dark:bg-yellow-900/30',
+            headerColor: 'text-yellow-700 dark:text-yellow-400',
+        },
+        done: {
+            label: t('tasks.kanban.done', 'Done'),
+            bg: 'bg-green-50 dark:bg-green-900/10',
+            dragOverBg: 'bg-green-100 dark:bg-green-900/20',
+            headerBg: 'bg-green-100 dark:bg-green-900/30',
+            headerColor: 'text-green-700 dark:text-green-400',
+        },
+    };
+
+    return (
+        <div className="w-full h-[calc(100vh-5rem)] flex flex-col pt-6 pb-4">
+            <div className="flex items-center justify-between mb-6 flex-shrink-0 px-4 sm:px-6">
+                <h2 className="text-2xl font-light text-gray-900 dark:text-gray-100">
+                    {t('sidebar.kanban', 'Kanban Board')}
+                </h2>
+            </div>
+
+            {loading && (
+                <p className="text-sm text-gray-500 dark:text-gray-400">{t('common.loading', 'Loading...')}</p>
+            )}
+            {error && (
+                <p className="text-sm text-red-500">{error}</p>
+            )}
+
+            {!loading && !error && (
+                <div className="flex-1 flex min-h-0 overflow-auto px-4 sm:px-6 gap-3">
+                    {COLS.map((col) => {
+                        const cfg = colConfig[col];
+                        const isDragOver = dragOverCol === col;
+                        const isDraggingActive = draggingTaskId !== null;
+                        const colTasks = columns[col];
+
+                        return (
+                            <div
+                                key={col}
+                                className={`relative flex flex-col flex-1 min-w-[200px] rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm overflow-hidden transition-colors duration-150 ${isDragOver ? cfg.dragOverBg : cfg.bg}`}
+                                onDragEnter={(e) => onColDragEnter(e, col)}
+                                onDragOver={onColDragOver}
+                                onDragLeave={(e) => onColDragLeave(e, col)}
+                                onDrop={(e) => onColDrop(e, col)}
+                            >
+                                {isDragOver && (
+                                    <div className="absolute inset-0 border-2 border-dashed border-gray-400 dark:border-gray-500 pointer-events-none z-10 rounded-xl" />
+                                )}
+
+                                {/* Column header */}
+                                <div className={`px-3 py-2 flex items-center justify-between flex-shrink-0 ${cfg.headerBg}`}>
+                                    <span className={`text-xs font-semibold tracking-wide uppercase ${cfg.headerColor}`}>
+                                        {cfg.label}
+                                    </span>
+                                    <span className={`text-xs font-medium ${cfg.headerColor} opacity-70`}>
+                                        {colTasks.length}
+                                    </span>
+                                </div>
+
+                                {/* Tasks */}
+                                <div className="flex-1 overflow-y-auto p-2 space-y-1.5">
+                                    {colTasks.length === 0 ? (
+                                        <p className={`text-xs py-3 text-center ${isDraggingActive ? 'text-gray-400 dark:text-gray-500' : 'text-gray-300 dark:text-gray-600'}`}>
+                                            {isDraggingActive
+                                                ? t('tasks.kanban.dropHere', 'Drop here')
+                                                : '—'}
+                                        </p>
+                                    ) : (
+                                        colTasks.map((task) => (
+                                            <div
+                                                key={task.id}
+                                                draggable
+                                                onDragStart={(e) => onDragStart(e, task)}
+                                                onDragEnd={onDragEnd}
+                                                className={`relative hover:z-[10000] focus-within:z-[10000] cursor-grab active:cursor-grabbing transition-opacity duration-150 ${draggingTaskId === task.id ? 'opacity-40' : 'opacity-100'}`}
+                                            >
+                                                <TaskItem
+                                                    task={task}
+                                                    onTaskUpdate={handleTaskUpdate}
+                                                    onTaskCompletionToggle={handleTaskCompletionToggle}
+                                                    onTaskDelete={handleTaskDelete}
+                                                    projects={projects}
+                                                    hideProjectName={false}
+                                                    onToggleToday={undefined}
+                                                    hideStatusControl={true}
+                                                />
+                                            </div>
+                                        ))
+                                    )}
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default KanbanBoard;

--- a/frontend/components/Profile/ProfileSettings.tsx
+++ b/frontend/components/Profile/ProfileSettings.tsx
@@ -136,6 +136,7 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
             next_task_suggestion_enabled: true,
             pomodoro_enabled: true,
             eisenhower_enabled: false,
+            kanban_enabled: false,
         },
         notification_preferences: null,
         keyboard_shortcuts: null,
@@ -549,6 +550,10 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
                         eisenhower_enabled:
                             data.features?.eisenhower_enabled !== undefined
                                 ? data.features.eisenhower_enabled
+                                : false,
+                        kanban_enabled:
+                            data.features?.kanban_enabled !== undefined
+                                ? data.features.kanban_enabled
                                 : false,
                     },
                     notification_preferences:
@@ -1077,6 +1082,12 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
                 );
             }
 
+            if (updatedProfile.features?.kanban_enabled !== undefined) {
+                useStore.getState().userSettingsStore.setKanbanEnabled(
+                    updatedProfile.features.kanban_enabled
+                );
+            }
+
             if (isPasswordChange) {
                 setFormData((prev) => ({
                     ...prev,
@@ -1325,6 +1336,19 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
                                                 ...prev.features,
                                                 eisenhower_enabled:
                                                     !prev.features?.eisenhower_enabled,
+                                            },
+                                        }))
+                                    }
+                                    kanbanEnabled={Boolean(
+                                        formData.features?.kanban_enabled
+                                    )}
+                                    onToggleKanban={() =>
+                                        setFormData((prev) => ({
+                                            ...prev,
+                                            features: {
+                                                ...prev.features,
+                                                kanban_enabled:
+                                                    !prev.features?.kanban_enabled,
                                             },
                                         }))
                                     }

--- a/frontend/components/Profile/tabs/FeaturesTab.tsx
+++ b/frontend/components/Profile/tabs/FeaturesTab.tsx
@@ -6,6 +6,8 @@ interface FeaturesTabProps {
     isActive: boolean;
     eisenhowerEnabled: boolean;
     onToggleEisenhower: () => void;
+    kanbanEnabled: boolean;
+    onToggleKanban: () => void;
     formData: ProfileFormData;
     onToggleAi: (field: keyof Features) => void;
 }
@@ -57,6 +59,8 @@ const FeaturesTab: React.FC<FeaturesTabProps> = ({
     isActive,
     eisenhowerEnabled,
     onToggleEisenhower,
+    kanbanEnabled,
+    onToggleKanban,
     formData,
     onToggleAi,
 }) => {
@@ -79,6 +83,15 @@ const FeaturesTab: React.FC<FeaturesTabProps> = ({
                     )}
                     value={eisenhowerEnabled}
                     onToggle={onToggleEisenhower}
+                />
+                <ToggleRow
+                    label={t('sidebar.kanban', 'Kanban Board')}
+                    description={t(
+                        'profile.kanbanDescription',
+                        'Enable the Kanban Board for tracking task progress across swimlanes.'
+                    )}
+                    value={kanbanEnabled}
+                    onToggle={onToggleKanban}
                 />
             </div>
 

--- a/frontend/components/Profile/types.ts
+++ b/frontend/components/Profile/types.ts
@@ -13,6 +13,7 @@ export interface Features {
     next_task_suggestion_enabled: boolean;
     pomodoro_enabled: boolean;
     eisenhower_enabled: boolean;
+    kanban_enabled: boolean;
 }
 
 export interface NotificationPreferences {

--- a/frontend/components/Sidebar/SidebarNav.tsx
+++ b/frontend/components/Sidebar/SidebarNav.tsx
@@ -8,6 +8,7 @@ import {
     ClockIcon,
     CalendarIcon,
     Squares2X2Icon,
+    ViewColumnsIcon,
 } from '@heroicons/react/24/solid';
 import { PlusCircleIcon } from '@heroicons/react/24/outline';
 import { useStore } from '../../store/useStore';
@@ -29,6 +30,7 @@ const SidebarNav: React.FC<SidebarNavProps> = ({
     const { t } = useTranslation();
     const store = useStore();
     const eisenhowerEnabled = useStore((state) => state.userSettingsStore.eisenhowerEnabled);
+    const kanbanEnabled = useStore((state) => state.userSettingsStore.kanbanEnabled);
     const [featureFlags, setFeatureFlags] = useState<FeatureFlags>({
         backups: false,
         calendar: false,
@@ -84,6 +86,12 @@ const SidebarNav: React.FC<SidebarNavProps> = ({
             icon: <Squares2X2Icon className="h-5 w-5" />,
             userFlag: 'eisenhower',
         },
+        {
+            path: '/kanban',
+            title: t('sidebar.kanban', 'Kanban Board'),
+            icon: <ViewColumnsIcon className="h-5 w-5" />,
+            userFlag: 'kanban',
+        },
     ];
 
     const navLinks = allNavLinks.filter((link) => {
@@ -93,11 +101,14 @@ const SidebarNav: React.FC<SidebarNavProps> = ({
         if (link.userFlag === 'eisenhower') {
             return eisenhowerEnabled;
         }
+        if (link.userFlag === 'kanban') {
+            return kanbanEnabled;
+        }
         return true;
     });
 
     const isActive = (path: string, query?: string) => {
-        if (path === '/inbox' || path === '/today' || path === '/calendar' || path === '/eisenhower') {
+        if (path === '/inbox' || path === '/today' || path === '/calendar' || path === '/eisenhower' || path === '/kanban') {
             const isPathMatch = location.pathname === path;
             return isPathMatch
                 ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white'

--- a/frontend/components/Task/TaskHeader.tsx
+++ b/frontend/components/Task/TaskHeader.tsx
@@ -35,6 +35,7 @@ interface TaskHeaderProps {
     onDelete?: (e: React.MouseEvent) => void;
     isUpcomingView?: boolean;
     onMenuOpenChange?: (isOpen: boolean) => void;
+    hideStatusControl?: boolean;
 }
 
 const TaskHeader: React.FC<TaskHeaderProps> = ({
@@ -53,6 +54,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
     onDelete: _onDelete,
     isUpcomingView = false,
     onMenuOpenChange,
+    hideStatusControl = false,
 }) => {
     const { t } = useTranslation();
     void _onToggleToday;
@@ -183,7 +185,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
             {/* Full view (md and larger) */}
             <div className="hidden md:flex flex-col md:flex-row md:items-center md:relative">
                 <div
-                    className={`flex items-center space-x-3 mb-2 md:mb-0 flex-1 min-w-0 ${!isUpcomingView ? 'pr-56' : ''}`}
+                    className={`flex items-center space-x-3 mb-2 md:mb-0 flex-1 min-w-0 ${!isUpcomingView && !hideStatusControl ? 'pr-56' : ''}`}
                 >
                     <div className="hidden">
                         <TaskPriorityIcon
@@ -450,7 +452,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
                         )}
                     </div>
                 </div>
-                {!isUpcomingView && !task.habit_mode && onToggleCompletion && (
+                {!isUpcomingView && !task.habit_mode && !hideStatusControl && onToggleCompletion && (
                     <div className="absolute right-0 top-1/2 -translate-y-1/2 flex items-center">
                         <TaskStatusControl
                             task={task}

--- a/frontend/components/Task/TaskItem.tsx
+++ b/frontend/components/Task/TaskItem.tsx
@@ -157,6 +157,7 @@ interface TaskItemProps {
     isUpcomingView?: boolean;
     showCompletedTasks?: boolean;
     isInCompletedSection?: boolean;
+    hideStatusControl?: boolean;
 }
 
 const TaskItem: React.FC<TaskItemProps> = ({
@@ -170,6 +171,7 @@ const TaskItem: React.FC<TaskItemProps> = ({
     isUpcomingView = false,
     showCompletedTasks = false,
     isInCompletedSection = false,
+    hideStatusControl = false,
 }) => {
     const navigate = useNavigate();
     const location = useLocation();
@@ -410,6 +412,7 @@ const TaskItem: React.FC<TaskItemProps> = ({
                     onDelete={handleDeleteClick}
                     isUpcomingView={isUpcomingView}
                     onMenuOpenChange={setIsStatusMenuOpen}
+                    hideStatusControl={hideStatusControl}
                 />
 
                 {/* Progress bar at bottom of parent task */}

--- a/frontend/entities/User.ts
+++ b/frontend/entities/User.ts
@@ -5,6 +5,7 @@ export interface UserFeatures {
     next_task_suggestion_enabled?: boolean;
     pomodoro_enabled?: boolean;
     eisenhower_enabled?: boolean;
+    kanban_enabled?: boolean;
 }
 
 export interface User {

--- a/frontend/store/useStore.ts
+++ b/frontend/store/useStore.ts
@@ -103,6 +103,8 @@ interface InboxStore {
 interface UserSettingsStore {
     eisenhowerEnabled: boolean;
     setEisenhowerEnabled: (enabled: boolean) => void;
+    kanbanEnabled: boolean;
+    setKanbanEnabled: (enabled: boolean) => void;
 }
 
 interface HabitsStore {
@@ -793,6 +795,14 @@ export const useStore = create<StoreState>((set: any) => ({
                 userSettingsStore: {
                     ...state.userSettingsStore,
                     eisenhowerEnabled: enabled,
+                },
+            })),
+        kanbanEnabled: false,
+        setKanbanEnabled: (enabled) =>
+            set((state) => ({
+                userSettingsStore: {
+                    ...state.userSettingsStore,
+                    kanbanEnabled: enabled,
                 },
             })),
     },

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -55,6 +55,7 @@
     "completed": "Completed",
     "allTasks": "All Tasks",
     "eisenhower": "Eisenhower Matrix",
+    "kanban": "Kanban Board",
     "unpinView": "Unpin view",
     "pinView": "Pin view"
   },
@@ -159,6 +160,14 @@
       "notImportant": "Not Important",
       "dropHere": "Drop here",
       "urgentHint": "Tag tasks with 'urgent' to mark them as urgent"
+    },
+    "kanban": {
+      "title": "Kanban Board",
+      "todo": "To Do",
+      "inProgress": "In Progress",
+      "waiting": "Waiting",
+      "done": "Done",
+      "dropHere": "Drop here"
     },
     "show": "Show",
     "open": "Open",
@@ -325,6 +334,7 @@
     "enableAutoSuggestNextActions": "Enable Next Action Prompts",
     "productivityFeatures": "Productivity Features",
     "pomodoroDescription": "Enable the Pomodoro timer in the navigation bar for focused work sessions.",
+    "kanbanDescription": "Enable the Kanban Board for tracking task progress across swimlanes.",
     "enablePomodoro": "Enable Pomodoro Timer",
     "productivityAssistant": "Productivity Assistant",
     "productivityAssistantDescription": "Show productivity insights that help identify stalled projects, vague tasks, and workflow improvements on your Today page.",


### PR DESCRIPTION
## Description

Adds a Kanban board as an opt-in feature toggled from Profile → Features & Add-ons, alongside the existing Eisenhower Matrix. Also fixes a bug where both Eisenhower and Kanban enabled settings were not persisting across page reloads.

**Root cause of the persistence bug:** `GET /api/current_user` was returning the `features` JSON column as a raw string instead of a parsed object. On every page load, `App.tsx` would try to read `data.user.features?.eisenhower_enabled` (which is `undefined` on a string) and call `setEisenhowerEnabled(false)` and `setKanbanEnabled(false)`, overriding the saved values. Fixed by adding the same `JSON.parse` guard that already existed in the profile GET endpoint.

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related Issues

Fixes #

## Testing

**How did you test this?**

- Verified `GET /api/current_user` now returns `features` as a parsed object (was raw JSON string before)
- Confirmed full save/reload cycle: disable both → reload → re-enable → reload, values persist at each step
- Verified sidebar Kanban and Eisenhower links appear/disappear correctly based on feature toggle state

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Database migrations included and tested (if applicable)
- [x] Translation keys added and synced (if applicable)

## Additional Notes

The separate `eisenhower_enabled` TINYINT column (added by migration `20260616000001`) still exists in the DB schema but is no longer referenced by the model — the value lives exclusively in the `features` JSON column. The column is harmless dead schema.