### PR TITLE
feat(ui): add consistent back button to task and project views

### DIFF
--- a/frontend/components/Project/ProjectBanner.tsx
+++ b/frontend/components/Project/ProjectBanner.tsx
@@ -8,6 +8,7 @@ import {
     CameraIcon,
 } from '@heroicons/react/24/outline';
 import BannerBadge from '../Shared/BannerBadge';
+import BackButton from '../Shared/BackButton';
 import { Project } from '../../entities/Project';
 import { Area } from '../../entities/Area';
 import { useNavigate } from 'react-router-dom';
@@ -81,6 +82,7 @@ const ProjectBanner: React.FC<ProjectBannerProps> = ({
                         style={{ backgroundColor: project.color }}
                     />
                 )}
+                <BackButton variant="overlay" className="absolute top-4 right-4 z-20" />
 
                 {creatorName && (
                     <div className="absolute top-2 right-2 bg-black bg-opacity-60 text-white text-xs px-2 py-1 rounded backdrop-blur-sm">

--- a/frontend/components/Project/ProjectDetails.tsx
+++ b/frontend/components/Project/ProjectDetails.tsx
@@ -12,7 +12,6 @@ import {
     XCircleIcon,
     ChartBarIcon,
     CheckIcon,
-    ArrowLeftIcon,
 } from '@heroicons/react/24/outline';
 import { useToast } from '../Shared/ToastContext';
 import ProjectModal from './ProjectModal';
@@ -853,13 +852,6 @@ const ProjectDetails: React.FC = () => {
             />
 
             <div className="w-full px-4 sm:px-6 lg:px-10">
-                <button
-                    onClick={() => navigate(-1)}
-                    className="flex items-center gap-2 text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white mb-4"
-                >
-                    <ArrowLeftIcon className="h-5 w-5" />
-                    {t('common.back', 'Back')}
-                </button>
                 <div className="w-full">
                     <div className="mb-4">
                         <div className="flex items-center justify-between min-h-[2.5rem]">

--- a/frontend/components/Shared/BackButton.tsx
+++ b/frontend/components/Shared/BackButton.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from 'react-i18next';
+
+interface BackButtonProps {
+    className?: string;
+    variant?: 'default' | 'overlay';
+}
+
+const BackButton: React.FC<BackButtonProps> = ({
+    className = '',
+    variant = 'default',
+}) => {
+    const navigate = useNavigate();
+    const { t } = useTranslation();
+
+    const baseClass =
+        variant === 'overlay'
+            ? 'flex items-center gap-1.5 text-sm text-white/90 hover:text-white bg-black/40 hover:bg-black/60 backdrop-blur-sm px-3 py-1.5 rounded-full transition-colors'
+            : 'flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-100 transition-colors';
+
+    return (
+        <button
+            onClick={() => navigate(-1)}
+            className={`${baseClass} ${className}`}
+        >
+            <ArrowLeftIcon className="h-4 w-4" />
+            <span>{t('common.back', 'Back')}</span>
+        </button>
+    );
+};
+
+export default BackButton;

--- a/frontend/components/Task/TaskDetails/TaskDetailsHeader.tsx
+++ b/frontend/components/Task/TaskDetails/TaskDetailsHeader.tsx
@@ -13,6 +13,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { Link } from 'react-router-dom';
 import { Task, PriorityType } from '../../../entities/Task';
+import BackButton from '../../Shared/BackButton';
 import { formatDateTime } from '../../../utils/dateUtils';
 import TaskStatusControl from '../TaskStatusControl';
 import { getStatusValue } from '../../../constants/taskStatus';
@@ -271,7 +272,7 @@ const TaskDetailsHeader: React.FC<TaskDetailsHeaderProps> = ({
         <div className="mb-6">
             <div className="rounded-lg shadow-sm bg-white dark:bg-gray-900 border-2 border-gray-50 dark:border-gray-800 px-6 py-5">
                 <div className="flex items-center justify-between gap-4">
-                    <div className="flex-1 min-w-0">
+                    <div className="flex-1 min-w-0 overflow-hidden">
                         {isEditingTitle ? (
                             <input
                                 ref={titleInputRef}
@@ -580,6 +581,7 @@ const TaskDetailsHeader: React.FC<TaskDetailsHeaderProps> = ({
                             </>
                         )}
                     </div>
+                    <BackButton className="flex-shrink-0 self-start" />
                 </div>
 
                 {/* Divider - Edge to edge */}


### PR DESCRIPTION
## Description

Adds a shared `BackButton` component used consistently across the task detail and project detail views.

## Type of Change

- [x] New feature

## Changes

- **`frontend/components/Shared/BackButton.tsx`** — new shared component with two variants:
  - `default`: muted gray text link, for use on plain page backgrounds (task view)
  - `overlay`: frosted semi-transparent pill, for use on banner images (project view)
- **Project view**: back button overlaid in the **top-right** of the banner image; color circle remains top-left
- **Task view**: back button sits in the **top-right of the header card**, inline with the title row
- Removed inline back button from `ProjectDetails.tsx` and `ArrowLeftIcon` import now unused there

## Related Issues

N/A

## Testing

- Open a task detail page → "← Back" appears top-right inside the header card
- Open a project detail page → "← Back" frosted pill appears top-right of the banner image
- Color circle (when project has a color) remains top-left, no overlap
- Both variants work in light and dark mode

## Checklist

- [x] Tested in both light and dark mode
- [x] No console errors
- [x] Shared component used in both views (single source of truth)