### PR TITLE
fix(inbox): prevent stale analysis result from truncating task name

### DIFF
--- a/frontend/components/Inbox/QuickCaptureInput.tsx
+++ b/frontend/components/Inbox/QuickCaptureInput.tsx
@@ -172,6 +172,7 @@ const QuickCaptureInput = React.forwardRef<
         const [urlPreviewImageError, setUrlPreviewImageError] = useState(false);
         const urlPreviewRequestIdRef = useRef(0);
         const dismissedPreviewUrlRef = useRef<string | null>(null);
+        const lastAnalyzedTextRef = useRef<string>('');
 
         const isEditMode = mode === 'edit';
 
@@ -718,7 +719,7 @@ const QuickCaptureInput = React.forwardRef<
         };
 
         const getAllTags = (text: string): string[] => {
-            if (analysisResult) {
+            if (analysisResult && lastAnalyzedTextRef.current === text.trim()) {
                 const explicitTags = analysisResult.parsed_tags;
 
                 const isUrlContent =
@@ -751,7 +752,7 @@ const QuickCaptureInput = React.forwardRef<
         };
 
         const getAllProjects = (text: string): string[] => {
-            if (analysisResult) {
+            if (analysisResult && lastAnalyzedTextRef.current === text.trim()) {
                 return analysisResult.parsed_projects;
             }
 
@@ -759,7 +760,7 @@ const QuickCaptureInput = React.forwardRef<
         };
 
         const getCleanedContent = (text: string): string => {
-            if (analysisResult) {
+            if (analysisResult && lastAnalyzedTextRef.current === text) {
                 return analysisResult.cleaned_content;
             }
 
@@ -861,12 +862,14 @@ const QuickCaptureInput = React.forwardRef<
                     if (response.ok) {
                         const result = await response.json();
                         setAnalysisResult(result);
+                        lastAnalyzedTextRef.current = text;
                     } else {
                         console.error(
                             'Failed to analyze text:',
                             response.statusText
                         );
                         setAnalysisResult(null);
+                        lastAnalyzedTextRef.current = '';
                     }
                 } catch (error) {
                     if (analysisRequestIdRef.current !== requestId) {
@@ -874,6 +877,7 @@ const QuickCaptureInput = React.forwardRef<
                     }
                     console.error('Error analyzing text:', error);
                     setAnalysisResult(null);
+                    lastAnalyzedTextRef.current = '';
                 } finally {
                     if (analysisRequestIdRef.current === requestId) {
                         setIsAnalyzing(false);
@@ -1252,7 +1256,7 @@ const QuickCaptureInput = React.forwardRef<
                 clearText: clearComposerText,
                 updateText: (value: string) => setInputText(value),
             }),
-            [inputText, clearComposerText]
+            [inputText, clearComposerText, analysisResult]
         );
 
         const defaultFooterActions =


### PR DESCRIPTION
## Description

When creating a task from the Inbox using the "Create Task" button, the text was sometimes truncated to a shorter version of what was typed.

**Root cause:** `QuickCaptureInput` debounces text analysis by 300ms. When the user types quickly, an analysis result from a *previous* (shorter) text could still be in state when `composerFooterContext` is recomputed. The `getCleanedContent`, `getAllTags`, and `getAllProjects` functions checked `if (analysisResult)` but never verified the result matched the *current* input — so a stale `analysisResult.cleaned_content` from "Telefon" would be used even though `inputText` was already "Telefon Wohnzimmer per Kabel anschliessen".

Additionally, `analysisResult` was missing from `composerFooterContext`'s `useMemo` dependency array, so even when a fresh analysis completed, the context wasn't refreshed.

**Fix:**
- Add `lastAnalyzedTextRef` to track which text was last successfully analyzed
- Guard `getCleanedContent`, `getAllTags`, `getAllProjects` to only use `analysisResult` when `lastAnalyzedTextRef.current` matches the current text; otherwise fall back to local regex parsing
- Add `analysisResult` to `composerFooterContext`'s `useMemo` dependency array so the context updates when new analysis arrives

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1191

## Testing

1. Start the app (`npm start`)
2. Go to Inbox
3. Type a multi-word sentence like "Telefon Wohnzimmer per Kabel anschliessen" quickly
4. Immediately click "Create Task" (before the 300ms analysis debounce can complete for the full text)
5. Verify the task modal opens with the full text in the name field
6. Also test: type the same sentence, wait 1 second, then click "Create Task" — full text should still appear

## Checklist

- [x] My changes follow the project's code conventions
- [x] I have tested the fix manually
- [x] Linting passes (`npm run lint`)
- [x] Tests pass (`npm test`)