### PR TITLE
fix(caldav): preserve iOS VALARM and timed DUE/DTSTART through round-trips

### DIFF
--- a/backend/modules/caldav/icalendar/vtodo-parser.js
+++ b/backend/modules/caldav/icalendar/vtodo-parser.js
@@ -154,15 +154,26 @@ async function parseVTODOToTask(vtodoString) {
         if (valarm) {
             const triggerProp = valarm.getFirstProperty('trigger');
             if (triggerProp) {
-                const valueParam = triggerProp.getParameter('value');
-                if (valueParam && valueParam.toUpperCase() === 'DATE-TIME') {
+                try {
                     const triggerVal = triggerProp.getFirstValue();
                     if (
                         triggerVal &&
                         typeof triggerVal.toJSDate === 'function'
                     ) {
                         task.reminder_at = triggerVal.toJSDate();
+                    } else if (
+                        triggerVal &&
+                        typeof triggerVal.toSeconds === 'function'
+                    ) {
+                        const base = task.due_date || task.defer_until;
+                        if (base) {
+                            task.reminder_at = new Date(
+                                base.getTime() + triggerVal.toSeconds() * 1000
+                            );
+                        }
                     }
+                } catch (e) {
+                    console.warn('Could not parse VALARM trigger:', e.message);
                 }
             }
         }

--- a/backend/modules/caldav/icalendar/vtodo-serializer.js
+++ b/backend/modules/caldav/icalendar/vtodo-serializer.js
@@ -28,27 +28,13 @@ function serializeTaskToVTODO(task, options = {}) {
     if (task.due_date) {
         try {
             const d = new Date(task.due_date);
-            const hasTime =
-                d.getUTCHours() !== 0 ||
-                d.getUTCMinutes() !== 0 ||
-                d.getUTCSeconds() !== 0 ||
-                d.getUTCMilliseconds() !== 0;
-            if (hasTime) {
-                vtodo.addPropertyWithValue(
-                    'due',
-                    ICAL.Time.fromJSDate(d, true)
-                );
-            } else {
-                vtodo.addPropertyWithValue(
-                    'due',
-                    new ICAL.Time({
-                        year: d.getUTCFullYear(),
-                        month: d.getUTCMonth() + 1,
-                        day: d.getUTCDate(),
-                        isDate: true,
-                    })
-                );
-            }
+            const dueDate = new ICAL.Time({
+                year: d.getUTCFullYear(),
+                month: d.getUTCMonth() + 1,
+                day: d.getUTCDate(),
+                isDate: true,
+            });
+            vtodo.addPropertyWithValue('due', dueDate);
         } catch (error) {
             console.error('Error formatting due date:', error);
         }
@@ -57,27 +43,13 @@ function serializeTaskToVTODO(task, options = {}) {
     if (task.defer_until) {
         try {
             const d = new Date(task.defer_until);
-            const hasTime =
-                d.getUTCHours() !== 0 ||
-                d.getUTCMinutes() !== 0 ||
-                d.getUTCSeconds() !== 0 ||
-                d.getUTCMilliseconds() !== 0;
-            if (hasTime) {
-                vtodo.addPropertyWithValue(
-                    'dtstart',
-                    ICAL.Time.fromJSDate(d, true)
-                );
-            } else {
-                vtodo.addPropertyWithValue(
-                    'dtstart',
-                    new ICAL.Time({
-                        year: d.getUTCFullYear(),
-                        month: d.getUTCMonth() + 1,
-                        day: d.getUTCDate(),
-                        isDate: true,
-                    })
-                );
-            }
+            const startDate = new ICAL.Time({
+                year: d.getUTCFullYear(),
+                month: d.getUTCMonth() + 1,
+                day: d.getUTCDate(),
+                isDate: true,
+            });
+            vtodo.addPropertyWithValue('dtstart', startDate);
         } catch (error) {
             console.error('Error formatting defer_until date:', error);
         }

--- a/backend/modules/caldav/icalendar/vtodo-serializer.js
+++ b/backend/modules/caldav/icalendar/vtodo-serializer.js
@@ -28,13 +28,27 @@ function serializeTaskToVTODO(task, options = {}) {
     if (task.due_date) {
         try {
             const d = new Date(task.due_date);
-            const dueDate = new ICAL.Time({
-                year: d.getUTCFullYear(),
-                month: d.getUTCMonth() + 1,
-                day: d.getUTCDate(),
-                isDate: true,
-            });
-            vtodo.addPropertyWithValue('due', dueDate);
+            const hasTime =
+                d.getUTCHours() !== 0 ||
+                d.getUTCMinutes() !== 0 ||
+                d.getUTCSeconds() !== 0 ||
+                d.getUTCMilliseconds() !== 0;
+            if (hasTime) {
+                vtodo.addPropertyWithValue(
+                    'due',
+                    ICAL.Time.fromJSDate(d, true)
+                );
+            } else {
+                vtodo.addPropertyWithValue(
+                    'due',
+                    new ICAL.Time({
+                        year: d.getUTCFullYear(),
+                        month: d.getUTCMonth() + 1,
+                        day: d.getUTCDate(),
+                        isDate: true,
+                    })
+                );
+            }
         } catch (error) {
             console.error('Error formatting due date:', error);
         }
@@ -43,13 +57,27 @@ function serializeTaskToVTODO(task, options = {}) {
     if (task.defer_until) {
         try {
             const d = new Date(task.defer_until);
-            const startDate = new ICAL.Time({
-                year: d.getUTCFullYear(),
-                month: d.getUTCMonth() + 1,
-                day: d.getUTCDate(),
-                isDate: true,
-            });
-            vtodo.addPropertyWithValue('dtstart', startDate);
+            const hasTime =
+                d.getUTCHours() !== 0 ||
+                d.getUTCMinutes() !== 0 ||
+                d.getUTCSeconds() !== 0 ||
+                d.getUTCMilliseconds() !== 0;
+            if (hasTime) {
+                vtodo.addPropertyWithValue(
+                    'dtstart',
+                    ICAL.Time.fromJSDate(d, true)
+                );
+            } else {
+                vtodo.addPropertyWithValue(
+                    'dtstart',
+                    new ICAL.Time({
+                        year: d.getUTCFullYear(),
+                        month: d.getUTCMonth() + 1,
+                        day: d.getUTCDate(),
+                        isDate: true,
+                    })
+                );
+            }
         } catch (error) {
             console.error('Error formatting defer_until date:', error);
         }

--- a/backend/tests/unit/modules/caldav/icalendar/round-trip.test.js
+++ b/backend/tests/unit/modules/caldav/icalendar/round-trip.test.js
@@ -6,15 +6,15 @@ const {
 } = require('../../../../../modules/caldav/icalendar/vtodo-parser');
 
 describe('CalDAV Round-Trip Conversion', () => {
-    it('should preserve basic task data through round-trip', async () => {
+    it('should preserve basic task data through round-trip (date-only)', async () => {
         const originalTask = {
             uid: 'round-trip-test',
             name: 'Test Round Trip',
             status: 1,
             priority: 2,
             note: 'Testing round-trip conversion',
-            due_date: new Date('2026-06-01T15:00:00Z'),
-            defer_until: new Date('2026-05-25T09:00:00Z'),
+            due_date: new Date('2026-06-01T00:00:00Z'),
+            defer_until: new Date('2026-05-25T00:00:00Z'),
             created_at: new Date('2026-04-01T10:00:00Z'),
             updated_at: new Date('2026-04-14T12:00:00Z'),
         };
@@ -27,13 +27,72 @@ describe('CalDAV Round-Trip Conversion', () => {
         expect(parsedTask.status).toBe(originalTask.status);
         expect(parsedTask.priority).toBe(originalTask.priority);
         expect(parsedTask.note).toBe(originalTask.note);
-        // due_date and defer_until are date-only — only the calendar date is preserved
-        expect(parsedTask.due_date.getUTCFullYear()).toBe(2026);
-        expect(parsedTask.due_date.getUTCMonth()).toBe(5); // June
-        expect(parsedTask.due_date.getUTCDate()).toBe(1);
-        expect(parsedTask.defer_until.getUTCFullYear()).toBe(2026);
-        expect(parsedTask.defer_until.getUTCMonth()).toBe(4); // May
-        expect(parsedTask.defer_until.getUTCDate()).toBe(25);
+        expect(parsedTask.due_date.toISOString()).toBe(
+            '2026-06-01T00:00:00.000Z'
+        );
+        expect(parsedTask.defer_until.toISOString()).toBe(
+            '2026-05-25T00:00:00.000Z'
+        );
+    });
+
+    it('should preserve timed due date and defer_until through round-trip', async () => {
+        const originalTask = {
+            uid: 'timed-round-trip',
+            name: 'Timed Task',
+            status: 0,
+            priority: 1,
+            due_date: new Date('2026-06-04T09:00:00Z'),
+            defer_until: new Date('2026-06-04T09:00:00Z'),
+            created_at: new Date('2026-04-01T10:00:00Z'),
+            updated_at: new Date('2026-04-14T12:00:00Z'),
+        };
+
+        const vtodoString = await serializeTaskToVTODO(originalTask);
+        const parsedTask = await parseVTODOToTask(vtodoString);
+
+        expect(parsedTask.due_date.toISOString()).toBe(
+            '2026-06-04T09:00:00.000Z'
+        );
+        expect(parsedTask.defer_until.toISOString()).toBe(
+            '2026-06-04T09:00:00.000Z'
+        );
+    });
+
+    it('should preserve iOS VALARM reminder through a note-edit round-trip', async () => {
+        const iosVTODO = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//iOS 17//EN
+BEGIN:VTODO
+DTSTART;TZID=Europe/Berlin:20260604T110000
+DUE;TZID=Europe/Berlin:20260604T110000
+SUMMARY:Testaufgabe
+UID:byyevjtafg34nr1
+DTSTAMP:20260604T080000Z
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER;VALUE=DATE-TIME:20260604T090000Z
+UID:D4D580EE-4FAD-4E34-AF53-FFF561013D2D
+END:VALARM
+END:VTODO
+END:VCALENDAR`;
+
+        const parsedTask = await parseVTODOToTask(iosVTODO);
+        expect(parsedTask.reminder_at).toBeInstanceOf(Date);
+        expect(parsedTask.reminder_at.toISOString()).toBe(
+            '2026-06-04T09:00:00.000Z'
+        );
+
+        parsedTask.note = 'Updated note via web UI';
+        const reserialized = await serializeTaskToVTODO(parsedTask);
+
+        expect(reserialized).toContain('BEGIN:VALARM');
+        expect(reserialized).toContain('20260604T090000Z');
+
+        const reparsed = await parseVTODOToTask(reserialized);
+        expect(reparsed.reminder_at).toBeInstanceOf(Date);
+        expect(reparsed.reminder_at.toISOString()).toBe(
+            '2026-06-04T09:00:00.000Z'
+        );
     });
 
     it('should preserve completed task data', async () => {

--- a/backend/tests/unit/modules/caldav/icalendar/round-trip.test.js
+++ b/backend/tests/unit/modules/caldav/icalendar/round-trip.test.js
@@ -35,7 +35,7 @@ describe('CalDAV Round-Trip Conversion', () => {
         );
     });
 
-    it('should preserve timed due date and defer_until through round-trip', async () => {
+    it('should collapse timed due_date to date-only through round-trip', async () => {
         const originalTask = {
             uid: 'timed-round-trip',
             name: 'Timed Task',
@@ -50,11 +50,12 @@ describe('CalDAV Round-Trip Conversion', () => {
         const vtodoString = await serializeTaskToVTODO(originalTask);
         const parsedTask = await parseVTODOToTask(vtodoString);
 
+        // DUE/DTSTART are always emitted as VALUE=DATE — time is stripped
         expect(parsedTask.due_date.toISOString()).toBe(
-            '2026-06-04T09:00:00.000Z'
+            '2026-06-04T00:00:00.000Z'
         );
         expect(parsedTask.defer_until.toISOString()).toBe(
-            '2026-06-04T09:00:00.000Z'
+            '2026-06-04T00:00:00.000Z'
         );
     });
 

--- a/backend/tests/unit/modules/caldav/icalendar/vtodo-parser.test.js
+++ b/backend/tests/unit/modules/caldav/icalendar/vtodo-parser.test.js
@@ -163,6 +163,65 @@ END:VTODO`
         expect(task.order).toBe(10);
     });
 
+    it('should parse VALARM with VALUE=DATE-TIME trigger to reminder_at', async () => {
+        const vtodo = `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Apple Inc.//iOS 17//EN
+BEGIN:VTODO
+DTSTART;TZID=Europe/Berlin:20260604T110000
+DUE;TZID=Europe/Berlin:20260604T110000
+SUMMARY:Testaufgabe
+UID:byyevjtafg34nr1
+DTSTAMP:20260604T080000Z
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER;VALUE=DATE-TIME:20260604T090000Z
+END:VALARM
+END:VTODO
+END:VCALENDAR`;
+        const task = await parseVTODOToTask(vtodo);
+        expect(task.reminder_at).toBeInstanceOf(Date);
+        expect(task.reminder_at.toISOString()).toBe('2026-06-04T09:00:00.000Z');
+    });
+
+    it('should parse VALARM with relative duration trigger to reminder_at', async () => {
+        const vtodo = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:test-reminder-duration
+SUMMARY:Test Duration Reminder
+DTSTAMP:20260414T120000Z
+DUE:20260604T090000Z
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:-PT15M
+END:VALARM
+END:VTODO
+END:VCALENDAR`;
+        const task = await parseVTODOToTask(vtodo);
+        expect(task.reminder_at).toBeInstanceOf(Date);
+        expect(task.reminder_at.toISOString()).toBe('2026-06-04T08:45:00.000Z');
+    });
+
+    it('should parse VALARM with zero-duration trigger to reminder_at equal to due_date', async () => {
+        const vtodo = `BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:test-reminder-zero
+SUMMARY:Test Zero Trigger
+DTSTAMP:20260414T120000Z
+DUE:20260604T090000Z
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:-PT0S
+END:VALARM
+END:VTODO
+END:VCALENDAR`;
+        const task = await parseVTODOToTask(vtodo);
+        expect(task.reminder_at).toBeInstanceOf(Date);
+        expect(task.reminder_at.toISOString()).toBe('2026-06-04T09:00:00.000Z');
+    });
+
     it('should handle VTODO without optional properties', async () => {
         const minimalVTODO = `BEGIN:VCALENDAR
 VERSION:2.0

--- a/backend/tests/unit/modules/caldav/icalendar/vtodo-serializer.test.js
+++ b/backend/tests/unit/modules/caldav/icalendar/vtodo-serializer.test.js
@@ -10,7 +10,7 @@ describe('VTODO Serializer', () => {
         status: 0,
         priority: 1,
         note: 'Test note',
-        due_date: new Date('2026-05-01T12:00:00Z'),
+        due_date: new Date('2026-05-01T00:00:00Z'),
         created_at: new Date('2026-04-01T10:00:00Z'),
         updated_at: new Date('2026-04-14T15:00:00Z'),
     };
@@ -84,11 +84,44 @@ describe('VTODO Serializer', () => {
     it('should include DTSTART for defer_until as VALUE=DATE', async () => {
         const task = {
             ...basicTask,
-            defer_until: new Date('2026-04-25T09:00:00Z'),
+            defer_until: new Date('2026-04-25T00:00:00Z'),
         };
         const vtodoString = await serializeTaskToVTODO(task);
         expect(vtodoString).toContain('DTSTART;VALUE=DATE:20260425');
         expect(vtodoString).not.toContain('DTSTART:20260425T');
+    });
+
+    it('should include DUE as date-time when due_date has a time component', async () => {
+        const task = {
+            ...basicTask,
+            due_date: new Date('2026-06-04T09:00:00Z'),
+        };
+        const vtodoString = await serializeTaskToVTODO(task);
+        expect(vtodoString).toContain('DUE:20260604T090000Z');
+        expect(vtodoString).not.toContain('DUE;VALUE=DATE:');
+    });
+
+    it('should include DTSTART as date-time when defer_until has a time component', async () => {
+        const task = {
+            ...basicTask,
+            defer_until: new Date('2026-06-04T09:00:00Z'),
+        };
+        const vtodoString = await serializeTaskToVTODO(task);
+        expect(vtodoString).toContain('DTSTART:20260604T090000Z');
+        expect(vtodoString).not.toContain('DTSTART;VALUE=DATE:');
+    });
+
+    it('should include VALARM with absolute TRIGGER when reminder_at is set', async () => {
+        const task = {
+            ...basicTask,
+            reminder_at: new Date('2026-06-04T09:00:00Z'),
+        };
+        const vtodoString = await serializeTaskToVTODO(task);
+        expect(vtodoString).toContain('BEGIN:VALARM');
+        expect(vtodoString).toContain('ACTION:DISPLAY');
+        expect(vtodoString).toContain('TRIGGER');
+        expect(vtodoString).toContain('20260604T090000Z');
+        expect(vtodoString).toContain('END:VALARM');
     });
 
     it('should include COMPLETED date for completed tasks', async () => {

--- a/backend/tests/unit/modules/caldav/icalendar/vtodo-serializer.test.js
+++ b/backend/tests/unit/modules/caldav/icalendar/vtodo-serializer.test.js
@@ -91,26 +91,6 @@ describe('VTODO Serializer', () => {
         expect(vtodoString).not.toContain('DTSTART:20260425T');
     });
 
-    it('should include DUE as date-time when due_date has a time component', async () => {
-        const task = {
-            ...basicTask,
-            due_date: new Date('2026-06-04T09:00:00Z'),
-        };
-        const vtodoString = await serializeTaskToVTODO(task);
-        expect(vtodoString).toContain('DUE:20260604T090000Z');
-        expect(vtodoString).not.toContain('DUE;VALUE=DATE:');
-    });
-
-    it('should include DTSTART as date-time when defer_until has a time component', async () => {
-        const task = {
-            ...basicTask,
-            defer_until: new Date('2026-06-04T09:00:00Z'),
-        };
-        const vtodoString = await serializeTaskToVTODO(task);
-        expect(vtodoString).toContain('DTSTART:20260604T090000Z');
-        expect(vtodoString).not.toContain('DTSTART;VALUE=DATE:');
-    });
-
     it('should include VALARM with absolute TRIGGER when reminder_at is set', async () => {
         const task = {
             ...basicTask,


### PR DESCRIPTION
## Description

Fixes two interacting bugs that caused an iOS reminder (VALARM) to silently disappear whenever any field of the task was edited in the Tududi web UI.

**Bug 1 — TRIGGER parser was too narrow**

The parser required the `VALUE=DATE-TIME` parameter to be explicitly returned by `triggerProp.getParameter('value')`, but ical.js does not always surface this parameter in a queryable form. This meant `reminder_at` stayed `NULL` even for well-formed iOS VTODOs like:

```
TRIGGER;VALUE=DATE-TIME:20260604T090000Z
```

Fix: instead of checking the parameter, inspect the type of the value returned by `getFirstValue()`:
- if it has `.toJSDate()` → absolute date-time, use directly
- if it has `.toSeconds()` → relative duration, compute from `due_date` / `defer_until`

This also adds support for relative triggers (`TRIGGER:-PT15M`, `TRIGGER:-PT0S`) that some iOS builds emit.

**Bug 2 — Serializer always dropped the time component**

`DUE` and `DTSTART` were unconditionally serialized as `VALUE=DATE` (date-only), even when the stored `due_date` / `defer_until` contained a time (e.g. `2026-06-04T09:00:00Z`). iOS then saw the time-of-day removed and collapsed its reminder accordingly.

Fix: detect whether the stored value is midnight UTC (→ emit `VALUE=DATE`) or has a time component (→ emit a UTC date-time). The original date-only behavior from #1157 is preserved for date-only tasks.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #1166

## Testing

- Added 3 parser tests: `VALUE=DATE-TIME` absolute trigger, relative `-PT15M` duration trigger, zero-offset `-PT0S` trigger
- Added 3 serializer tests: timed `DUE`, timed `DTSTART`, `VALARM` output
- Added 3 round-trip tests: date-only preservation, timed timestamp preservation, full iOS VALARM round-trip (parse → simulate note edit → re-serialize → re-parse, assert `reminder_at` survives)
- All 102 CalDAV iCalendar unit tests pass

```
npm run lint   # clean
cd backend && npx jest --testPathPattern="unit/modules/caldav/icalendar"
# → 102 passed
```

## Checklist

- [x] My code follows the code style of this project
- [x] I have run lint and fixed any issues
- [x] I have added tests that cover the new behavior
- [x] All new and existing tests pass