### PR TITLE
feat(tasks): add direct area assignment to tasks

### DIFF
--- a/backend/migrations/20260623000001-add-area-id-to-tasks.js
+++ b/backend/migrations/20260623000001-add-area-id-to-tasks.js
@@ -1,0 +1,25 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn('tasks', 'area_id', {
+            type: Sequelize.INTEGER,
+            allowNull: true,
+            references: {
+                model: 'areas',
+                key: 'id',
+            },
+            onUpdate: 'CASCADE',
+            onDelete: 'SET NULL',
+        });
+
+        await queryInterface.addIndex('tasks', ['area_id'], {
+            name: 'tasks_area_id_idx',
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeIndex('tasks', 'tasks_area_id_idx');
+        await queryInterface.removeColumn('tasks', 'area_id');
+    },
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -91,6 +91,8 @@ User.hasMany(Task, { foreignKey: 'user_id' });
 Task.belongsTo(User, { foreignKey: 'user_id' });
 Task.belongsTo(Project, { foreignKey: 'project_id', allowNull: true });
 Project.hasMany(Task, { foreignKey: 'project_id' });
+Task.belongsTo(Area, { foreignKey: 'area_id', allowNull: true });
+Area.hasMany(Task, { foreignKey: 'area_id' });
 
 User.hasMany(Tag, { foreignKey: 'user_id' });
 Tag.belongsTo(User, { foreignKey: 'user_id' });

--- a/backend/models/task.js
+++ b/backend/models/task.js
@@ -126,6 +126,14 @@ module.exports = (sequelize) => {
                     key: 'id',
                 },
             },
+            area_id: {
+                type: DataTypes.INTEGER,
+                allowNull: true,
+                references: {
+                    model: 'areas',
+                    key: 'id',
+                },
+            },
             recurring_parent_id: {
                 type: DataTypes.INTEGER,
                 allowNull: true,

--- a/backend/modules/tasks/core/serializers.js
+++ b/backend/modules/tasks/core/serializers.js
@@ -95,6 +95,12 @@ async function serializeTask(
                   uid: taskJson.Project.uid,
               }
             : null,
+        Area: taskJson.Area
+            ? {
+                  ...taskJson.Area,
+                  uid: taskJson.Area.uid,
+              }
+            : null,
         subtasks: Subtasks
             ? Subtasks.map((subtask) => ({
                   ...subtask,

--- a/backend/modules/tasks/queries/metrics-computation.js
+++ b/backend/modules/tasks/queries/metrics-computation.js
@@ -17,7 +17,7 @@ const {
     fetchTasksCompletedToday,
 } = require('./metrics-queries');
 
-const MAX_SUGGESTED_TASKS = 10;
+const MAX_SUGGESTED_TASKS = 50;
 
 const getPriorityValue = (priority) => {
     const priorityOrder = {

--- a/backend/modules/tasks/queries/query-builders.js
+++ b/backend/modules/tasks/queries/query-builders.js
@@ -1,4 +1,4 @@
-const { Task, Tag, Project, sequelize } = require('../../../models');
+const { Task, Tag, Project, Area, sequelize } = require('../../../models');
 const { Op, QueryTypes } = require('sequelize');
 const permissionsService = require('../../../services/permissionsService');
 const {
@@ -86,6 +86,11 @@ async function filterTasksByParams(
         {
             model: Project,
             attributes: ['id', 'name', 'status', 'uid'],
+            required: false,
+        },
+        {
+            model: Area,
+            attributes: ['id', 'name', 'uid', 'color'],
             required: false,
         },
         {
@@ -249,8 +254,10 @@ async function filterTasksByParams(
                     [Op.notIn]: [
                         Task.STATUS.DONE,
                         Task.STATUS.ARCHIVED,
+                        Task.STATUS.CANCELLED,
                         'done',
                         'archived',
+                        'cancelled',
                     ],
                 };
             } else if (!params.client_side_filtering) {
@@ -290,8 +297,10 @@ async function filterTasksByParams(
                     [Op.notIn]: [
                         Task.STATUS.DONE,
                         Task.STATUS.ARCHIVED,
+                        Task.STATUS.CANCELLED,
                         'done',
                         'archived',
+                        'cancelled',
                     ],
                 };
             } else if (!params.client_side_filtering) {
@@ -316,8 +325,10 @@ async function filterTasksByParams(
                     [Op.notIn]: [
                         Task.STATUS.DONE,
                         Task.STATUS.ARCHIVED,
+                        Task.STATUS.CANCELLED,
                         'done',
                         'archived',
+                        'cancelled',
                     ],
                 };
             } else if (params.status === 'all') {
@@ -397,6 +408,10 @@ async function filterTasksByParams(
         };
     }
 
+    if (params.area_id) {
+        whereClause.area_id = params.area_id;
+    }
+
     const finalWhereClause = {
         [Op.and]: [ownedOrShared, whereClause],
     };
@@ -420,6 +435,11 @@ function getTaskIncludeConfig() {
         {
             model: Project,
             attributes: ['id', 'name', 'status', 'uid'],
+            required: false,
+        },
+        {
+            model: Area,
+            attributes: ['id', 'name', 'uid', 'color'],
             required: false,
         },
         {
@@ -455,6 +475,11 @@ function getTaskIncludeConfigLight() {
         {
             model: Project,
             attributes: ['id', 'name', 'status', 'uid'],
+            required: false,
+        },
+        {
+            model: Area,
+            attributes: ['id', 'name', 'uid', 'color'],
             required: false,
         },
     ];

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -42,6 +42,7 @@ const {
     validateProjectAccess,
     validateParentTaskAccess,
     validateDeferUntilAndDueDate,
+    validateAreaAccess,
 } = require('./utils/validation');
 const {
     buildTaskAttributes,
@@ -404,8 +405,15 @@ router.get('/tasks/metrics', async (req, res) => {
 
 router.post('/task', async (req, res) => {
     try {
-        const { name, project_id, parent_task_id, tags, Tags, subtasks } =
-            req.body;
+        const {
+            name,
+            project_id,
+            area_id,
+            parent_task_id,
+            tags,
+            Tags,
+            subtasks,
+        } = req.body;
         const tagsData = tags || Tags;
 
         if (!name || name.trim() === '') {
@@ -445,6 +453,16 @@ router.post('/task', async (req, res) => {
             return res
                 .status(error.message === 'Forbidden' ? 403 : 400)
                 .json({ error: error.message });
+        }
+
+        try {
+            const validAreaId = await validateAreaAccess(
+                area_id,
+                req.currentUser.id
+            );
+            if (validAreaId) taskAttributes.area_id = validAreaId;
+        } catch (error) {
+            return res.status(400).json({ error: error.message });
         }
 
         try {
@@ -541,6 +559,7 @@ router.patch('/task/:uid', requireTaskWriteAccess, async (req, res) => {
         const {
             status,
             project_id,
+            area_id,
             parent_task_id,
             tags,
             Tags,
@@ -654,6 +673,18 @@ router.patch('/task/:uid', requireTaskWriteAccess, async (req, res) => {
                 return res
                     .status(error.message === 'Forbidden' ? 403 : 400)
                     .json({ error: error.message });
+            }
+        }
+
+        if (area_id !== undefined) {
+            try {
+                const validAreaId = await validateAreaAccess(
+                    area_id,
+                    req.currentUser.id
+                );
+                taskAttributes.area_id = validAreaId;
+            } catch (error) {
+                return res.status(400).json({ error: error.message });
             }
         }
 

--- a/backend/modules/tasks/utils/constants.js
+++ b/backend/modules/tasks/utils/constants.js
@@ -1,4 +1,4 @@
-const { Tag, Project, Task } = require('../../../models');
+const { Tag, Project, Area, Task } = require('../../../models');
 
 const TASK_INCLUDES = [
     {
@@ -9,6 +9,11 @@ const TASK_INCLUDES = [
     {
         model: Project,
         attributes: ['id', 'name', 'uid', 'image_url', 'color'],
+        required: false,
+    },
+    {
+        model: Area,
+        attributes: ['id', 'name', 'uid', 'color'],
         required: false,
     },
 ];

--- a/backend/modules/tasks/utils/validation.js
+++ b/backend/modules/tasks/utils/validation.js
@@ -1,4 +1,4 @@
-const { Project, Task } = require('../../../models');
+const { Project, Task, Area } = require('../../../models');
 const permissionsService = require('../../../services/permissionsService');
 
 async function validateProjectAccess(projectId, userId) {
@@ -135,8 +135,22 @@ function validateDeferUntilAndDueDate(
     }
 }
 
+async function validateAreaAccess(areaId, userId) {
+    if (!areaId || !areaId.toString().trim()) {
+        return null;
+    }
+
+    const area = await Area.findOne({ where: { id: areaId, user_id: userId } });
+    if (!area) {
+        throw new Error('Invalid area.');
+    }
+
+    return areaId;
+}
+
 module.exports = {
     validateProjectAccess,
     validateParentTaskAccess,
     validateDeferUntilAndDueDate,
+    validateAreaAccess,
 };

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -248,7 +248,7 @@ const App: React.FC = () => {
                                 element={<ProjectDetails />}
                             />
                             <Route path="/areas" element={<Areas />} />
-                            <Route path="/area/:id" element={<AreaDetails />} />
+                            <Route path="/area/:uidSlug" element={<AreaDetails />} />
                             <Route path="/tags" element={<Tags />} />
                             <Route
                                 path="/tag/:uidSlug"

--- a/frontend/components/Area/AreaDetails.tsx
+++ b/frontend/components/Area/AreaDetails.tsx
@@ -1,63 +1,310 @@
-import React, { useEffect, useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import React, { useEffect, useState, useCallback } from 'react';
+import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { PencilIcon } from '@heroicons/react/24/outline';
 import { useStore } from '../../store/useStore';
 import { Area } from '../../entities/Area';
-import { useTranslation } from 'react-i18next';
+import { Project } from '../../entities/Project';
+import { Task } from '../../entities/Task';
+import { fetchTasks } from '../../utils/tasksService';
+import { updateArea } from '../../utils/areasService';
+import AreaModal from './AreaModal';
+import TaskList from '../Task/TaskList';
 
 const AreaDetails: React.FC = () => {
     const { t } = useTranslation();
-    const { id } = useParams<{ id: string }>();
-    const { areas } = useStore((state: any) => state.areasStore);
+    const { uidSlug } = useParams<{ uidSlug: string }>();
+    const navigate = useNavigate();
+
+    const areasStore = useStore((state: any) => state.areasStore);
+    const projectsStore = useStore((state: any) => state.projectsStore);
+    const tasksStore = useStore((state: any) => state.tasksStore);
+
     const [area, setArea] = useState<Area | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [isError, setIsError] = useState(false);
+    const [areaTasks, setAreaTasks] = useState<Task[]>([]);
+    const [loadingTasks, setLoadingTasks] = useState(false);
+    const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+
+    const areaUid = uidSlug?.split('-')[0] || '';
 
     useEffect(() => {
-        if (!areas.length) setIsLoading(true);
-        const foundArea = areas.find((a: Area) => a.id === Number(id));
-        setArea(foundArea || null);
-        if (!foundArea) {
+        if (!areasStore.isLoading && areasStore.areas.length === 0) {
+            areasStore.loadAreas();
+        }
+    }, [areasStore]);
+
+    useEffect(() => {
+        if (!projectsStore.hasLoaded && !projectsStore.isLoading) {
+            projectsStore.loadProjects();
+        }
+    }, [projectsStore]);
+
+    useEffect(() => {
+        if (!areaUid) {
+            setIsError(true);
+            setIsLoading(false);
+            return;
+        }
+
+        const found = areasStore.areas.find((a: Area) => a.uid === areaUid);
+        if (found) {
+            setArea(found);
+            setIsError(false);
+        } else if (!areasStore.isLoading && areasStore.areas.length > 0) {
             setIsError(true);
         }
-        setIsLoading(false);
-    }, [id, areas]);
+        setIsLoading(areasStore.isLoading && !found);
+    }, [areaUid, areasStore.areas, areasStore.isLoading]);
+
+    const loadAreaTasks = useCallback(async () => {
+        if (!area?.id) return;
+        setLoadingTasks(true);
+        try {
+            const result = await fetchTasks(`?area_id=${area.id}&type=all&status=all`);
+            setAreaTasks(result.tasks || []);
+        } catch (err) {
+            console.error('Error fetching area tasks:', err);
+            setAreaTasks([]);
+        } finally {
+            setLoadingTasks(false);
+        }
+    }, [area?.id]);
+
+    useEffect(() => {
+        if (area?.id) {
+            loadAreaTasks();
+        }
+    }, [area?.id, loadAreaTasks]);
+
+    const areaProjects = projectsStore.projects.filter((p: Project) => {
+        const projectArea = p.area || (p as any).Area;
+        return projectArea?.uid === areaUid;
+    });
+
+    const handleTaskUpdate = async (updatedTask: Task) => {
+        setAreaTasks((prev) =>
+            prev.map((t) => (t.uid === updatedTask.uid ? updatedTask : t))
+        );
+        tasksStore.setTasks(
+            tasksStore.tasks.map((t: Task) =>
+                t.uid === updatedTask.uid ? updatedTask : t
+            )
+        );
+    };
+
+    const handleTaskDelete = (taskUid: string) => {
+        setAreaTasks((prev) => prev.filter((t) => t.uid !== taskUid));
+        tasksStore.setTasks(
+            tasksStore.tasks.filter((t: Task) => t.uid !== taskUid)
+        );
+    };
+
+    const handleAreaSave = async (areaData: Partial<Area>) => {
+        if (!area?.uid) return;
+        const result = await updateArea(area.uid, {
+            name: areaData.name,
+            description: areaData.description,
+            color: areaData.color,
+        });
+        areasStore.setAreas(
+            areasStore.areas.map((a: Area) =>
+                a.uid === result.uid ? result : a
+            )
+        );
+        setArea(result);
+        setIsEditModalOpen(false);
+
+        const slug = result.name
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-|-$/g, '');
+        navigate(`/area/${result.uid}-${slug}`, { replace: true });
+    };
+
+    const getProjectLink = (project: Project) => {
+        if (project.uid) {
+            const slug = project.name
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, '-')
+                .replace(/^-|-$/g, '');
+            return `/project/${project.uid}-${slug}`;
+        }
+        return `/project/${project.id}`;
+    };
 
     if (isLoading) {
         return (
-            <div className="flex items-center justify-center h-screen bg-gray-100 dark:bg-gray-900">
-                <div className="text-xl font-semibold text-gray-700 dark:text-gray-200">
-                    {t('areas.loading')}
-                </div>
+            <div className="flex items-center justify-center h-64 text-gray-500 dark:text-gray-400">
+                {t('areas.loading', 'Loading…')}
             </div>
         );
     }
 
     if (isError || !area) {
         return (
-            <div className="flex items-center justify-center h-screen bg-gray-100 dark:bg-gray-900">
-                <div className="text-red-500 text-lg">
-                    {isError ? t('areas.error') : t('areas.notFound')}
-                </div>
+            <div className="flex items-center justify-center h-64 text-red-500">
+                {t('areas.notFound', 'Area not found')}
             </div>
         );
     }
 
+    const activeTasks = areaTasks.filter(
+        (t) => t.status !== 'done' && t.status !== 2 && t.status !== 'archived' && t.status !== 3
+    );
+    const completedTasks = areaTasks.filter(
+        (t) => t.status === 'done' || t.status === 2
+    );
+
     return (
-        <div className="min-h-screen bg-gray-100 dark:bg-gray-900 p-4 sm:p-6 lg:p-8">
-            <div className="max-w-5xl mx-auto bg-white dark:bg-gray-800 shadow-lg rounded-lg p-6">
-                <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-4">
-                    {t('areas.details')}: {area?.name}
-                </h2>
-                <p className="text-md text-gray-700 dark:text-gray-300">
-                    {area?.description}
-                </p>
-                <Link
-                    to={`/projects?area_id=${area?.id}`}
-                    className="text-blue-600 dark:text-blue-400 hover:underline mt-4 block"
-                >
-                    {t('areas.viewProjects', { name: area?.name })}
-                </Link>
+        <div className="w-full px-2 sm:px-4 lg:px-6 pt-4 pb-8">
+            {/* Area Header */}
+            <div
+                className="rounded-xl mb-8 overflow-hidden"
+                style={area.color ? { backgroundColor: area.color } : undefined}
+            >
+                <div className={`p-6 ${area.color ? '' : 'bg-gray-50 dark:bg-gray-900 rounded-xl'}`}>
+                    <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0">
+                            <h1
+                                className={`text-3xl font-light uppercase tracking-wide ${
+                                    area.color ? 'text-white' : 'text-gray-900 dark:text-gray-100'
+                                }`}
+                            >
+                                {area.name}
+                            </h1>
+                            {area.description && (
+                                <p
+                                    className={`mt-2 text-sm ${
+                                        area.color ? 'text-white/80' : 'text-gray-600 dark:text-gray-400'
+                                    }`}
+                                >
+                                    {area.description}
+                                </p>
+                            )}
+                            <div
+                                className={`mt-3 flex gap-4 text-xs ${
+                                    area.color ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'
+                                }`}
+                            >
+                                <span>
+                                    {areaProjects.length}{' '}
+                                    {t('areas.projects', 'projects')}
+                                </span>
+                                <span>
+                                    {activeTasks.length}{' '}
+                                    {t('areas.tasks', 'tasks')}
+                                </span>
+                            </div>
+                        </div>
+                        <button
+                            onClick={() => setIsEditModalOpen(true)}
+                            className={`p-2 rounded-lg transition-colors flex-shrink-0 ${
+                                area.color
+                                    ? 'text-white/80 hover:text-white hover:bg-white/10'
+                                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
+                            }`}
+                            title={t('areas.edit', 'Edit area')}
+                        >
+                            <PencilIcon className="h-5 w-5" />
+                        </button>
+                    </div>
+                </div>
             </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+                {/* Projects column */}
+                <div className="lg:col-span-1">
+                    <h2 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4">
+                        {t('areas.projectsInArea', 'Projects')}
+                    </h2>
+                    {areaProjects.length === 0 ? (
+                        <p className="text-sm text-gray-400 dark:text-gray-500">
+                            {t('areas.noProjects', 'No projects in this area')}
+                        </p>
+                    ) : (
+                        <div className="space-y-2">
+                            {areaProjects.map((project: Project) => (
+                                <Link
+                                    key={project.uid || project.id}
+                                    to={getProjectLink(project)}
+                                    className="flex items-center gap-3 p-3 rounded-lg bg-white dark:bg-gray-900 shadow-sm hover:shadow-md transition-shadow"
+                                >
+                                    {project.image_url ? (
+                                        <img
+                                            src={project.image_url}
+                                            alt={project.name}
+                                            className="w-8 h-8 rounded object-cover flex-shrink-0"
+                                        />
+                                    ) : (
+                                        <div
+                                            className="w-8 h-8 rounded flex-shrink-0"
+                                            style={{
+                                                backgroundColor:
+                                                    (project as any).color || area.color || '#6b7280',
+                                            }}
+                                        />
+                                    )}
+                                    <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">
+                                        {project.name}
+                                    </span>
+                                </Link>
+                            ))}
+                        </div>
+                    )}
+                </div>
+
+                {/* Tasks column */}
+                <div className="lg:col-span-2">
+                    <h2 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4">
+                        {t('areas.tasksInArea', 'Tasks')}
+                    </h2>
+                    {loadingTasks ? (
+                        <div className="text-sm text-gray-400 dark:text-gray-500">
+                            {t('loading.tasks', 'Loading tasks…')}
+                        </div>
+                    ) : activeTasks.length === 0 && completedTasks.length === 0 ? (
+                        <p className="text-sm text-gray-400 dark:text-gray-500">
+                            {t('areas.noTasks', 'No tasks directly in this area')}
+                        </p>
+                    ) : (
+                        <div className="space-y-6">
+                            {activeTasks.length > 0 && (
+                                <TaskList
+                                    tasks={activeTasks}
+                                    projects={projectsStore.projects}
+                                    onTaskUpdate={handleTaskUpdate}
+                                    onTaskDelete={handleTaskDelete}
+                                />
+                            )}
+                            {completedTasks.length > 0 && (
+                                <div>
+                                    <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">
+                                        {t('tasks.completed', 'Completed')} ({completedTasks.length})
+                                    </h3>
+                                    <TaskList
+                                        tasks={completedTasks}
+                                        projects={projectsStore.projects}
+                                        onTaskUpdate={handleTaskUpdate}
+                                        onTaskDelete={handleTaskDelete}
+                                        showCompletedTasks={true}
+                                    />
+                                </div>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {isEditModalOpen && (
+                <AreaModal
+                    isOpen={isEditModalOpen}
+                    area={area}
+                    onSave={handleAreaSave}
+                    onClose={() => setIsEditModalOpen(false)}
+                />
+            )}
         </div>
     );
 };

--- a/frontend/components/Areas.tsx
+++ b/frontend/components/Areas.tsx
@@ -179,11 +179,11 @@ const Areas: React.FC = () => {
                                 key={area.uid}
                                 to={
                                     area.uid
-                                        ? `/projects?area=${area.uid}-${area.name
+                                        ? `/area/${area.uid}-${area.name
                                               .toLowerCase()
                                               .replace(/[^a-z0-9]+/g, '-')
                                               .replace(/^-|-$/g, '')}`
-                                        : `/projects?area_id=${area.uid}`
+                                        : `/areas`
                                 }
                                 className={`rounded-lg shadow-md relative flex flex-col group hover:opacity-90 transition-opacity cursor-pointer ${
                                     !area.color ? 'bg-gray-50 dark:bg-gray-900' : ''

--- a/frontend/components/Project/ProjectBanner.tsx
+++ b/frontend/components/Project/ProjectBanner.tsx
@@ -161,20 +161,19 @@ const ProjectBanner: React.FC<ProjectBannerProps> = ({
                                 onClick={() => {
                                     const projectArea =
                                         project.area || (project as any).Area;
-                                    const area = areas.find(
-                                        (a) => a.id === projectArea.id
-                                    );
-                                    const areaUid = area?.uid;
+                                    const areaUid =
+                                        projectArea.uid ||
+                                        areas.find(
+                                            (a) => a.id === projectArea.id
+                                        )?.uid;
                                     if (!areaUid) return;
                                     const areaSlug = projectArea.name
                                         .toLowerCase()
                                         .replace(/[^a-z0-9]+/g, '-')
                                         .replace(/^-|-$/g, '');
-                                    navigate(
-                                        `/projects?area=${areaUid}-${areaSlug}`
-                                    );
+                                    navigate(`/area/${areaUid}-${areaSlug}`);
                                 }}
-                                className="text-xs text-white/90 hover:text-blue-200 transition-colors cursor-pointer font-medium"
+                                className="text-xs text-white/90 hover:text-white transition-colors cursor-pointer font-medium underline underline-offset-2"
                             >
                                 {(project.area || (project as any).Area)?.name}
                             </button>

--- a/frontend/components/Shared/ToastContext.tsx
+++ b/frontend/components/Shared/ToastContext.tsx
@@ -8,11 +8,13 @@ interface Toast {
     id: number;
     message: string | React.ReactNode;
     type: 'success' | 'error';
+    onUndo?: () => void;
 }
 
 interface ToastContextProps {
     showSuccessToast: (message: string | React.ReactNode) => void;
     showErrorToast: (message: string | React.ReactNode) => void;
+    showUndoToast: (message: string | React.ReactNode, onUndo: () => void) => void;
 }
 
 const ToastContext = createContext<ToastContextProps | undefined>(undefined);
@@ -46,8 +48,18 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
         [removeToast]
     );
 
+    const showUndoToast = useCallback(
+        (message: string | React.ReactNode, onUndo: () => void) => {
+            const id = Date.now() + Math.random();
+            const newToast: Toast = { id, message, type: 'success', onUndo };
+            setToasts((prev) => [...prev, newToast]);
+            setTimeout(() => removeToast(id), 6000);
+        },
+        [removeToast]
+    );
+
     return (
-        <ToastContext.Provider value={{ showSuccessToast, showErrorToast }}>
+        <ToastContext.Provider value={{ showSuccessToast, showErrorToast, showUndoToast }}>
             {children}
             <div className="fixed top-20 right-4 z-50 space-y-2">
                 {toasts.map((toast, index) => (
@@ -56,6 +68,7 @@ export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({
                         message={toast.message}
                         type={toast.type}
                         onClose={() => removeToast(toast.id)}
+                        onUndo={toast.onUndo ? () => { removeToast(toast.id); toast.onUndo!(); } : undefined}
                         style={{ transform: `translateY(${index * 4}px)` }}
                     />
                 ))}
@@ -76,8 +89,9 @@ const ToastComponent: React.FC<{
     message: string | React.ReactNode;
     type: 'success' | 'error';
     onClose: () => void;
+    onUndo?: () => void;
     style?: React.CSSProperties;
-}> = ({ message, type, onClose, style }) => {
+}> = ({ message, type, onClose, onUndo, style }) => {
     return (
         <div
             className={`px-4 py-3 rounded-lg shadow-md text-white transition-all duration-300 ${
@@ -85,18 +99,26 @@ const ToastComponent: React.FC<{
             }`}
             style={style}
         >
-            <div className="flex items-center">
-                <div className="flex-shrink-0 mr-3">
+            <div className="flex items-center gap-3">
+                <div className="flex-shrink-0">
                     {type === 'success' ? (
                         <CheckCircleIcon className="h-5 w-5" />
                     ) : (
                         <ExclamationTriangleIcon className="h-5 w-5" />
                     )}
                 </div>
-                <div className="flex-1">{message}</div>
+                <div className="flex-1 text-sm">{message}</div>
+                {onUndo && (
+                    <button
+                        onClick={onUndo}
+                        className="flex-shrink-0 text-sm font-semibold underline underline-offset-2 hover:opacity-80 transition-opacity"
+                    >
+                        Undo
+                    </button>
+                )}
                 <button
                     onClick={onClose}
-                    className="ml-4 text-xl leading-none hover:opacity-75 flex-shrink-0"
+                    className="flex-shrink-0 text-lg leading-none hover:opacity-75"
                 >
                     &times;
                 </button>

--- a/frontend/components/Task/TaskDetails.tsx
+++ b/frontend/components/Task/TaskDetails.tsx
@@ -5,6 +5,7 @@ import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
 import ConfirmDialog from '../Shared/ConfirmDialog';
 import { Task } from '../../entities/Task';
 import { Project } from '../../entities/Project';
+import { Area } from '../../entities/Area';
 import {
     updateTask,
     deleteTask,
@@ -24,6 +25,7 @@ import {
     TaskDetailsHeader,
     TaskContentCard,
     TaskProjectCard,
+    TaskAreaCard,
     TaskTagsCard,
     TaskSubtasksCard,
     TaskRecurrenceCard,
@@ -73,6 +75,7 @@ const TaskDetails: React.FC = () => {
     const projectsStore = useStore((state: any) => state.projectsStore);
     const tagsStore = useStore((state: any) => state.tagsStore);
     const tasksStore = useStore((state: any) => state.tasksStore);
+    const areasStore = useStore((state: any) => state.areasStore);
     const task = useStore((state: any) =>
         state.tasksStore.tasks.find((t: Task) => t.uid === uid)
     );
@@ -181,6 +184,12 @@ const TaskDetails: React.FC = () => {
             tagsStore.loadTags();
         }
     }, [tagsStore]);
+
+    useEffect(() => {
+        if (!areasStore.isLoading && areasStore.areas.length === 0) {
+            areasStore.loadAreas();
+        }
+    }, [areasStore]);
 
     const handleStartRecurrenceEdit = () => {
         setRecurrenceForm({
@@ -1041,6 +1050,61 @@ const TaskDetails: React.FC = () => {
         }
     };
 
+    const handleAreaSelection = async (area: Area) => {
+        if (!task?.uid) return;
+
+        try {
+            taskModifiedRef.current = true;
+            await updateTask(task.uid, { area_id: area.id });
+
+            if (uid) {
+                const updatedTask = await fetchTaskByUid(uid);
+                tasksStore.updateTaskInStore(updatedTask);
+            }
+
+            showSuccessToast(
+                t('task.areaUpdated', 'Area updated successfully')
+            );
+            setTimelineRefreshKey((prev) => prev + 1);
+        } catch (error) {
+            console.error('Error updating area:', error);
+            showErrorToast(t('task.areaUpdateError', 'Failed to update area'));
+        }
+    };
+
+    const handleClearArea = async () => {
+        if (!task?.uid) return;
+
+        try {
+            taskModifiedRef.current = true;
+            await updateTask(task.uid, { area_id: null });
+
+            if (uid) {
+                const updatedTask = await fetchTaskByUid(uid);
+                tasksStore.updateTaskInStore(updatedTask);
+            }
+
+            showSuccessToast(
+                t('task.areaCleared', 'Area cleared successfully')
+            );
+            setTimelineRefreshKey((prev) => prev + 1);
+        } catch (error) {
+            console.error('Error clearing area:', error);
+            showErrorToast(t('task.areaClearError', 'Failed to clear area'));
+        }
+    };
+
+    const getAreaLink = (area: Area) => {
+        if (area.uid) {
+            const slug = area.name
+                .toLowerCase()
+                .replace(/[^a-z0-9]+/g, '-')
+                .replace(/^-|-$/g, '');
+            return `/area/${area.uid}-${slug}`;
+        }
+        return `/area/${area.id}`;
+    };
+
     const handleTagsUpdate = async (tags: string[]) => {
         if (!task?.uid) {
             return;
@@ -1193,6 +1257,14 @@ const TaskDetails: React.FC = () => {
                                         handleProjectCreateInlineWrapper
                                     }
                                     getProjectLink={getProjectLink}
+                                />
+
+                                <TaskAreaCard
+                                    task={task}
+                                    areas={areasStore.areas}
+                                    onAreaSelect={handleAreaSelection}
+                                    onAreaClear={handleClearArea}
+                                    getAreaLink={getAreaLink}
                                 />
 
                                 <TaskTagsCard

--- a/frontend/components/Task/TaskDetails/index.ts
+++ b/frontend/components/Task/TaskDetails/index.ts
@@ -8,3 +8,4 @@ export { default as TaskRecurrenceCard } from './TaskRecurrenceCard';
 export { default as TaskDueDateCard } from './TaskDueDateCard';
 export { default as TaskDeferUntilCard } from './TaskDeferUntilCard';
 export { default as TaskAttachmentsCard } from './TaskAttachmentsCard';
+export { default as TaskAreaCard } from './TaskAreaCard';

--- a/frontend/components/Task/TaskItem.tsx
+++ b/frontend/components/Task/TaskItem.tsx
@@ -6,6 +6,15 @@ import TaskHeader from './TaskHeader';
 import { useToast } from '../Shared/ToastContext';
 import TaskPriorityIcon from '../Shared/Icons/TaskPriorityIcon';
 import { isTaskCompleted } from '../../constants/taskStatus';
+import {
+    ExclamationTriangleIcon,
+    BoltIcon,
+    ArrowPathIcon,
+    ClockIcon,
+    ScaleIcon,
+    ArrowRightCircleIcon,
+    SparklesIcon,
+} from '@heroicons/react/24/outline';
 
 // Import SubtasksDisplay component from TaskHeader
 interface SubtasksDisplayProps {
@@ -140,7 +149,7 @@ const SubtasksDisplay: React.FC<SubtasksDisplayProps> = ({
         </div>
     );
 };
-import { toggleTaskCompletion, fetchSubtasks } from '../../utils/tasksService';
+import { toggleTaskCompletion, updateTask, fetchSubtasks } from '../../utils/tasksService';
 import { isTaskOverdueInTodayPlan } from '../../utils/dateUtils';
 import { useTranslation } from 'react-i18next';
 import ConfirmDialog from '../Shared/ConfirmDialog';
@@ -159,6 +168,7 @@ interface TaskItemProps {
     isInCompletedSection?: boolean;
     hideStatusControl?: boolean;
     isKanbanView?: boolean;
+    showSuggestionChips?: boolean;
 }
 
 const TaskItem: React.FC<TaskItemProps> = ({
@@ -174,13 +184,14 @@ const TaskItem: React.FC<TaskItemProps> = ({
     isInCompletedSection = false,
     hideStatusControl = false,
     isKanbanView = false,
+    showSuggestionChips = false,
 }) => {
     const navigate = useNavigate();
     const location = useLocation();
     const { t } = useTranslation();
     const [projectList, setProjectList] = useState<Project[]>(projects);
     const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
-    const { showErrorToast } = useToast();
+    const { showErrorToast, showUndoToast } = useToast();
     const [isAnimatingOut, setIsAnimatingOut] = useState(false);
 
     // Status menu state
@@ -311,6 +322,8 @@ const TaskItem: React.FC<TaskItemProps> = ({
                     task.status !== 'archived' &&
                     task.status !== 3;
 
+                const previousStatus = task.status;
+
                 // If completing the task in upcoming view and not showing completed tasks, trigger animation
                 if (isCompletingTask && isUpcomingView && !showCompletedTasks) {
                     setIsAnimatingOut(true);
@@ -319,6 +332,29 @@ const TaskItem: React.FC<TaskItemProps> = ({
                 }
 
                 const response = await toggleTaskCompletion(task.uid!, task);
+
+                // Show undo toast on completion
+                if (isCompletingTask) {
+                    showUndoToast(
+                        <>Task <span className="font-semibold">&apos;{task.name}&apos;</span> completed.</>,
+                        async () => {
+                            try {
+                                const reverted = await updateTask(task.uid!, {
+                                    ...task,
+                                    status: previousStatus,
+                                    completed_at: null,
+                                });
+                                if (onTaskCompletionToggle) {
+                                    onTaskCompletionToggle(reverted);
+                                } else {
+                                    await onTaskUpdate({ ...task, ...reverted });
+                                }
+                            } catch {
+                                showErrorToast('Failed to undo task completion.');
+                            }
+                        }
+                    );
+                }
 
                 // Handle the updated task
                 if (onTaskCompletionToggle) {
@@ -430,6 +466,32 @@ const TaskItem: React.FC<TaskItemProps> = ({
                     </div>
                 )}
             </div>
+
+            {/* Suggestion reason row — only in Suggested section */}
+            {showSuggestionChips && task._suggestionMeta && (() => {
+                const { reason, reasonLabel, reasonColor } = task._suggestionMeta;
+                const iconProps = { className: 'h-3.5 w-3.5 flex-shrink-0' };
+                const icon =
+                    reason === 'due'        ? <ExclamationTriangleIcon {...iconProps} /> :
+                    reason === 'high'       ? <BoltIcon {...iconProps} /> :
+                    reason === 'revive'     ? <ArrowPathIcon {...iconProps} /> :
+                    reason === 'aging_review' ? <ClockIcon {...iconProps} /> :
+                    reason === 'area_balance' ? <ScaleIcon {...iconProps} /> :
+                    reason === 'fits_now'   ? <SparklesIcon {...iconProps} /> :
+                                              <ArrowRightCircleIcon {...iconProps} />;
+                return (
+                    <div
+                        className="flex items-center gap-2 ml-4 px-3 py-1.5 rounded-b-lg text-[11px] select-none"
+                        style={{
+                            backgroundColor: `${reasonColor}12`,
+                            color: `${reasonColor}cc`,
+                        }}
+                    >
+                        {icon}
+                        <span className="font-light leading-tight">{reasonLabel}</span>
+                    </div>
+                );
+            })()}
 
             {/* Hide subtasks display for archived tasks */}
             {showSubtasks &&

--- a/frontend/components/Task/TaskList.tsx
+++ b/frontend/components/Task/TaskList.tsx
@@ -15,6 +15,7 @@ interface TaskListProps {
     showCompletedTasks?: boolean;
     isInCompletedSection?: boolean;
     isUpcomingView?: boolean;
+    showSuggestionChips?: boolean;
 }
 
 const TaskList: React.FC<TaskListProps> = ({
@@ -28,6 +29,7 @@ const TaskList: React.FC<TaskListProps> = ({
     showCompletedTasks = false,
     isInCompletedSection = false,
     isUpcomingView = false,
+    showSuggestionChips = false,
 }) => {
     // Conditionally filter tasks based on showCompletedTasks prop
     const filteredTasks = showCompletedTasks
@@ -36,8 +38,10 @@ const TaskList: React.FC<TaskListProps> = ({
               const isCompleted =
                   task.status === 'done' ||
                   task.status === 'archived' ||
+                  task.status === 'cancelled' ||
                   task.status === 2 ||
-                  task.status === 3;
+                  task.status === 3 ||
+                  task.status === 5;
               return !isCompleted;
           });
 
@@ -61,6 +65,7 @@ const TaskList: React.FC<TaskListProps> = ({
                             isInCompletedSection={isInCompletedSection}
                             isUpcomingView={isUpcomingView}
                             showCompletedTasks={showCompletedTasks}
+                            showSuggestionChips={showSuggestionChips}
                         />
                     </div>
                 ))

--- a/frontend/components/Task/TasksToday.tsx
+++ b/frontend/components/Task/TasksToday.tsx
@@ -6,6 +6,7 @@ import i18n from 'i18next';
 import { useNavigate } from 'react-router-dom';
 import { getLocalesPath, getApiPath } from '../../config/paths';
 import { sortTasksByPriorityDueDateProject } from '../../utils/taskSortUtils';
+import { scoreAndSortSuggestedTasks } from '../../utils/suggestionScoringUtils';
 import { getTodayDateString } from '../../utils/dateUtils';
 import {
     ClipboardDocumentListIcon,
@@ -96,7 +97,7 @@ const TasksToday: React.FC = () => {
         showActiveProjects: true,
         showProductivity: false,
         showNextTaskSuggestion: false,
-        showSuggestions: false,
+        showSuggestions: true,
         showDueToday: true,
         showCompleted: true,
         showProgressBar: true, // Always enabled
@@ -169,7 +170,7 @@ const TasksToday: React.FC = () => {
     const [overdueDisplayLimit, setOverdueDisplayLimit] = useState(20);
 
     // Client-side pagination for Suggested tasks
-    const [suggestedDisplayLimit, setSuggestedDisplayLimit] = useState(20);
+    const [suggestedDisplayLimit, setSuggestedDisplayLimit] = useState(5);
 
     // Client-side pagination for Completed Today tasks (since backend returns all)
     const [completedTodayDisplayLimit, setCompletedTodayDisplayLimit] =
@@ -197,12 +198,28 @@ const TasksToday: React.FC = () => {
         return filterNonHabitTasks(tasks);
     }, [metrics.tasks_completed_today, getTasksFromStore]);
 
-    // Sort tasks using multi-criteria sorting (Priority → Due Date → Project) for consistency
-    // Task data comes from global store so priority changes are immediately reflected
+    // Smart scoring: one-per-project candidate pool, priority-dominant score, reason chips.
+    // Use all store tasks minus tasks already shown in other sections — gives buildCandidatePool
+    // the widest possible view of pending work across all active projects.
     const sortedSuggestedTasks = useMemo(() => {
-        const tasks = getTasksFromStore(metrics.suggested_tasks || []);
-        return sortTasksByPriorityDueDateProject(tasks);
-    }, [metrics.suggested_tasks, getTasksFromStore]);
+        const excludedIds = new Set<number>();
+        [
+            ...(metrics.tasks_in_progress || []),
+            ...(metrics.tasks_due_today || []),
+            ...(metrics.tasks_overdue || []),
+            ...(metrics.today_plan_tasks || []),
+            ...(metrics.tasks_completed_today || []),
+        ].forEach((t: Task) => { if (t.id != null) excludedIds.add(t.id); });
+
+        const candidateTasks = storeTasks.filter(
+            (t: Task) => t.id != null && !excludedIds.has(t.id)
+        );
+
+        if (localProjects.length > 0) {
+            return scoreAndSortSuggestedTasks(candidateTasks, localProjects);
+        }
+        return sortTasksByPriorityDueDateProject(candidateTasks);
+    }, [metrics, storeTasks, localProjects]);
 
     const sortedDueTodayTasks = useMemo(() => {
         const tasks = getTasksFromStore(metrics.tasks_due_today || []);
@@ -464,7 +481,7 @@ const TasksToday: React.FC = () => {
             setIsLoading(true);
             try {
                 const result = await fetchTasks(
-                    `?type=today&limit=20&offset=0`
+                    `?type=today&limit=20&offset=0&include_lists=true`
                 );
                 if (isMounted.current) {
                     setMetrics({
@@ -568,7 +585,7 @@ const TasksToday: React.FC = () => {
                             showActiveProjects: true,
                             showProductivity: false,
                             showNextTaskSuggestion: false,
-                            showSuggestions: false,
+                            showSuggestions: true,
                             showDueToday: true,
                             showCompleted: true,
                             showProgressBar: true, // Always enabled
@@ -1213,6 +1230,15 @@ const TasksToday: React.FC = () => {
     const totalCompletedItems =
         completedTasksList.length + completedHabits.length;
 
+    // Auto-show suggestions when the day is completely empty
+    const isEmptyDay =
+        totalPlannedItems === 0 &&
+        sortedDueTodayTasks.length === 0 &&
+        sortedOverdueTasks.length === 0;
+    const effectiveShowSuggestions =
+        todaySettings.showSuggestions ||
+        (isEmptyDay && sortedSuggestedTasks.length > 0);
+
     // Handle settings change
     const handleSettingsChange = (newSettings: typeof todaySettings) => {
         setTodaySettings(newSettings);
@@ -1775,9 +1801,14 @@ const TasksToday: React.FC = () => {
                     >
                         <div className="bg-white dark:bg-gray-900 rounded-lg shadow p-4 h-20"></div>
                     </div>
-                ) : todaySettings.showSuggestions &&
+                ) : effectiveShowSuggestions &&
                   sortedSuggestedTasks.length > 0 ? (
                     <div className="mt-2 mb-6">
+                        {isEmptyDay && (
+                            <p className="text-sm text-gray-400 dark:text-gray-500 mb-3 italic">
+                                {t('tasks.noPlanYet', 'No plan yet — here are some ideas:')}
+                            </p>
+                        )}
                         <div
                             className="flex items-center justify-between cursor-pointer mt-6 mb-2 pb-2 border-b border-gray-200 dark:border-gray-700"
                             onClick={toggleSuggestedCollapsed}
@@ -1810,48 +1841,24 @@ const TasksToday: React.FC = () => {
                                     onTaskDelete={handleTaskDelete}
                                     projects={localProjects}
                                     onToggleToday={undefined}
+                                    showSuggestionChips={true}
                                 />
 
                                 {suggestedDisplayLimit <
                                     sortedSuggestedTasks.length && (
-                                    <div className="flex justify-center pt-4 pb-2 gap-3">
+                                    <div className="flex justify-center pt-3 pb-2">
                                         <button
                                             onClick={() =>
                                                 setSuggestedDisplayLimit(
-                                                    (prev) => prev + 20
+                                                    (prev) => prev + 5
                                                 )
                                             }
-                                            className="inline-flex items-center px-5 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
+                                            className="text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                                         >
-                                            <QueueListIcon className="h-4 w-4 mr-2" />
-                                            {t('common.loadMore', 'Load More')}
-                                        </button>
-                                        <button
-                                            onClick={() =>
-                                                setSuggestedDisplayLimit(
-                                                    sortedSuggestedTasks.length
-                                                )
-                                            }
-                                            className="inline-flex items-center px-5 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition-colors"
-                                        >
-                                            {t('common.showAll', 'Show All')}
+                                            {Math.min(5, sortedSuggestedTasks.length - suggestedDisplayLimit)} more
                                         </button>
                                     </div>
                                 )}
-
-                                <div className="text-center text-sm text-gray-500 dark:text-gray-400 pt-2 pb-4">
-                                    {t(
-                                        'tasks.showingItems',
-                                        'Showing {{current}} of {{total}} tasks',
-                                        {
-                                            current: Math.min(
-                                                suggestedDisplayLimit,
-                                                sortedSuggestedTasks.length
-                                            ),
-                                            total: sortedSuggestedTasks.length,
-                                        }
-                                    )}
-                                </div>
                             </>
                         )}
                     </div>

--- a/frontend/components/Tasks.tsx
+++ b/frontend/components/Tasks.tsx
@@ -21,6 +21,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { getApiPath } from '../config/paths';
 import { getCsrfToken } from '../utils/csrfService';
+import { isTaskActive } from '../constants/taskStatus';
 
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
 
@@ -96,14 +97,9 @@ const Tasks: React.FC = () => {
                 return isCompleted;
             });
         } else if (status === 'active') {
-            filteredTasks = filteredTasks.filter((task: Task) => {
-                const isCompleted =
-                    task.status === 'done' ||
-                    task.status === 'archived' ||
-                    task.status === 2 ||
-                    task.status === 3;
-                return !isCompleted;
-            });
+            filteredTasks = filteredTasks.filter((task: Task) =>
+                isTaskActive(task.status)
+            );
         }
 
         if (taskSearchQuery.trim() && !isUpcomingView) {

--- a/frontend/entities/Task.ts
+++ b/frontend/entities/Task.ts
@@ -1,5 +1,6 @@
 import { Tag } from './Tag';
 import { Project } from './Project';
+import { Area } from './Area';
 import { Attachment } from './Attachment';
 
 export interface Task {
@@ -16,6 +17,8 @@ export interface Task {
     tags?: Tag[];
     project_id?: number;
     Project?: Project;
+    area_id?: number;
+    Area?: Area;
     created_at?: string;
     updated_at?: string;
     recurrence_type?: RecurrenceType;
@@ -42,6 +45,13 @@ export interface Task {
     habit_best_streak?: number;
     habit_total_completions?: number;
     habit_last_completion_at?: string;
+    // Transient UI field set by suggestion scoring — never persisted or sent to server
+    _suggestionMeta?: {
+        score: number;
+        reason: 'area_balance' | 'due' | 'fits_now' | 'revive' | 'high' | 'aging_review' | 'next_step';
+        reasonLabel: string;
+        reasonColor: string;
+    };
 }
 
 export type StatusType =

--- a/frontend/store/useStore.ts
+++ b/frontend/store/useStore.ts
@@ -33,10 +33,12 @@ interface ProjectsStore {
     currentProject: Project | null;
     isLoading: boolean;
     isError: boolean;
+    hasLoaded: boolean;
     setProjects: (projects: Project[]) => void;
     setCurrentProject: (project: Project | null) => void;
     setLoading: (isLoading: boolean) => void;
     setError: (isError: boolean) => void;
+    loadProjects: () => Promise<void>;
 }
 
 interface TagsStore {
@@ -236,6 +238,7 @@ export const useStore = create<StoreState>((set: any) => ({
         currentProject: null,
         isLoading: false,
         isError: false,
+        hasLoaded: false,
         setProjects: (projects) =>
             set((state) => ({
                 projectsStore: { ...state.projectsStore, projects },
@@ -252,6 +255,42 @@ export const useStore = create<StoreState>((set: any) => ({
             set((state) => ({
                 projectsStore: { ...state.projectsStore, isError },
             })),
+        loadProjects: async () => {
+            const state = useStore.getState();
+            if (state.projectsStore.isLoading) return;
+
+            const { fetchProjects } = await import('../utils/projectsService');
+
+            set((state) => ({
+                projectsStore: {
+                    ...state.projectsStore,
+                    isLoading: true,
+                    isError: false,
+                },
+            }));
+
+            try {
+                const projects = await fetchProjects();
+                set((state) => ({
+                    projectsStore: {
+                        ...state.projectsStore,
+                        projects,
+                        isLoading: false,
+                        hasLoaded: true,
+                    },
+                }));
+            } catch (error) {
+                console.error('loadProjects: Failed to load projects:', error);
+                set((state) => ({
+                    projectsStore: {
+                        ...state.projectsStore,
+                        isError: true,
+                        isLoading: false,
+                        hasLoaded: true,
+                    },
+                }));
+            }
+        },
     },
     tagsStore: {
         tags: [],

--- a/frontend/utils/suggestionScoringUtils.ts
+++ b/frontend/utils/suggestionScoringUtils.ts
@@ -1,0 +1,314 @@
+import { Task } from '../entities/Task';
+import { Project } from '../entities/Project';
+
+export type SuggestionReason =
+    | 'due'
+    | 'fits_now'
+    | 'revive'
+    | 'high'
+    | 'aging_review'
+    | 'next_step'
+    | 'area_balance';
+
+export interface SuggestionMeta {
+    score: number;
+    reason: SuggestionReason;
+    reasonLabel: string;
+    reasonColor: string;
+}
+
+export interface SuggestionOpts {
+    balanceMode?: boolean;
+    contextFilter?: string;
+}
+
+interface AreaStats {
+    name: string;
+    color: string;
+    total: number;
+    share: number;
+}
+
+const FALLBACK_COLOR = '#6b7280';
+
+function getPriorityScore(priority: Task['priority']): number {
+    if (priority === 'high' || priority === 2) return 100;
+    if (priority === 'medium' || priority === 1) return 60;
+    if (priority === 'low' || priority === 0) return 30;
+    return 0;
+}
+
+function isPendingStatus(status: Task['status']): boolean {
+    return (
+        status === 'not_started' ||
+        status === 'waiting' ||
+        status === (0 as any) ||
+        status === (1 as any)
+    );
+}
+
+function isActiveProject(project: Project): boolean {
+    return project.status !== 'done' && project.status !== 'cancelled';
+}
+
+function isSomedayTask(task: Task): boolean {
+    return (task.tags ?? []).some(
+        (tag) => tag.name?.toLowerCase() === 'someday'
+    );
+}
+
+export function computeAreaStats(projects: Project[]): AreaStats[] {
+    const map = new Map<
+        string,
+        { color: string; total: number }
+    >();
+
+    projects.forEach((p) => {
+        const areaObj = (p as any).Area ?? p.area;
+        const name = areaObj?.name ?? 'No Area';
+        const color: string = areaObj?.color ?? FALLBACK_COLOR;
+        const total = p.task_status?.total ?? 0;
+        const existing = map.get(name);
+        if (existing) {
+            existing.total += total;
+        } else {
+            map.set(name, { color, total });
+        }
+    });
+
+    const totalAll = Array.from(map.values()).reduce((s, a) => s + a.total, 0);
+
+    return Array.from(map.entries()).map(([name, data]) => ({
+        name,
+        color: data.color,
+        total: data.total,
+        share: totalAll > 0 ? (data.total / totalAll) * 100 : 0,
+    }));
+}
+
+// Build one-per-project candidate pool: one next action per active project + all orphan tasks.
+// Uses the task's own embedded Project.status (from getTaskIncludeConfigLight) so we don't
+// depend on ID-matching against localProjects, which can silently fail.
+export function buildCandidatePool(
+    tasks: Task[],
+    projects: Project[]
+): Task[] {
+    const pendingTasks = tasks.filter(
+        (t) => isPendingStatus(t.status) && !isSomedayTask(t)
+    );
+
+    // Group pending tasks by project_id, reading status from the embedded Project object
+    const byProject = new Map<
+        number,
+        { tasks: Task[]; projectStatus: string | undefined }
+    >();
+    const orphans: Task[] = [];
+
+    pendingTasks.forEach((task) => {
+        const projectId = task.project_id ?? (task.Project as any)?.id ?? null;
+        if (projectId) {
+            const existing = byProject.get(projectId);
+            if (existing) {
+                existing.tasks.push(task);
+            } else {
+                const projectStatus =
+                    (task.Project as any)?.status ??
+                    projects.find((p) => p.id === projectId)?.status;
+                byProject.set(projectId, {
+                    tasks: [task],
+                    projectStatus,
+                });
+            }
+        } else {
+            orphans.push(task);
+        }
+    });
+
+    const candidates: Task[] = [];
+
+    // One next action per active project
+    byProject.forEach(({ tasks: projTasks, projectStatus }) => {
+        if (!isActiveProject({ status: projectStatus } as Project)) return;
+
+        const sorted = [...projTasks].sort((a, b) => {
+            const pa = getPriorityScore(a.priority);
+            const pb = getPriorityScore(b.priority);
+            if (pb !== pa) return pb - pa;
+            const dateA = a.created_at ? new Date(a.created_at).getTime() : 0;
+            const dateB = b.created_at ? new Date(b.created_at).getTime() : 0;
+            return dateA - dateB;
+        });
+        candidates.push(sorted[0]);
+    });
+
+    candidates.push(...orphans);
+    return candidates;
+}
+
+export function scoreCandidate(
+    task: Task,
+    projects: Project[],
+    areaStats: AreaStats[],
+    opts: SuggestionOpts = {}
+): SuggestionMeta {
+    const project = projects.find((p) => p.id === task.project_id);
+    const areaObj = project ? ((project as any).Area ?? project.area) : null;
+    const areaName: string = areaObj?.name ?? 'No Area';
+    const areaColor: string = areaObj?.color ?? FALLBACK_COLOR;
+    const areaStat = areaStats.find((a) => a.name === areaName);
+
+    let score = getPriorityScore(task.priority);
+    let reason: SuggestionReason = 'next_step';
+
+    // Orphan boost: tasks without a project get a slight nudge
+    if (!task.project_id) {
+        score += 5;
+    }
+
+    // Due today / overdue nudge (highest priority nudge)
+    const today = new Date().toISOString().split('T')[0];
+    if (task.due_date) {
+        const dueStr = task.due_date.split('T')[0];
+        if (dueStr <= today) {
+            score += 15;
+            reason = 'due';
+        }
+    }
+
+    // Context filter nudge
+    if (opts.contextFilter && reason === 'next_step') {
+        const hasContextTag = (task.tags ?? []).some(
+            (tag) =>
+                tag.name?.toLowerCase() ===
+                opts.contextFilter?.toLowerCase()
+        );
+        if (hasContextTag) {
+            score += 10;
+            reason = 'fits_now';
+        }
+    }
+
+    // Stalled project nudge
+    if (project?.is_stalled && reason === 'next_step') {
+        score += 8;
+        reason = 'revive';
+    }
+
+    // Balance mode nudge (opt-in only)
+    if (opts.balanceMode && areaStat && reason === 'next_step') {
+        const numAreas = areaStats.filter((a) => a.total > 0).length;
+        const equalShare = numAreas > 0 ? 100 / numAreas : 100;
+        if (areaStat.share < equalShare * 0.6) {
+            score += 30;
+            reason = 'area_balance';
+        } else if (areaStat.share < equalShare * 0.85) {
+            score += 15;
+            reason = 'area_balance';
+        }
+    }
+
+    // High priority chip (no score change — score already captured in priority_score)
+    if (
+        reason === 'next_step' &&
+        (task.priority === 'high' || task.priority === 2)
+    ) {
+        reason = 'high';
+    }
+
+    // Aging review chip — only for orphan tasks (no project), informational only, no score change.
+    // Project next-actions keep 'next_step' regardless of age: an old project task is a real
+    // next action, not a deletion candidate.
+    const refDate = task.updated_at ?? task.created_at;
+    let agingDays = 0;
+    if (refDate) {
+        agingDays = Math.round(
+            (Date.now() - new Date(refDate).getTime()) / 86_400_000
+        );
+    }
+    if (reason === 'next_step' && agingDays >= 60 && !task.project_id) {
+        reason = 'aging_review';
+    }
+
+    // Build chip label and color
+    const projectName = project?.name ?? '';
+
+    let reasonLabel: string;
+    let reasonColor: string;
+
+    switch (reason) {
+        case 'due': {
+            const isOverdue = task.due_date
+                ? task.due_date.split('T')[0] < today
+                : false;
+            reasonLabel = isOverdue
+                ? 'This task is overdue'
+                : 'This task is due today';
+            reasonColor = isOverdue ? '#f97316' : '#ef4444';
+            break;
+        }
+        case 'fits_now':
+            reasonLabel = 'Matches your current context';
+            reasonColor = areaColor;
+            break;
+        case 'revive':
+            reasonLabel = projectName
+                ? `Completing this moves ${projectName} forward`
+                : 'Completing this revives stalled work';
+            reasonColor = FALLBACK_COLOR;
+            break;
+        case 'high':
+            reasonLabel = 'High priority — worth tackling now';
+            reasonColor = '#ef4444';
+            break;
+        case 'aging_review':
+            reasonLabel = `Hasn't been touched in ${agingDays} days — still relevant?`;
+            reasonColor = FALLBACK_COLOR;
+            break;
+        case 'area_balance':
+            reasonLabel = `Helps balance your ${areaName} area`;
+            reasonColor = areaStat?.color ?? FALLBACK_COLOR;
+            break;
+        case 'next_step':
+        default:
+            reasonLabel = projectName
+                ? `The next open step in ${projectName}`
+                : 'A good action to tackle next';
+            reasonColor = areaColor;
+            reason = 'next_step';
+            break;
+    }
+
+    return { score, reason, reasonLabel, reasonColor };
+}
+
+export function scoreAndSortSuggestedTasks(
+    tasks: Task[],
+    projects: Project[],
+    opts: SuggestionOpts = {}
+): Array<Task & { _suggestionMeta: SuggestionMeta }> {
+    const areaStats = computeAreaStats(projects);
+    const candidates = buildCandidatePool(tasks, projects);
+
+
+    const scored = candidates.map((task) => ({
+        ...task,
+        _suggestionMeta: scoreCandidate(task, projects, areaStats, opts),
+    }));
+
+    scored.sort((a, b) => b._suggestionMeta.score - a._suggestionMeta.score);
+
+    // Safety net: enforce max 1 task per project after scoring
+    const seenProjects = new Set<number>();
+    const deduped = scored.filter((task) => {
+        if (task.project_id == null) return true;
+        if (seenProjects.has(task.project_id)) return false;
+        seenProjects.add(task.project_id);
+        return true;
+    });
+
+    // Stale tasks are informational nudges, not priorities.
+    // Cap at 1 and push to the end so project next-actions lead.
+    const nonStale = deduped.filter((t) => t._suggestionMeta.reason !== 'aging_review');
+    const stale = deduped.filter((t) => t._suggestionMeta.reason === 'aging_review');
+    return [...nonStale, ...stale.slice(0, 1)];
+}


### PR DESCRIPTION
## Description

Tasks can now be assigned directly to an **Area** without requiring an intermediate Project. This fills a gap in the hierarchy where loose tasks within a life domain had no clean home.

**What changed:**
- New DB migration adds `area_id` FK to the `tasks` table (nullable, SET NULL on area delete)
- Task model, serializers, query-builders, and validation updated to support `area_id`
- `POST /task` and `PATCH /task/:uid` routes now accept and validate `area_id` with ownership checks
- `TaskAreaCard` component in TaskDetails lets users select or clear an area on a task
- `AreaDetails` page redesigned: now shows a live task list for all tasks assigned to the area
- `TaskItem` displays area assignment where relevant
- `Task` entity extended with `area_id` / `Area` fields and a transient `_suggestionMeta` UI field
- `useStore` gains `loadProjects` + `hasLoaded` to avoid redundant fetches

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Testing

```bash
npm run db:migrate      # applies the area_id migration
npm start               # verify task create/edit with area assignment
```

- Create a task and assign it to an area via TaskDetails → Area card
- Clear the area assignment and confirm it persists
- Navigate to an Area detail page and confirm area-assigned tasks appear in the list
- Confirm tasks without an area are unaffected

## Checklist

- [x] Code follows project conventions
- [x] Linting passes (`npm run lint`)
- [x] Migration includes both `up` and `down` paths
- [x] No breaking changes to existing task API fields