### PR TITLE
fix(uid): complete migration from numeric IDs to UIDs

### DIFF
--- a/backend/modules/goals/controller.js
+++ b/backend/modules/goals/controller.js
@@ -14,8 +14,8 @@ const goalsController = {
     async list(req, res, next) {
         try {
             const userId = requireUserId(req);
-            const { area_id } = req.query;
-            const goals = await goalsService.getAll(userId, area_id);
+            const { area_id, area_uid } = req.query;
+            const goals = await goalsService.getAll(userId, area_id, area_uid);
             res.json({ goals });
         } catch (err) {
             next(err);

--- a/backend/modules/goals/service.js
+++ b/backend/modules/goals/service.js
@@ -1,10 +1,18 @@
 'use strict';
 
 const goalsRepository = require('./repository');
+const { Area } = require('../../models');
 const { NotFoundError, ValidationError } = require('../../shared/errors');
 
 class GoalsService {
-    async getAll(userId, areaId) {
+    async getAll(userId, areaId, areaUid) {
+        if (areaUid) {
+            const area = await Area.findOne({ where: { uid: areaUid } });
+            if (area) {
+                return goalsRepository.findAllByArea(userId, area.id);
+            }
+            return [];
+        }
         if (areaId) {
             return goalsRepository.findAllByArea(userId, areaId);
         }

--- a/backend/modules/notifications/controller.js
+++ b/backend/modules/notifications/controller.js
@@ -38,7 +38,7 @@ const notificationsController = {
             const userId = requireUserId(req);
             const result = await notificationsService.markAsRead(
                 userId,
-                req.params.id
+                req.params.uid
             );
             res.json(result);
         } catch (error) {
@@ -51,7 +51,7 @@ const notificationsController = {
             const userId = requireUserId(req);
             const result = await notificationsService.markAsUnread(
                 userId,
-                req.params.id
+                req.params.uid
             );
             res.json(result);
         } catch (error) {
@@ -74,7 +74,7 @@ const notificationsController = {
             const userId = requireUserId(req);
             const result = await notificationsService.dismiss(
                 userId,
-                req.params.id
+                req.params.uid
             );
             res.json(result);
         } catch (error) {

--- a/backend/modules/notifications/repository.js
+++ b/backend/modules/notifications/repository.js
@@ -25,6 +25,12 @@ class NotificationsRepository extends BaseRepository {
             where: { id, user_id: userId, ...options },
         });
     }
+
+    async findByUidAndUser(uid, userId, options = {}) {
+        return this.model.findOne({
+            where: { uid, user_id: userId, ...options },
+        });
+    }
 }
 
 module.exports = new NotificationsRepository();

--- a/backend/modules/notifications/routes.js
+++ b/backend/modules/notifications/routes.js
@@ -9,13 +9,13 @@ router.get(
     '/notifications/unread-count',
     notificationsController.getUnreadCount
 );
-router.post('/notifications/:id/read', notificationsController.markAsRead);
-router.post('/notifications/:id/unread', notificationsController.markAsUnread);
+router.post('/notifications/:uid/read', notificationsController.markAsRead);
+router.post('/notifications/:uid/unread', notificationsController.markAsUnread);
 router.post(
     '/notifications/mark-all-read',
     notificationsController.markAllAsRead
 );
-router.delete('/notifications/:id', notificationsController.dismiss);
+router.delete('/notifications/:uid', notificationsController.dismiss);
 router.post(
     '/test-notifications/trigger',
     notificationsController.triggerTestNotification

--- a/backend/modules/notifications/service.js
+++ b/backend/modules/notifications/service.js
@@ -19,9 +19,9 @@ class NotificationsService {
         return { count };
     }
 
-    async markAsRead(userId, notificationId) {
-        const notification = await notificationsRepository.findByIdAndUser(
-            notificationId,
+    async markAsRead(userId, notificationUid) {
+        const notification = await notificationsRepository.findByUidAndUser(
+            notificationUid,
             userId
         );
         if (!notification) {
@@ -31,9 +31,9 @@ class NotificationsService {
         return { notification, message: 'Notification marked as read' };
     }
 
-    async markAsUnread(userId, notificationId) {
-        const notification = await notificationsRepository.findByIdAndUser(
-            notificationId,
+    async markAsUnread(userId, notificationUid) {
+        const notification = await notificationsRepository.findByUidAndUser(
+            notificationUid,
             userId
         );
         if (!notification) {
@@ -48,9 +48,9 @@ class NotificationsService {
         return { count, message: `Marked ${count} notifications as read` };
     }
 
-    async dismiss(userId, notificationId) {
-        const notification = await notificationsRepository.findByIdAndUser(
-            notificationId,
+    async dismiss(userId, notificationUid) {
+        const notification = await notificationsRepository.findByUidAndUser(
+            notificationUid,
             userId,
             { dismissed_at: null }
         );

--- a/backend/modules/tasks/core/serializers.js
+++ b/backend/modules/tasks/core/serializers.js
@@ -82,6 +82,8 @@ async function serializeTask(
         name: displayName,
         original_name: taskJson.name,
         uid: task.uid,
+        project_uid: taskJson.Project?.uid || null,
+        area_uid: taskJson.Area?.uid || null,
         recurring_parent_uid: recurringParentUid,
         due_date: processDueDateForResponse(taskJson.due_date, safeTimezone),
         defer_until: processDeferUntilForResponse(

--- a/backend/modules/tasks/queries/query-builders.js
+++ b/backend/modules/tasks/queries/query-builders.js
@@ -408,7 +408,12 @@ async function filterTasksByParams(
         };
     }
 
-    if (params.area_id) {
+    if (params.area_uid) {
+        const area = await Area.findOne({ where: { uid: params.area_uid } });
+        if (area) {
+            whereClause.area_id = area.id;
+        }
+    } else if (params.area_id) {
         whereClause.area_id = params.area_id;
     }
 

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -408,7 +408,9 @@ router.post('/task', async (req, res) => {
         const {
             name,
             project_id,
+            project_uid,
             area_id,
+            area_uid,
             parent_task_id,
             tags,
             Tags,
@@ -445,7 +447,7 @@ router.post('/task', async (req, res) => {
 
         try {
             const validProjectId = await validateProjectAccess(
-                project_id,
+                project_uid || project_id,
                 req.currentUser.id
             );
             if (validProjectId) taskAttributes.project_id = validProjectId;
@@ -457,7 +459,7 @@ router.post('/task', async (req, res) => {
 
         try {
             const validAreaId = await validateAreaAccess(
-                area_id,
+                area_uid || area_id,
                 req.currentUser.id
             );
             if (validAreaId) taskAttributes.area_id = validAreaId;
@@ -559,7 +561,9 @@ router.patch('/task/:uid', requireTaskWriteAccess, async (req, res) => {
         const {
             status,
             project_id,
+            project_uid,
             area_id,
+            area_uid,
             parent_task_id,
             tags,
             Tags,
@@ -662,10 +666,12 @@ router.patch('/task/:uid', requireTaskWriteAccess, async (req, res) => {
 
         await handleCompletionStatus(taskAttributes, status, task);
 
-        if (project_id !== undefined) {
+        const projectIdentifier =
+            project_uid !== undefined ? project_uid : project_id;
+        if (projectIdentifier !== undefined) {
             try {
                 const validProjectId = await validateProjectAccess(
-                    project_id,
+                    projectIdentifier,
                     req.currentUser.id
                 );
                 taskAttributes.project_id = validProjectId;
@@ -676,10 +682,11 @@ router.patch('/task/:uid', requireTaskWriteAccess, async (req, res) => {
             }
         }
 
-        if (area_id !== undefined) {
+        const areaIdentifier = area_uid !== undefined ? area_uid : area_id;
+        if (areaIdentifier !== undefined) {
             try {
                 const validAreaId = await validateAreaAccess(
-                    area_id,
+                    areaIdentifier,
                     req.currentUser.id
                 );
                 taskAttributes.area_id = validAreaId;

--- a/backend/modules/tasks/utils/validation.js
+++ b/backend/modules/tasks/utils/validation.js
@@ -1,12 +1,19 @@
 const { Project, Task, Area } = require('../../../models');
 const permissionsService = require('../../../services/permissionsService');
 
-async function validateProjectAccess(projectId, userId) {
-    if (!projectId || !projectId.toString().trim()) {
+function isUid(value) {
+    const str = value.toString().trim();
+    return isNaN(Number(str)) || !Number.isInteger(Number(str));
+}
+
+async function validateProjectAccess(projectIdOrUid, userId) {
+    if (!projectIdOrUid || !projectIdOrUid.toString().trim()) {
         return null;
     }
 
-    const project = await Project.findOne({ where: { id: projectId } });
+    const value = projectIdOrUid.toString().trim();
+    const where = isUid(value) ? { uid: value } : { id: value };
+    const project = await Project.findOne({ where });
     if (!project) {
         throw new Error('Invalid project.');
     }
@@ -24,7 +31,7 @@ async function validateProjectAccess(projectId, userId) {
         throw new Error('Forbidden');
     }
 
-    return projectId;
+    return project.id;
 }
 
 async function validateParentTaskAccess(parentTaskId, userId) {
@@ -135,17 +142,21 @@ function validateDeferUntilAndDueDate(
     }
 }
 
-async function validateAreaAccess(areaId, userId) {
-    if (!areaId || !areaId.toString().trim()) {
+async function validateAreaAccess(areaIdOrUid, userId) {
+    if (!areaIdOrUid || !areaIdOrUid.toString().trim()) {
         return null;
     }
 
-    const area = await Area.findOne({ where: { id: areaId, user_id: userId } });
+    const value = areaIdOrUid.toString().trim();
+    const where = isUid(value)
+        ? { uid: value, user_id: userId }
+        : { id: value, user_id: userId };
+    const area = await Area.findOne({ where });
     if (!area) {
         throw new Error('Invalid area.');
     }
 
-    return areaId;
+    return area.id;
 }
 
 module.exports = {

--- a/backend/tests/integration/notification-soft-delete.test.js
+++ b/backend/tests/integration/notification-soft-delete.test.js
@@ -40,7 +40,7 @@ describe('Notification Soft Delete', () => {
 
             // Delete (dismiss) the notification
             const deleteResponse = await agent.delete(
-                `/api/notifications/${notification.id}`
+                `/api/notifications/${notification.uid}`
             );
 
             expect(deleteResponse.status).toBe(200);
@@ -72,7 +72,7 @@ describe('Notification Soft Delete', () => {
 
             // Try to dismiss again
             const deleteResponse = await agent.delete(
-                `/api/notifications/${notification.id}`
+                `/api/notifications/${notification.uid}`
             );
 
             expect(deleteResponse.status).toBe(404);
@@ -98,7 +98,7 @@ describe('Notification Soft Delete', () => {
             });
 
             // Dismiss the first notification
-            await agent.delete(`/api/notifications/${notification1.id}`);
+            await agent.delete(`/api/notifications/${notification1.uid}`);
 
             // Get notifications
             const getResponse = await agent.get('/api/notifications');
@@ -134,7 +134,7 @@ describe('Notification Soft Delete', () => {
             expect(countResponse.body.count).toBe(2);
 
             // Dismiss one notification
-            await agent.delete(`/api/notifications/${notification1.id}`);
+            await agent.delete(`/api/notifications/${notification1.uid}`);
 
             // Check unread count again (should be 1)
             countResponse = await agent.get('/api/notifications/unread-count');

--- a/frontend/components/Area/AreaDetails.tsx
+++ b/frontend/components/Area/AreaDetails.tsx
@@ -106,42 +106,42 @@ const AreaDetails: React.FC = () => {
     }, [areaUid, areasStore.areas, areasStore.isLoading]);
 
     const loadAreaTasks = useCallback(async () => {
-        if (!area?.id) return;
+        if (!area?.uid) return;
         setLoadingTasks(true);
         try {
-            const result = await fetchTasks(`?area_id=${area.id}&type=all&status=all`);
+            const result = await fetchTasks(`?area_uid=${area.uid}&type=all&status=all`);
             setAreaTasks(result.tasks || []);
         } catch {
             setAreaTasks([]);
         } finally {
             setLoadingTasks(false);
         }
-    }, [area?.id]);
+    }, [area?.uid]);
 
     useEffect(() => {
-        if (area?.id) {
+        if (area?.uid) {
             loadAreaTasks();
         }
-    }, [area?.id, loadAreaTasks]);
+    }, [area?.uid, loadAreaTasks]);
 
     const loadGoals = useCallback(async () => {
-        if (!area?.id) return;
+        if (!area?.uid) return;
         setLoadingGoals(true);
         try {
-            const data = await fetchGoals(area.id);
+            const data = await fetchGoals(area.uid);
             setGoals(data);
         } catch {
             setGoals([]);
         } finally {
             setLoadingGoals(false);
         }
-    }, [area?.id]);
+    }, [area?.uid]);
 
     useEffect(() => {
-        if (area?.id) {
+        if (area?.uid) {
             loadGoals();
         }
-    }, [area?.id, loadGoals]);
+    }, [area?.uid, loadGoals]);
 
     const areaProjects = projectsStore.projects.filter((p: Project) => {
         const projectArea = p.area || (p as any).Area;

--- a/frontend/components/Inbox/InboxItemDetail.tsx
+++ b/frontend/components/Inbox/InboxItemDetail.tsx
@@ -340,7 +340,7 @@ const InboxItemDetail: React.FC<InboxItemDetailProps> = ({
             return existingTag || { name: hashtagName };
         });
 
-        let projectId = undefined;
+        let projectUid: string | undefined = undefined;
         if (sourceProjectRefs.length > 0) {
             const projectName = sourceProjectRefs[0];
             const matchingProject = projects.find(
@@ -348,7 +348,7 @@ const InboxItemDetail: React.FC<InboxItemDetailProps> = ({
                     project.name.toLowerCase() === projectName.toLowerCase()
             );
             if (matchingProject) {
-                projectId = matchingProject.id;
+                projectUid = matchingProject.uid;
             }
         }
 
@@ -356,7 +356,7 @@ const InboxItemDetail: React.FC<InboxItemDetailProps> = ({
             sourceText,
             cleanedContent: cleaned,
             tagObjects,
-            projectId,
+            projectUid,
             projectRefsList: sourceProjectRefs,
             hashtagsList: sourceHashtags,
         };
@@ -376,7 +376,7 @@ const InboxItemDetail: React.FC<InboxItemDetailProps> = ({
                 status: 'not_started',
                 priority: null,
                 tags: payload.tagObjects,
-                project_id: payload.projectId,
+                project_uid: payload.projectUid,
                 completed_at: null,
             };
 
@@ -492,7 +492,7 @@ const InboxItemDetail: React.FC<InboxItemDetailProps> = ({
             title: finalTitle,
             content: finalContent,
             tags: tagObjects,
-            project_uid: payload.projectId,
+            project_uid: payload.projectUid,
         };
 
         if (item.uid !== undefined) {

--- a/frontend/components/Inbox/QuickCaptureInput.tsx
+++ b/frontend/components/Inbox/QuickCaptureInput.tsx
@@ -1074,7 +1074,7 @@ const QuickCaptureInput = React.forwardRef<
                             }
                         );
 
-                        let projectId = undefined;
+                        let projectUid: string | undefined = undefined;
                         if (analysisResult.parsed_projects.length > 0) {
                             const projectName =
                                 analysisResult.parsed_projects[0];
@@ -1084,7 +1084,7 @@ const QuickCaptureInput = React.forwardRef<
                                     projectName.toLowerCase()
                             );
                             if (matchingProject) {
-                                projectId = matchingProject.id;
+                                projectUid = matchingProject.uid;
                             }
                         }
 
@@ -1093,7 +1093,7 @@ const QuickCaptureInput = React.forwardRef<
                             status: 'not_started',
                             priority: 'low',
                             tags: taskTags,
-                            project_id: projectId,
+                            project_uid: projectUid,
                             completed_at: null,
                         };
 
@@ -1151,7 +1151,7 @@ const QuickCaptureInput = React.forwardRef<
 
                         const taskTags = [...hashtagTags, ...finalBookmarkTag];
 
-                        let projectId = undefined;
+                        let noteProjectUid: string | undefined = undefined;
                         if (analysisResult.parsed_projects.length > 0) {
                             const projectName =
                                 analysisResult.parsed_projects[0];
@@ -1161,7 +1161,7 @@ const QuickCaptureInput = React.forwardRef<
                                     projectName.toLowerCase()
                             );
                             if (matchingProject) {
-                                projectId = matchingProject.id;
+                                noteProjectUid = matchingProject.uid;
                             }
                         }
 
@@ -1169,7 +1169,7 @@ const QuickCaptureInput = React.forwardRef<
                             title: cleanedText || trimmedText,
                             content: trimmedText,
                             tags: taskTags,
-                            project_id: projectId,
+                            project_uid: noteProjectUid,
                         };
 
                         try {

--- a/frontend/components/Notifications/NotificationsDropdown.tsx
+++ b/frontend/components/Notifications/NotificationsDropdown.tsx
@@ -15,6 +15,7 @@ import { fetchWithCsrf } from '../../utils/csrfService';
 
 interface Notification {
     id: number;
+    uid: string;
     title: string;
     message: string;
     level: 'info' | 'warning' | 'error' | 'success';
@@ -97,10 +98,10 @@ const NotificationsDropdown: React.FC<NotificationsDropdownProps> = ({
         setIsOpen(!isOpen);
     };
 
-    const handleMarkAsRead = async (id: number) => {
+    const handleMarkAsRead = async (uid: string) => {
         try {
             const response = await fetchWithCsrf(
-                getApiPath(`notifications/${id}/read`),
+                getApiPath(`notifications/${uid}/read`),
                 {
                     method: 'POST',
                     credentials: 'include',
@@ -114,7 +115,7 @@ const NotificationsDropdown: React.FC<NotificationsDropdownProps> = ({
                 if (updatedNotification) {
                     setNotifications((prev) =>
                         prev.map((n) =>
-                            n.id === id
+                            n.uid === uid
                                 ? {
                                       ...n,
                                       read_at: updatedNotification.read_at,
@@ -152,14 +153,14 @@ const NotificationsDropdown: React.FC<NotificationsDropdownProps> = ({
         }
     };
 
-    const handleDelete = async (id: number) => {
+    const handleDelete = async (uid: string) => {
         try {
-            const response = await fetchWithCsrf(getApiPath(`notifications/${id}`), {
+            const response = await fetchWithCsrf(getApiPath(`notifications/${uid}`), {
                 method: 'DELETE',
                 credentials: 'include',
             });
             if (response.ok) {
-                setNotifications((prev) => prev.filter((n) => n.id !== id));
+                setNotifications((prev) => prev.filter((n) => n.uid !== uid));
                 fetchUnreadCount();
             }
         } catch (error) {
@@ -303,7 +304,7 @@ const NotificationsDropdown: React.FC<NotificationsDropdownProps> = ({
                         ) : (
                             notifications.map((notification) => (
                                 <div
-                                    key={notification.id}
+                                    key={notification.uid}
                                     className={`p-4 border-b ${
                                         isDarkMode
                                             ? 'border-gray-700'
@@ -357,7 +358,7 @@ const NotificationsDropdown: React.FC<NotificationsDropdownProps> = ({
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 handleMarkAsRead(
-                                                                    notification.id
+                                                                    notification.uid
                                                                 );
                                                             }}
                                                             className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded"
@@ -373,7 +374,7 @@ const NotificationsDropdown: React.FC<NotificationsDropdownProps> = ({
                                                         onClick={(e) => {
                                                             e.stopPropagation();
                                                             handleDelete(
-                                                                notification.id
+                                                                notification.uid
                                                             );
                                                         }}
                                                         className="p-1 hover:bg-gray-200 dark:hover:bg-gray-600 rounded"

--- a/frontend/components/Project/ProjectDetails.tsx
+++ b/frontend/components/Project/ProjectDetails.tsx
@@ -290,7 +290,7 @@ const ProjectDetails: React.FC = () => {
         const newTask = await createTask({
             name: taskName,
             status: 0,
-            project_id: project.id,
+            project_uid: project.uid,
             completed_at: null,
         });
         setTasks([...tasks, newTask]);
@@ -438,13 +438,13 @@ const ProjectDetails: React.FC = () => {
     };
 
     const handleCreateNextAction = async (
-        projectId: number,
+        projectUid: string,
         actionDescription: string
     ) => {
         const newTask = await createTask({
             name: actionDescription,
             status: 0,
-            project_id: projectId,
+            project_uid: projectUid,
             priority: 0,
             completed_at: null,
         });
@@ -1128,9 +1128,8 @@ const ProjectDetails: React.FC = () => {
                                     title: '',
                                     content: '',
                                     tags: [],
-                                    project_id: project.id,
                                     project: {
-                                        id: project.id,
+                                        id: project.id!,
                                         name: project.name,
                                         uid: project.uid,
                                     },

--- a/frontend/components/Project/ProjectModal.tsx
+++ b/frontend/components/Project/ProjectModal.tsx
@@ -108,7 +108,13 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
 
     useEffect(() => {
         if (formData.area_id) {
-            fetchGoals(formData.area_id).then(setAvailableGoals).catch(() => setAvailableGoals([]));
+            const area = areas.find((a) => a.id === formData.area_id);
+            const areaUid = area?.uid || formData.area_uid;
+            if (areaUid) {
+                fetchGoals(areaUid)
+                    .then(setAvailableGoals)
+                    .catch(() => setAvailableGoals([]));
+            }
         } else {
             setAvailableGoals([]);
         }

--- a/frontend/components/Project/ProjectTasksSection.tsx
+++ b/frontend/components/Project/ProjectTasksSection.tsx
@@ -10,7 +10,7 @@ interface ProjectTasksSectionProps {
     project: Project | null;
     displayTasks: Task[];
     showAutoSuggestForm: boolean;
-    onAddNextAction: (projectId: number, description: string) => void;
+    onAddNextAction: (projectUid: string, description: string) => void;
     onDismissNextAction: () => void;
     onTaskCreate: (taskName: string) => Promise<void>;
     onTaskUpdate: (task: Task) => Promise<void>;
@@ -45,8 +45,8 @@ const ProjectTasksSection: React.FC<ProjectTasksSectionProps> = ({
                 <div className="transition-all duration-300 ease-in-out opacity-100 transform translate-y-0">
                     <AutoSuggestNextActionBox
                         onAddAction={(actionDescription) => {
-                            if (project?.id) {
-                                onAddNextAction(project.id, actionDescription);
+                            if (project?.uid) {
+                                onAddNextAction(project.uid, actionDescription);
                             }
                         }}
                         onDismiss={onDismissNextAction}

--- a/frontend/components/ViewDetail.tsx
+++ b/frontend/components/ViewDetail.tsx
@@ -263,23 +263,11 @@ const ViewDetail: React.FC = () => {
             }
 
             let matchedProject: Project | undefined;
-            if (
-                task.project_id !== undefined &&
-                task.project_id !== null &&
-                typeof task.project_id !== 'string'
-            ) {
+            if (task.project_uid) {
+                matchedProject = projectLookupMap.byUid.get(task.project_uid);
+            }
+            if (!matchedProject && task.project_id !== undefined && task.project_id !== null) {
                 matchedProject = projectLookupMap.byId.get(task.project_id);
-            }
-
-            if (!matchedProject && task.Project?.uid) {
-                matchedProject = projectLookupMap.byUid.get(task.Project.uid);
-            }
-
-            if (!matchedProject && typeof task.project_id === 'string') {
-                const numericId = Number(task.project_id);
-                if (!Number.isNaN(numericId)) {
-                    matchedProject = projectLookupMap.byId.get(numericId);
-                }
             }
 
             return matchedProject

--- a/frontend/entities/Task.ts
+++ b/frontend/entities/Task.ts
@@ -16,8 +16,10 @@ export interface Task {
     note?: string;
     tags?: Tag[];
     project_id?: number;
+    project_uid?: string;
     Project?: Project;
     area_id?: number;
+    area_uid?: string;
     Area?: Area;
     created_at?: string;
     updated_at?: string;

--- a/frontend/utils/goalsService.ts
+++ b/frontend/utils/goalsService.ts
@@ -3,8 +3,8 @@ import { handleAuthResponse, getPostHeadersWithCsrf } from './authUtils';
 import { getApiPath } from '../config/paths';
 import { getCsrfToken } from './csrfService';
 
-export const fetchGoals = async (areaId?: number): Promise<Goal[]> => {
-    const url = areaId ? `goals?area_id=${areaId}` : 'goals';
+export const fetchGoals = async (areaUid?: string): Promise<Goal[]> => {
+    const url = areaUid ? `goals?area_uid=${areaUid}` : 'goals';
     const response = await fetch(getApiPath(url), {
         credentials: 'include',
         headers: { Accept: 'application/json' },


### PR DESCRIPTION
## Description

Completes the partially-done migration from numeric database IDs to string UIDs in the frontend and backend, as described in #1218. The frontend was mixing numeric `id` fields with `uid` strings inconsistently, preventing a clean path toward offline sync.

Key changes:
- **Backend validation** now accepts either a UID string or numeric ID for project/area lookups (backward-compatible), always storing the numeric FK internally
- **Task serializer** now returns `project_uid` and `area_uid` alongside the numeric `project_id` and `area_id`
- **Task filtering** supports `area_uid` query param in addition to `area_id`
- **Goals fetching** uses `area_uid` instead of numeric `area_id`
- **Notifications** routes now use `:uid` instead of `:id`
- **Frontend task creation** uses `project_uid` instead of `project_id` in ProjectDetails, QuickCaptureInput, and InboxItemDetail
- **InboxItemDetail bug fixed**: when converting to a note, the code was incorrectly passing `matchingProject.id` (a numeric integer) as `project_uid` (which expects a UUID string)
- **ViewDetail** project matching simplified to use `task.project_uid` first, falling back to numeric `project_id`

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1218

## Testing

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)

## Additional Notes

The numeric `project_id` and `area_id` fields are preserved in DB schema and API responses for backward compatibility. The backend accepts both formats during the transition period. The primary remaining UID migration items (GoalDropdown using `goal.uid`, AreaDropdown using `area.uid`) require component-level changes and will be handled in a follow-up.