### PR TITLE
fix(caldav): fix calendar discovery for Tasks.org and other CalDAV clients

### DIFF
--- a/backend/modules/caldav/protocol/discovery.js
+++ b/backend/modules/caldav/protocol/discovery.js
@@ -74,24 +74,48 @@ async function handlePrincipalPropfind(req, res) {
             return res.status(400).json({ error: 'Invalid PROPFIND request' });
         }
 
-        const href = `/caldav/${encodeURIComponent(username)}/`;
+        const depth = parseInt(req.headers.depth || '0', 10);
+        const principalHref = `/caldav/${encodeURIComponent(username)}/`;
+
         const props = {
             'D:resourcetype': {
                 'D:collection': '',
                 'D:principal': '',
             },
+            // Point home-set to the principal itself so clients doing a
+            // depth-1 PROPFIND on it discover the tasks/ calendar as a child.
             'C:calendar-home-set': {
-                'D:href': `/caldav/${encodeURIComponent(username)}/tasks/`,
+                'D:href': principalHref,
             },
             'D:current-user-principal': {
-                'D:href': `/caldav/${encodeURIComponent(username)}/`,
+                'D:href': principalHref,
             },
             'D:displayname': username,
         };
 
         const propstat = buildPropstat(props);
-        const response = buildResponse(href, propstat);
-        const xml = buildMultistatus([response]);
+        const response = buildResponse(principalHref, propstat);
+        const responses = [response];
+
+        // Depth-1: expose the tasks calendar as a child of the home set so
+        // clients like Tasks.org can discover it without creating a new list.
+        if (depth >= 1) {
+            const tasksHref = `/caldav/${encodeURIComponent(username)}/tasks/`;
+            const tasksProps = {
+                'D:resourcetype': {
+                    'D:collection': '',
+                    'C:calendar': '',
+                },
+                'D:displayname': 'Tududi Tasks',
+                'C:calendar-description': 'Tasks from Tududi',
+                'C:supported-calendar-component-set': {
+                    'C:comp': { $: { name: 'VTODO' } },
+                },
+            };
+            responses.push(buildResponse(tasksHref, buildPropstat(tasksProps)));
+        }
+
+        const xml = buildMultistatus(responses);
 
         res.status(207)
             .set('Content-Type', 'application/xml; charset=utf-8')

--- a/backend/modules/caldav/routes.js
+++ b/backend/modules/caldav/routes.js
@@ -75,6 +75,36 @@ registerMethod('PROPFIND', '/caldav/:username/tasks/:uid', handlePropfind);
 
 registerMethod('REPORT', '/caldav/:username/tasks/', handleReport);
 
+// MKCOL on the existing tasks calendar: 405 Method Not Allowed (already exists).
+router.all(
+    '/caldav/:username/tasks/',
+    xmlParser,
+    caldavAuth,
+    (req, res, next) => {
+        if (req.method !== 'MKCOL') return next();
+        res.set('Allow', 'OPTIONS, GET, HEAD, PUT, DELETE, PROPFIND, REPORT');
+        return res.status(405).end();
+    }
+);
+
+// MKCOL inside the tasks calendar (e.g. Tasks.org creating a "list"):
+// CalDAV forbids sub-collections inside a calendar collection (RFC 4791).
+router.all(
+    '/caldav/:username/tasks/:uid',
+    xmlParser,
+    caldavAuth,
+    (req, res, next) => {
+        if (req.method !== 'MKCOL') return next();
+        return res
+            .status(409)
+            .set('Content-Type', 'application/xml; charset=utf-8')
+            .send(
+                '<?xml version="1.0"?>' +
+                    '<D:error xmlns:D="DAV:"><D:resource-must-be-null/></D:error>'
+            );
+    }
+);
+
 router.get('/caldav/:username/tasks/', xmlParser, caldavAuth, (req, res) => {
     res.status(207).send(
         '<?xml version="1.0"?><D:multistatus xmlns:D="DAV:"/>'

--- a/backend/tests/integration/caldav-protocol.test.js
+++ b/backend/tests/integration/caldav-protocol.test.js
@@ -82,9 +82,44 @@ describe('CalDAV Protocol - Phase 3', () => {
                 .expect(207);
 
             expect(response.text).toContain('calendar-home-set');
+            // calendar-home-set now points to the principal so clients can
+            // discover the tasks/ calendar as a depth-1 child (fixes Tasks.org)
             expect(response.text).toContain(
-                `/caldav/${encodeURIComponent(testUser.email)}/tasks/`
+                `/caldav/${encodeURIComponent(testUser.email)}/`
             );
+        });
+
+        test('PROPFIND /caldav/:username/ depth 1 should expose tasks calendar as child', async () => {
+            const propfindBody = `<?xml version="1.0" encoding="utf-8"?>
+                <D:propfind xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+                    <D:allprop/>
+                </D:propfind>`;
+
+            const response = await request(app)
+                .propfind(`/caldav/${testUser.email}/`)
+                .set('Authorization', authHeader)
+                .set('Content-Type', 'application/xml')
+                .set('Depth', '1')
+                .send(propfindBody)
+                .expect(207);
+
+            const tasksHref = `/caldav/${encodeURIComponent(testUser.email)}/tasks/`;
+            expect(response.text).toContain(tasksHref);
+            expect(response.text).toContain('C:calendar');
+        });
+
+        test('MKCOL inside tasks calendar should return 409 Conflict', async () => {
+            await request(app)
+                .mkcol(`/caldav/${testUser.email}/tasks/new-collection/`)
+                .set('Authorization', authHeader)
+                .expect(409);
+        });
+
+        test('MKCOL on tasks calendar itself should return 405', async () => {
+            await request(app)
+                .mkcol(`/caldav/${testUser.email}/tasks/`)
+                .set('Authorization', authHeader)
+                .expect(405);
         });
     });
 


### PR DESCRIPTION
## Description

Fixes CalDAV sync not working with Tasks.org (and similar clients). On a fresh install, Tasks.org couldn't discover any existing calendar lists and returned a 404 when trying to create one.

**Root cause:** `calendar-home-set` pointed to `/caldav/:username/tasks/` (the calendar itself). CalDAV clients treat the home-set as a **container** and do a depth-1 PROPFIND looking for child calendars inside it. Since `tasks/` is the calendar, not a container, no child calendars were returned and clients showed "no lists found."

**Fix:**
- Changed `calendar-home-set` to point to `/caldav/:username/` (the principal URL)
- Added depth-1 handling to `handlePrincipalPropfind` so the `tasks/` calendar is enumerated as a child resource with `C:calendar` resource type — clients now discover it without needing to create a new list
- Added MKCOL handlers: 405 Method Not Allowed on the existing `tasks/` calendar, 409 Conflict for sub-collection attempts inside it (per RFC 4791 which forbids collections inside a calendar collection)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1199

## Testing

- Updated existing `calendar-home-set` test to assert the new principal URL
- Added 3 new integration tests:
  - PROPFIND depth-1 on principal exposes `tasks/` as a child C:calendar
  - MKCOL inside tasks returns 409 Conflict
  - MKCOL on tasks itself returns 405 Method Not Allowed
- All 28 CalDAV protocol integration tests pass
- `npm run lint` clean

```
npm run lint        # clean (2 pre-existing warnings, 0 errors)
npx jest caldav-protocol  # 28/28 pass
```

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective
- [x] Existing tests pass