### PR TITLE
fix(projects): allow clearing a project's color

### DIFF
--- a/frontend/components/Project/ProjectModal.tsx
+++ b/frontend/components/Project/ProjectModal.tsx
@@ -671,7 +671,7 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                                                         onChange={(color) =>
                                                             setFormData((prev) => ({
                                                                 ...prev,
-                                                                color: color || undefined,
+                                                                color,
                                                             }))
                                                         }
                                                     />


### PR DESCRIPTION
## Description

For Version v1.2.0-dev.2

The "None" color option in `ProjectModal` set `color` to `undefined` instead of an empty string, so it was dropped from the JSON payload entirely and the backend (which only updates `color` when the key is present) never cleared the existing value.

The fix matches the pattern already used in `AreaModal.tsx` (`color: color || ''`): pass the empty string straight through instead of converting it to `undefined`.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

  No existing issue, found this while testing an unrelated feature.

## Testing

**How did you test this?**

Created a project, assigned it a color, saved, reopened the edit modal, clicked "None" in the color picker, saved again, and confirmed via the API response that `color` was now `null` instead of still holding the previous value.
Repeated and confirmed on a second pass after restarting the dev server.

**Commands run:**

- [ ] `npm run pre-push` — `eslint` passes clean on the changed file; `prettier -c` reports pre-existing formatting drift on this file that already exists on `main` before this change, unrelated to this fix, so left untouched to keep the diff minimal

- [x] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Screenshots

Not applicable. The UI is visually identical before and after. The bug was only in whether the cleared value persisted after saving.

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

One-line fix, no behavior change beyond allowing the color to actually be cleared.