### PR TITLE
fix(i18n): replace hardcoded strings with translation keys across components

### DIFF
--- a/frontend/components/Area/AreaDetails.tsx
+++ b/frontend/components/Area/AreaDetails.tsx
@@ -423,14 +423,14 @@ const AreaDetails: React.FC = () => {
                             <input
                                 autoFocus
                                 type="text"
-                                placeholder="Goal title"
+                                placeholder={t('areas.goalTitlePlaceholder')}
                                 value={goalForm.title}
                                 onChange={(e) => setGoalForm((f) => f ? { ...f, title: e.target.value } : f)}
                                 className="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-md py-1.5 px-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
                             />
                             <input
                                 type="text"
-                                placeholder="Why this matters (optional)"
+                                placeholder={t('areas.goalWhyPlaceholder')}
                                 value={goalForm.why}
                                 onChange={(e) => setGoalForm((f) => f ? { ...f, why: e.target.value } : f)}
                                 className="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-md py-1.5 px-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
@@ -441,8 +441,8 @@ const AreaDetails: React.FC = () => {
                                     onChange={(e) => setGoalForm((f) => f ? { ...f, horizon: e.target.value as GoalHorizon } : f)}
                                     className="flex-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md py-1.5 px-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
                                 >
-                                    <option value="season">Season</option>
-                                    <option value="year">Year</option>
+                                    <option value="season">{t('areas.horizonSeason')}</option>
+                                    <option value="year">{t('areas.horizonYear')}</option>
                                 </select>
                                 <select
                                     value={goalForm.status}
@@ -658,6 +658,7 @@ interface GoalBucketProps {
 const GoalBucket: React.FC<GoalBucketProps> = ({
     goal, projects, areaColor, getProjectLink, onEdit, onDelete, dimmed,
 }) => {
+    const { t } = useTranslation();
     const dotColor = areaColor || '#6b7280';
     return (
         <div className={dimmed ? 'opacity-60' : ''}>
@@ -673,10 +674,10 @@ const GoalBucket: React.FC<GoalBucketProps> = ({
                     </span>
                 </div>
                 <div className="flex items-center gap-1 flex-shrink-0">
-                    <button onClick={onEdit} className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" title="Edit goal">
+                    <button onClick={onEdit} className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" title={t('areas.editGoal')}>
                         <PencilSquareIcon className="h-3.5 w-3.5" />
                     </button>
-                    <button onClick={onDelete} className="p-1 text-gray-400 hover:text-red-500" title="Delete goal">
+                    <button onClick={onDelete} className="p-1 text-gray-400 hover:text-red-500" title={t('areas.deleteGoal')}>
                         <TrashIcon className="h-3.5 w-3.5" />
                     </button>
                 </div>
@@ -709,6 +710,7 @@ interface MaintenanceProjectRowProps {
 }
 
 const MaintenanceProjectRow: React.FC<MaintenanceProjectRowProps> = ({ project, getLink, onUnmark }) => {
+    const { t } = useTranslation();
     const cardColor = (project as any).color || '#6b7280';
     return (
         <div
@@ -724,7 +726,7 @@ const MaintenanceProjectRow: React.FC<MaintenanceProjectRowProps> = ({ project, 
             <button
                 onClick={() => onUnmark(project)}
                 className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
-                title="Move back to unlinked"
+                title={t('areas.moveBackToUnlinked')}
             >
                 unlink
             </button>

--- a/frontend/components/Areas.tsx
+++ b/frontend/components/Areas.tsx
@@ -368,7 +368,7 @@ const Areas: React.FC = () => {
                 {/* ConfirmDialog */}
                 {isConfirmDialogOpen && areaToDelete && (
                     <ConfirmDialog
-                        title="Delete Area"
+                        title={t('modals.deleteArea.title')}
                         message={`Are you sure you want to delete the area "${areaToDelete.name}"?`}
                         onConfirm={handleDeleteArea}
                         onCancel={closeConfirmDialog}

--- a/frontend/components/CalDAV/CalendarForm.tsx
+++ b/frontend/components/CalDAV/CalendarForm.tsx
@@ -308,7 +308,7 @@ const CalendarForm: React.FC<CalendarFormProps> = ({ onComplete, onCancel }) => 
                         className={`block w-full border rounded-md px-3 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 ${
                             errors.serverUrl ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
                         }`}
-                        placeholder="https://caldav.example.com"
+                        placeholder={t('profile.caldavWizard.serverUrlPlaceholder')}
                     />
                     {errors.serverUrl && (
                         <p className="mt-1 text-xs text-red-600 dark:text-red-400">{errors.serverUrl}</p>
@@ -331,7 +331,7 @@ const CalendarForm: React.FC<CalendarFormProps> = ({ onComplete, onCancel }) => 
                         className={`block w-full border rounded-md px-3 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 ${
                             errors.calendarPath ? 'border-red-500' : 'border-gray-300 dark:border-gray-600'
                         }`}
-                        placeholder="/calendars/user/tasks"
+                        placeholder={t('profile.caldavWizard.calendarPathPlaceholder')}
                     />
                     {errors.calendarPath && (
                         <p className="mt-1 text-xs text-red-600 dark:text-red-400">{errors.calendarPath}</p>

--- a/frontend/components/CalDAV/SetupWizard.tsx
+++ b/frontend/components/CalDAV/SetupWizard.tsx
@@ -380,7 +380,7 @@ const SetupWizard: React.FC<SetupWizardProps> = ({
                                     })
                                 }
                                 className="block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500"
-                                placeholder="https://caldav.example.com"
+                                placeholder={t('profile.caldavWizard.serverUrlPlaceholder')}
                             />
                         </div>
                         <div>
@@ -401,7 +401,7 @@ const SetupWizard: React.FC<SetupWizardProps> = ({
                                     })
                                 }
                                 className="block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500"
-                                placeholder="/calendars/user/tasks"
+                                placeholder={t('profile.caldavWizard.calendarPathPlaceholder')}
                             />
                         </div>
                         <div className="grid grid-cols-2 gap-4">

--- a/frontend/components/Habits/HabitsTodayWidget.tsx
+++ b/frontend/components/Habits/HabitsTodayWidget.tsx
@@ -47,7 +47,7 @@ const HabitsTodayWidget: React.FC = () => {
                             <button
                                 onClick={() => logCompletion(habit.uid!)}
                                 className="text-green-600 hover:text-green-700 transition"
-                                title="Complete habit"
+                                title={t('habits.completeHabit')}
                             >
                                 <CheckCircleIcon className="w-6 h-6" />
                             </button>

--- a/frontend/components/Note/NoteDetails.tsx
+++ b/frontend/components/Note/NoteDetails.tsx
@@ -307,7 +307,7 @@ const NoteDetails: React.FC = () => {
                 {/* ConfirmDialog */}
                 {isConfirmDialogOpen && noteToDelete && (
                     <ConfirmDialog
-                        title="Delete Note"
+                        title={t('modals.deleteNote.title')}
                         message={`Are you sure you want to delete the note "${noteToDelete.title}"?`}
                         onConfirm={handleDeleteNote}
                         onCancel={() => {

--- a/frontend/components/Note/NoteModal.tsx
+++ b/frontend/components/Note/NoteModal.tsx
@@ -587,7 +587,7 @@ const NoteModal: React.FC<NoteModalProps> = ({
                                                                 handleChange
                                                             }
                                                             className="block w-full h-full min-h-0 sm:border sm:border-gray-300 sm:dark:border-gray-600 sm:rounded-md shadow-sm py-2 sm:py-3 px-3 sm:px-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 sm:focus:ring-2 sm:focus:ring-blue-500 transition duration-150 ease-in-out resize-none"
-                                                            placeholder="Write your content using Markdown formatting...&#10;&#10;Examples:&#10;# Heading&#10;**Bold text**&#10;*Italic text*&#10;- List item&#10;```code```"
+                                                            placeholder={t('notes.contentPlaceholderMarkdown')}
                                                             autoComplete="off"
                                                             data-testid="note-content-textarea"
                                                         />

--- a/frontend/components/Notifications/NotificationsDropdown.tsx
+++ b/frontend/components/Notifications/NotificationsDropdown.tsx
@@ -247,7 +247,7 @@ const NotificationsDropdown: React.FC<NotificationsDropdownProps> = ({
             <button
                 onClick={handleToggle}
                 className="relative flex items-center focus:outline-none"
-                aria-label="Notifications"
+                aria-label={t('profile.notifications')}
             >
                 <BellIcon className="h-6 w-6 text-gray-700 dark:text-gray-300" />
                 {unreadCount > 0 && (

--- a/frontend/components/Profile/tabs/TelegramTab.tsx
+++ b/frontend/components/Profile/tabs/TelegramTab.tsx
@@ -81,7 +81,7 @@ const TelegramTab: React.FC<TelegramTabProps> = ({
                             name="telegram_bot_token"
                             value={formData.telegram_bot_token || ''}
                             onChange={onChange}
-                            placeholder="123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ"
+                            placeholder={t('profile.telegramTokenPlaceholder')}
                             className="mt-1 block w-full border border-gray-300 dark:border-gray-700 rounded-md shadow-sm px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                         />
                         <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
@@ -101,7 +101,7 @@ const TelegramTab: React.FC<TelegramTabProps> = ({
                             name="telegram_allowed_users"
                             value={formData.telegram_allowed_users || ''}
                             onChange={onChange}
-                            placeholder="@username1, 123456789, @username2"
+                            placeholder={t('profile.telegramAllowedUsersPlaceholder')}
                             className="mt-1 block w-full border border-gray-300 dark:border-gray-700 rounded-md shadow-sm px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                         />
                         <div className="mt-2 text-xs text-gray-500 dark:text-gray-400 space-y-1">

--- a/frontend/components/Project/AutoSuggestNextActionBox.tsx
+++ b/frontend/components/Project/AutoSuggestNextActionBox.tsx
@@ -68,7 +68,7 @@ const AutoSuggestNextActionBox: React.FC<AutoSuggestNextActionBoxProps> = ({
                 <button
                     onClick={onDismiss}
                     className="text-blue-400 hover:text-blue-600 dark:text-blue-500 dark:hover:text-blue-300 transition-colors"
-                    aria-label="Dismiss"
+                    aria-label={t('common.dismiss')}
                 >
                     <svg
                         className="w-5 h-5"

--- a/frontend/components/Project/ProjectDetails.tsx
+++ b/frontend/components/Project/ProjectDetails.tsx
@@ -1173,7 +1173,7 @@ const ProjectDetails: React.FC = () => {
 
                     {isConfirmDialogOpen && noteToDelete && (
                         <ConfirmDialog
-                            title="Delete Note"
+                            title={t('modals.deleteNote.title')}
                             message={`Are you sure you want to delete the note "${noteToDelete.title}"?`}
                             onConfirm={() => {
                                 const identifier =

--- a/frontend/components/Project/ProjectModal.tsx
+++ b/frontend/components/Project/ProjectModal.tsx
@@ -699,7 +699,7 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                                                             onChange={
                                                                 handleDueDateChange
                                                             }
-                                                            placeholder="Select due date"
+                                                            placeholder={t('projects.selectDueDatePlaceholder')}
                                                         />
                                                     </div>
                                                 </div>
@@ -806,7 +806,7 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                                                     ? 'bg-blue-100 dark:bg-blue-900 text-blue-600 dark:text-blue-400'
                                                     : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700'
                                             }`}
-                                            title="Goal"
+                                            title={t('projects.goalTitle')}
                                         >
                                             <FlagIcon className="h-5 w-5" />
                                             {(formData.goal_id != null || formData.is_maintenance) && (

--- a/frontend/components/Shared/AttachmentCard.tsx
+++ b/frontend/components/Shared/AttachmentCard.tsx
@@ -4,6 +4,7 @@ import {
     ArrowDownTrayIcon,
     EyeIcon,
 } from '@heroicons/react/24/outline';
+import { useTranslation } from 'react-i18next';
 import { Attachment } from '../../entities/Attachment';
 import FileIcon from './Icons/FileIcon';
 
@@ -22,6 +23,7 @@ const AttachmentCard: React.FC<AttachmentCardProps> = ({
     onDownload,
     onPreview,
 }) => {
+    const { t } = useTranslation();
     const isImage = attachment.mime_type.startsWith('image/');
     const isPdf = attachment.mime_type === 'application/pdf';
     const canPreview = isImage || isPdf;
@@ -76,7 +78,7 @@ const AttachmentCard: React.FC<AttachmentCardProps> = ({
                                     onPreview(attachment);
                                 }}
                                 className="p-2 bg-white dark:bg-gray-800 rounded-full shadow-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                                title="Preview"
+                                title={t('common.preview')}
                             >
                                 <EyeIcon className="h-5 w-5 text-gray-700 dark:text-gray-300" />
                             </button>
@@ -87,7 +89,7 @@ const AttachmentCard: React.FC<AttachmentCardProps> = ({
                                 onDownload(attachment);
                             }}
                             className="p-2 bg-white dark:bg-gray-800 rounded-full shadow-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                            title="Download"
+                            title={t('common.download')}
                         >
                             <ArrowDownTrayIcon className="h-5 w-5 text-gray-700 dark:text-gray-300" />
                         </button>
@@ -97,7 +99,7 @@ const AttachmentCard: React.FC<AttachmentCardProps> = ({
                                 onDelete(attachment);
                             }}
                             className="p-2 bg-white dark:bg-gray-800 rounded-full shadow-lg hover:bg-red-100 dark:hover:bg-red-900 transition-colors"
-                            title="Delete"
+                            title={t('common.delete')}
                         >
                             <TrashIcon className="h-5 w-5 text-red-600 dark:text-red-400" />
                         </button>

--- a/frontend/components/Shared/UrlPreview.tsx
+++ b/frontend/components/Shared/UrlPreview.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { extractTitleFromText, UrlTitleResult } from '../../utils/urlService';
 import { XMarkIcon, PhotoIcon } from '@heroicons/react/24/outline';
 
@@ -8,6 +9,7 @@ interface UrlPreviewProps {
 }
 
 const UrlPreview: React.FC<UrlPreviewProps> = ({ text, onPreviewChange }) => {
+    const { t } = useTranslation();
     const [preview, setPreview] = useState<UrlTitleResult | null>(null);
     const [isLoading, setIsLoading] = useState(false);
     const [isVisible, setIsVisible] = useState(true);
@@ -75,7 +77,7 @@ const UrlPreview: React.FC<UrlPreviewProps> = ({ text, onPreviewChange }) => {
             <button
                 onClick={handleDismiss}
                 className="absolute top-2 right-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 z-10"
-                aria-label="Dismiss preview"
+                aria-label={t('common.dismiss')}
             >
                 <XMarkIcon className="h-4 w-4" />
             </button>

--- a/frontend/components/Tags.tsx
+++ b/frontend/components/Tags.tsx
@@ -397,7 +397,7 @@ const Tags: React.FC = () => {
                 {/* ConfirmDialog */}
                 {isConfirmDialogOpen && tagToDelete && (
                     <ConfirmDialog
-                        title="Delete Tag"
+                        title={t('modals.deleteTag.title')}
                         message={`Are you sure you want to delete the tag "${tagToDelete.name}"?`}
                         onConfirm={handleDeleteTag}
                         onCancel={closeConfirmDialog}

--- a/frontend/components/Task/LifeRadar.tsx
+++ b/frontend/components/Task/LifeRadar.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { getApiPath } from '../../config/paths';
 import { Project } from '../../entities/Project';
@@ -239,6 +240,7 @@ function WaitingForAge({
     tasks: Task[];
     projects: Project[];
 }) {
+    const { t: translate } = useTranslation();
     const navigate = useNavigate();
 
     const rows = useMemo(() => {
@@ -289,7 +291,7 @@ function WaitingForAge({
                             <button
                                 onClick={() => navigate(`/task/${t.uid}`)}
                                 className="text-[10px] text-blue-500 hover:text-blue-600 dark:text-blue-400 flex-shrink-0 leading-none"
-                                title="Chase up"
+                                title={translate('tasks.chaseUp')}
                             >
                                 ↗
                             </button>

--- a/frontend/components/Task/TaskForm/TaskContentSection.tsx
+++ b/frontend/components/Task/TaskForm/TaskContentSection.tsx
@@ -31,7 +31,7 @@ const TaskContentSection: React.FC<TaskContentSectionProps> = ({
                                 ? 'bg-blue-600 text-white'
                                 : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'
                         }`}
-                        title="Edit"
+                        title={t('common.edit')}
                     >
                         <PencilIcon className="h-3 w-3" />
                     </button>
@@ -43,7 +43,7 @@ const TaskContentSection: React.FC<TaskContentSectionProps> = ({
                                 ? 'bg-blue-600 text-white'
                                 : 'bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-300 dark:hover:bg-gray-600'
                         }`}
-                        title="Preview"
+                        title={t('common.preview')}
                     >
                         <EyeIcon className="h-3 w-3" />
                     </button>

--- a/frontend/components/Task/TaskHeader.tsx
+++ b/frontend/components/Task/TaskHeader.tsx
@@ -214,7 +214,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
                                         {task.habit_mode && (
                                             <FireIcon
                                                 className="h-4 w-4 text-orange-500 flex-shrink-0"
-                                                title="Habit"
+                                                title={t('tasks.habit')}
                                             />
                                         )}
                                         <span className="text-sm font-medium text-gray-900 dark:text-gray-300 tracking-tight truncate">
@@ -285,7 +285,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
                                 {task.habit_mode && (
                                     <FireIcon
                                         className="h-4 w-4 text-orange-500 flex-shrink-0"
-                                        title="Habit"
+                                        title={t('tasks.habit')}
                                     />
                                 )}
                                 <span className="text-md font-medium text-gray-900 dark:text-gray-300 truncate">
@@ -449,7 +449,7 @@ const TaskHeader: React.FC<TaskHeaderProps> = ({
                                 {task.habit_mode && (
                                     <FireIcon
                                         className="h-4 w-4 text-orange-500 flex-shrink-0"
-                                        title="Habit"
+                                        title={t('tasks.habit')}
                                     />
                                 )}
                                 <span className="truncate flex-1">

--- a/frontend/components/UniversalSearch/SaveViewModal.tsx
+++ b/frontend/components/UniversalSearch/SaveViewModal.tsx
@@ -95,7 +95,7 @@ const SaveViewModal: React.FC<SaveViewModalProps> = ({
                             htmlFor="viewName"
                             className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2"
                         >
-                            View Name <span className="text-red-500">*</span>
+                            {t('views.viewNameLabel')} <span className="text-red-500">*</span>
                         </label>
                         <input
                             type="text"
@@ -122,13 +122,13 @@ const SaveViewModal: React.FC<SaveViewModalProps> = ({
                         </p>
                         <ul className="text-xs text-gray-600 dark:text-gray-300 space-y-1">
                             {filters.length > 0 && (
-                                <li>• Filters: {filters.join(', ')}</li>
+                                <li>• {t('views.filtersLabel')} {filters.join(', ')}</li>
                             )}
                             {searchQuery && (
-                                <li>• Search: &quot;{searchQuery}&quot;</li>
+                                <li>• {t('views.searchLabel')} &quot;{searchQuery}&quot;</li>
                             )}
-                            {priority && <li>• Priority: {priority}</li>}
-                            {due && <li>• Due: {due}</li>}
+                            {priority && <li>• {t('views.priorityLabel')} {priority}</li>}
+                            {due && <li>• {t('views.dueLabel')} {due}</li>}
                         </ul>
                     </div>
 

--- a/frontend/components/ViewDetail.tsx
+++ b/frontend/components/ViewDetail.tsx
@@ -949,7 +949,7 @@ const ViewDetail: React.FC = () => {
                         <button
                             onClick={openConfirmDialog}
                             className="p-2 rounded-lg transition-colors text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-                            title="Delete view"
+                            title={t('views.deleteView')}
                         >
                             <TrashIcon className="h-5 w-5" />
                         </button>

--- a/public/locales/ar/translation.json
+++ b/public/locales/ar/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "نعم، ألغِ",
     "uploading": "جارٍ التحميل...",
     "refresh": "تحديث",
-    "unlinking": "فصل الارتباط..."
+    "unlinking": "فصل الارتباط...",
+    "preview": "معاينة",
+    "download": "تنزيل",
+    "exitFocusMode": "الخروج من وضع التركيز",
+    "searchTimezones": "بحث عن المناطق الزمنية...",
+    "dismiss": "إلغاء"
   },
   "sidebar": {
     "dashboard": "لوحة التحكم",
@@ -58,7 +63,10 @@
     "unpinView": "إلغاء تثبيت العرض",
     "pinView": "تثبيت العرض",
     "eisenhower": "مصفوفة أيزنهاور",
-    "kanban": "لوحة كانبان"
+    "kanban": "لوحة كانبان",
+    "addHabitAriaLabel": "إضافة عادة",
+    "addHabitTitle": "إضافة عادة",
+    "toggleDarkMode": "تبديل الوضع المظلم"
   },
   "navigation": {
     "home": "الرئيسية",
@@ -68,7 +76,11 @@
     "settings": "الإعدادات",
     "about": "حول",
     "logout": "تسجيل الخروج",
-    "backupRestore": "النسخ الاحتياطي والاستعادة"
+    "backupRestore": "النسخ الاحتياطي والاستعادة",
+    "toggleSearch": "تبديل البحث",
+    "quickInboxCapture": "التقاط سريع للبريد الوارد",
+    "userMenu": "قائمة المستخدم",
+    "search": "بحث"
   },
   "settings": {
     "todayPageSettings": "إعدادات صفحة اليوم",
@@ -181,7 +193,9 @@
       "waiting": "انتظار",
       "done": "تم",
       "dropHere": "اسحب هنا"
-    }
+    },
+    "chaseUp": "متابعة",
+    "habit": "عادة"
   },
   "timeline": {
     "activityTimeline": "جدول الأنشطة",
@@ -503,7 +517,9 @@
       "serverSettings": "إعدادات الخادم",
       "syncSettings": "إعدادات المزامنة",
       "setupSuccess": "تم تكوين التقويم بنجاح!",
-      "setupFailed": "فشل في إنشاء التقويم"
+      "setupFailed": "فشل في إنشاء التقويم",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "حل تعارضات المزامنة",
@@ -538,7 +554,9 @@
       "intervalError": "يجب أن يكون فترة المزامنة بين 1 و 1440 دقيقة",
       "updateSuccess": "تم تحديث التقويم بنجاح",
       "updateError": "فشل في تحديث التقويم"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "productivity": {
     "stalledProjects": "المشاريع المتوقفة",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "فشل في حفظ المشروع.",
     "projectImageTooLarge": "الصورة كبيرة جدًا. يرجى اختيار ملف أقل من 10 ميجابايت.",
     "projectImageUpload": "فشل تحميل الصورة. يرجى تجربة ملف أصغر أو تنسيق مختلف.",
-    "bannerSaveFailed": "فشل حفظ اللافتة"
+    "bannerSaveFailed": "فشل حفظ اللافتة",
+    "loginFailed": "فشل تسجيل الدخول. يرجى المحاولة مرة أخرى.",
+    "generalError": "حدث خطأ. يرجى المحاولة مرة أخرى.",
+    "viewNameRequired": "اسم العرض مطلوب",
+    "viewSaveFailed": "فشل في حفظ العرض. يرجى المحاولة مرة أخرى."
   },
   "inbox": {
     "title": "صندوق الوارد",
@@ -810,7 +832,9 @@
     "loadMoreError": "فشل في تحميل المزيد من العناصر",
     "loading": "جارٍ التحميل...",
     "loadMore": "تحميل المزيد من عناصر البريد الوارد",
-    "showingItems": "عرض {{current}} من {{total}} عنصر"
+    "showingItems": "عرض {{current}} من {{total}} عنصر",
+    "removeTag": "إزالة الوسم",
+    "removeProject": "إزالة المشروع"
   },
   "dateFormats": {
     "long": "EEEE، d MMMM، yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "الإجراء الأفضل التالي",
     "focusTask": "المهمة الأكثر تأثيرًا",
     "focusHint": "ينقل هذه المهمة إلى قيد التنفيذ واليوم",
-    "noNextAction": "كل شيء واضح - لا توجد مهام معلقة."
+    "noNextAction": "كل شيء واضح - لا توجد مهام متبقية.",
+    "selectDueDatePlaceholder": "اختر تاريخ الاستحقاق",
+    "goalTitle": "الهدف"
   },
   "projectItem": {
     "edit": "تعديل",
@@ -1088,7 +1114,14 @@
     "error": "خطأ في تحميل تفاصيل المنطقة.",
     "notFound": "لم يتم العثور على المنطقة.",
     "details": "تفاصيل المنطقة",
-    "viewProjects": "عرض المشاريع في {{name}}"
+    "viewProjects": "عرض المشاريع في {{name}}",
+    "goalTitlePlaceholder": "عنوان الهدف",
+    "goalWhyPlaceholder": "لماذا هذا مهم (اختياري)",
+    "editGoal": "تعديل الهدف",
+    "deleteGoal": "حذف الهدف",
+    "moveBackToUnlinked": "العودة إلى غير المرتبط",
+    "horizonSeason": "الموسم",
+    "horizonYear": "السنة"
   },
   "notes": {
     "loading": "جارٍ تحميل الملاحظات...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "حذف الملاحظة {{noteTitle}}",
     "deleteNoteTitle": "حذف الملاحظة {{noteTitle}}",
     "editNoteAriaLabel": "تعديل الملاحظة {{noteTitle}}",
-    "editNoteTitle": "تعديل الملاحظة {{noteTitle}}"
+    "editNoteTitle": "تعديل الملاحظة {{noteTitle}}",
+    "titlePlaceholder": "عنوان الملاحظة...",
+    "contentPlaceholder": "اكتب محتوى ملاحظتك هنا... (يدعم Markdown)",
+    "focusMode": "وضع التركيز",
+    "noteOptions": "خيارات الملاحظة",
+    "clickToEdit": "انقر للتعديل",
+    "contentPlaceholderFocus": "اكتب ملاحظتك... (يدعم Markdown)",
+    "contentPlaceholderMarkdown": "اكتب محتواك باستخدام تنسيق Markdown...\n\nأمثلة:\n# عنوان\n**نص عريض**\n*نص مائل*\n- عنصر قائمة\n```كود```"
   },
   "tags": {
     "loading": "جاري تحميل العلامات...",
@@ -1120,10 +1160,14 @@
     "viewTasksWithTag": "عرض المهام مع هذه العلامة",
     "typeToAdd": "اكتب لإضافة علامة",
     "noItemsWithTag": "لا توجد عناصر مع هذه العلامة",
-    "systemTag": "علامات النظام",
+    "systemTag": "علامة النظام",
     "systemTagDescription": "تم إنشاؤها تلقائيًا بواسطة التطبيق. إنها تدعم الميزات المدمجة ولا يمكن إعادة تسميتها أو حذفها.",
     "userTag": "علامات المستخدم",
-    "userTagDescription": "علاماتك الخاصة لتنظيم المهام والملاحظات والمشاريع."
+    "userTagDescription": "علاماتك الخاصة لتنظيم المهام والملاحظات والمشاريع.",
+    "systemTags": "وسوم النظام",
+    "systemTagsDescription": "مدارة تلقائيًا · لا يمكن حذفها أو إعادة تسميتها",
+    "system": "النظام",
+    "customize": "تخصيص"
   },
   "recurrence": {
     "none": "لا شيء",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "الأولوية:",
     "dueLabel": "استحقاق:",
     "tags": "علامات",
-    "recurring": "متكرر"
+    "recurring": "متكرر",
+    "saveAsSmartView": "حفظ كعرض ذكي",
+    "viewNamePlaceholder": "أدخل اسم العرض",
+    "viewNameLabel": "اسم العرض",
+    "viewWillSave": "سيتم حفظ هذا العرض:",
+    "saveView": "حفظ العرض",
+    "filtersLabel": "الفلاتر:",
+    "searchLabel": "بحث:"
   },
   "search": {
     "placeholder": "ابحث عن المهام، المشاريع، الملاحظات...",
@@ -1556,5 +1607,36 @@
     "done_desc": "انتهى وتم",
     "cancelled": "ملغى",
     "cancelled_desc": "لن يكتمل"
+  },
+  "habits": {
+    "completeHabit": "اكمال العادة"
+  },
+  "aiAssistant": {
+    "title": "مساعد الذكاء الاصطناعي",
+    "generatedAt": "تم إنشاؤه في {{time}}",
+    "emptyState": "اضغط على 'إنشاء ملخص' للحصول على ملخصك اليومي المدعوم بالذكاء الاصطناعي.",
+    "focusForToday": "التركيز لليوم",
+    "priorityActions": "الإجراءات ذات الأولوية",
+    "taskInsightsTitle": "رؤى الذكاء الاصطناعي",
+    "projectInsightsTitle": "رؤى الذكاء الاصطناعي",
+    "taskInsight": "حول هذه المهمة",
+    "taskNextStep": "الخطوة التالية",
+    "taskBreakdown": "كيفية التعامل معها",
+    "projectInsight": "حول هذا المشروع",
+    "projectNextAction": "الإجراء التالي",
+    "projectHealth": "صحة المشروع",
+    "watchOut": "احترس",
+    "suggestedLinks": "روابط مقترحة",
+    "generate": "إنشاء ملخص",
+    "regenerate": "إعادة إنشاء",
+    "generating": "جارٍ الإنشاء...",
+    "errorDefault": "فشل في إنشاء الرؤى. يرجى المحاولة مرة أخرى.",
+    "lowContextTitle": "لا توجد سياقات كافية لاقتراح رائع",
+    "lowContextHint": "أضف وصفًا أو ملاحظات أو علامات، أو قم بتعيين مشروع للحصول على رؤى أفضل. يمكنك الاستمرار في الإنشاء أدناه.",
+    "generateAnyway": "إنشاء على أي حال",
+    "statTotal": "الإجمالي",
+    "statDone": "تم",
+    "statActive": "نشط",
+    "statOverdue": "متأخر"
   }
 }

--- a/public/locales/bg/translation.json
+++ b/public/locales/bg/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Да, откажете",
     "uploading": "Качване...",
     "refresh": "Обнови",
-    "unlinking": "Откачане..."
+    "unlinking": "Откачане...",
+    "preview": "Преглед",
+    "download": "Изтегляне",
+    "exitFocusMode": "Излез от режим на фокус",
+    "searchTimezones": "Търсене на часови зони...",
+    "dismiss": "Отхвърли"
   },
   "sidebar": {
     "dashboard": "Табло",
@@ -58,7 +63,10 @@
     "unpinView": "Отпинване на преглед",
     "pinView": "Прикрепяне на преглед",
     "eisenhower": "Матрица на Айзенхауер",
-    "kanban": "Канбан дъска"
+    "kanban": "Канбан дъска",
+    "addHabitAriaLabel": "Добави навик",
+    "addHabitTitle": "Добави навик",
+    "toggleDarkMode": "Превключи тъмен режим"
   },
   "navigation": {
     "home": "Начало",
@@ -68,7 +76,11 @@
     "settings": "Настройки",
     "about": "За нас",
     "logout": "Изход",
-    "backupRestore": "Резервно копие и възстановяване"
+    "backupRestore": "Резервно копие и възстановяване",
+    "toggleSearch": "Превключи търсене",
+    "quickInboxCapture": "Бързо улавяне на входящи",
+    "userMenu": "Меню на потребителя",
+    "search": "Търсене"
   },
   "settings": {
     "todayPageSettings": "Настройки на страницата днес",
@@ -181,7 +193,9 @@
       "waiting": "Изчакване",
       "done": "Готово",
       "dropHere": "Пуснете тук"
-    }
+    },
+    "chaseUp": "Напомни",
+    "habit": "Навик"
   },
   "timeline": {
     "activityTimeline": "Хронология на активността",
@@ -503,7 +517,9 @@
       "serverSettings": "Настройки на сървъра",
       "syncSettings": "Настройки за синхронизация",
       "setupSuccess": "Календарят е конфигуриран успешно!",
-      "setupFailed": "Неуспешно създаване на календар"
+      "setupFailed": "Неуспешно създаване на календар",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "Разрешаване на конфликти при синхронизация",
@@ -538,7 +554,9 @@
       "intervalError": "Интервалът за синхронизация трябва да бъде между 1 и 1440 минути",
       "updateSuccess": "Календарят успешно актуализиран",
       "updateError": "Неуспешна актуализация на календара"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "productivity": {
     "stalledProjects": "Забавени проекти",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Неуспешно запазване на проекта.",
     "projectImageTooLarge": "Изображението е твърде голямо. Моля, изберете файл под 10MB.",
     "projectImageUpload": "Неуспешно качване на изображение. Моля, опитайте с по-малък файл или различен формат.",
-    "bannerSaveFailed": "Неуспешно запазване на банера"
+    "bannerSaveFailed": "Неуспешно запазване на банера",
+    "loginFailed": "Входът не успя. Моля, опитайте отново.",
+    "generalError": "Възникна грешка. Моля, опитайте отново.",
+    "viewNameRequired": "Името на изгледа е задължително",
+    "viewSaveFailed": "Неуспешно запазване на изгледа. Моля, опитайте отново."
   },
   "inbox": {
     "title": "Входяща поща",
@@ -810,7 +832,9 @@
     "loadMoreError": "Неуспешно зареждане на повече елементи",
     "loading": "Зареждане...",
     "loadMore": "Заредете повече елементи от входящата поща",
-    "showingItems": "Показване на {{current}} от {{total}} елемента"
+    "showingItems": "Показване на {{current}} от {{total}} елемента",
+    "removeTag": "Премахни етикет",
+    "removeProject": "Премахни проект"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Следващо най-добро действие",
     "focusTask": "Най-въздействаща задача",
     "focusHint": "Премества задачата в „в процес\" и „днес\"",
-    "noNextAction": "Всичко е наред - няма неизпълнени задачи."
+    "noNextAction": "Всичко е наред - няма неизпълнени задачи.",
+    "selectDueDatePlaceholder": "Изберете дата на падеж",
+    "goalTitle": "Цел"
   },
   "projectItem": {
     "edit": "Редактиране",
@@ -1088,7 +1114,14 @@
     "error": "Грешка при зареждане на детайли за област.",
     "notFound": "Областта не е намерена.",
     "details": "Детайли за област",
-    "viewProjects": "Преглед на проекти в {{name}}"
+    "viewProjects": "Преглед на проекти в {{name}}",
+    "goalTitlePlaceholder": "Заглавие на цел",
+    "goalWhyPlaceholder": "Защо това е важно (по избор)",
+    "editGoal": "Редактиране на цел",
+    "deleteGoal": "Изтриване на цел",
+    "moveBackToUnlinked": "Върни се към не свързани",
+    "horizonSeason": "Сезон",
+    "horizonYear": "Година"
   },
   "notes": {
     "loading": "Зареждане на бележки...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Изтрий бележка {{noteTitle}}",
     "deleteNoteTitle": "Изтрий бележка {{noteTitle}}",
     "editNoteAriaLabel": "Редактирай бележка {{noteTitle}}",
-    "editNoteTitle": "Редактирай бележка {{noteTitle}}"
+    "editNoteTitle": "Редактирай бележка {{noteTitle}}",
+    "titlePlaceholder": "Заглавие на бележка...",
+    "contentPlaceholder": "Напишете съдържанието на бележката тук... (поддържа Markdown)",
+    "focusMode": "Режим на фокус",
+    "noteOptions": "Опции за бележка",
+    "clickToEdit": "Щракнете, за да редактирате",
+    "contentPlaceholderFocus": "Напишете вашата бележка... (поддържа Markdown)",
+    "contentPlaceholderMarkdown": "Напишете съдържанието си, използвайки Markdown форматиране...\n\nПримери:\n# Заглавие\n**Дебел текст**\n*Курсивен текст*\n- Елемент от списък\n```код```"
   },
   "tags": {
     "loading": "Зареждане на тагове...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Системни тагове",
     "systemTagDescription": "Създадени автоматично от приложението. Те захранват вградените функции и не могат да бъдат преименувани или изтрити.",
     "userTag": "Потребителски тагове",
-    "userTagDescription": "Вашите собствени тагове за организиране на задачи, бележки и проекти."
+    "userTagDescription": "Вашите собствени тагове за организиране на задачи, бележки и проекти.",
+    "systemTags": "Системни етикети",
+    "systemTagsDescription": "Автоматично управлявани · Не могат да бъдат изтривани или преименувани",
+    "system": "Система",
+    "customize": "Персонализиране"
   },
   "recurrence": {
     "none": "Няма",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Приоритет:",
     "dueLabel": "Срок:",
     "tags": "Тагове",
-    "recurring": "Повтарящи се"
+    "recurring": "Повтарящи се",
+    "saveAsSmartView": "Запази като Умен изглед",
+    "viewNamePlaceholder": "Въведете име на изгледа",
+    "viewNameLabel": "Име на изгледа",
+    "viewWillSave": "Този изглед ще се запази:",
+    "saveView": "Запази изгледа",
+    "filtersLabel": "Филтри:",
+    "searchLabel": "Търсене:"
   },
   "search": {
     "placeholder": "Търсене на задачи, проекти, бележки...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Завършено и готово",
     "cancelled": "Отменено",
     "cancelled_desc": "Няма да бъде завършено"
+  },
+  "habits": {
+    "completeHabit": "Завърши навика"
+  },
+  "aiAssistant": {
+    "title": "AI Асистент",
+    "generatedAt": "Генерирано в {{time}}",
+    "emptyState": "Кликнете 'Генерирай резюме', за да получите ежедневния си обзор, захранван от AI.",
+    "focusForToday": "Фокус за днес",
+    "priorityActions": "Приоритетни действия",
+    "taskInsightsTitle": "AI Инсайти",
+    "projectInsightsTitle": "AI Инсайти",
+    "taskInsight": "За тази задача",
+    "taskNextStep": "Следваща стъпка",
+    "taskBreakdown": "Как да подходите към нея",
+    "projectInsight": "За този проект",
+    "projectNextAction": "Следващо действие",
+    "projectHealth": "Здраве на проекта",
+    "watchOut": "Внимавайте",
+    "suggestedLinks": "Предложени връзки",
+    "generate": "Генерирай резюме",
+    "regenerate": "Регенерирай",
+    "generating": "Генерира...",
+    "errorDefault": "Неуспешно генериране на информация. Моля, опитайте отново.",
+    "lowContextTitle": "Недостатъчен контекст за страхотно предложение",
+    "lowContextHint": "Добавете описание, бележки, тагове или назначете проект, за да получите по-добри прозрения. Все пак можете да генерирате по-долу.",
+    "generateAnyway": "Генерирай все пак",
+    "statTotal": "Общо",
+    "statDone": "Завършено",
+    "statActive": "Активно",
+    "statOverdue": "Просрочено"
   }
 }

--- a/public/locales/da/translation.json
+++ b/public/locales/da/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Ja, forkast",
     "uploading": "Uploader...",
     "refresh": "Opdater",
-    "unlinking": "Frakobler..."
+    "unlinking": "Frakobler...",
+    "preview": "Forhåndsvisning",
+    "download": "Download",
+    "exitFocusMode": "Forlad fokus tilstand",
+    "searchTimezones": "Søg efter tidszoner...",
+    "dismiss": "Afvis"
   },
   "sidebar": {
     "dashboard": "Dashboard",
@@ -58,7 +63,10 @@
     "unpinView": "Fjern fastgørelse af visning",
     "pinView": "Fastgør visning",
     "eisenhower": "Eisenhower Matrix",
-    "kanban": "Kanban Tavle"
+    "kanban": "Kanban Tavle",
+    "addHabitAriaLabel": "Tilføj vane",
+    "addHabitTitle": "Tilføj vane",
+    "toggleDarkMode": "Skift til mørk tilstand"
   },
   "navigation": {
     "home": "Hjem",
@@ -68,7 +76,11 @@
     "settings": "Indstillinger",
     "about": "Om",
     "logout": "Log ud",
-    "backupRestore": "Backup & Gendan"
+    "backupRestore": "Backup & Gendan",
+    "toggleSearch": "Skift søgning",
+    "quickInboxCapture": "Hurtig indbakkeoptagelse",
+    "userMenu": "Bruger menu",
+    "search": "Søg"
   },
   "settings": {
     "todayPageSettings": "Indstillinger for i dag",
@@ -181,7 +193,9 @@
       "waiting": "Venter",
       "done": "Færdig",
       "dropHere": "Slip her"
-    }
+    },
+    "chaseUp": "Følge op",
+    "habit": "Vane"
   },
   "timeline": {
     "activityTimeline": "Aktivitets Tidslinje",
@@ -503,7 +517,9 @@
       "serverSettings": "Serverindstillinger",
       "syncSettings": "Synkroniseringsindstillinger",
       "setupSuccess": "Kalender konfigureret med succes!",
-      "setupFailed": "Fejl ved oprettelse af kalender"
+      "setupFailed": "Fejl ved oprettelse af kalender",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "Løs synkroniseringskonflikter",
@@ -538,7 +554,9 @@
       "intervalError": "Synkroniseringsintervallet skal være mellem 1 og 1440 minutter",
       "updateSuccess": "Kalenderen er blevet opdateret med succes",
       "updateError": "Kunne ikke opdatere kalender"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@brugernavn1, 123456789, @brugernavn2"
   },
   "productivity": {
     "stalledProjects": "Stagnerede Projekter",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Kunne ikke gemme projekt.",
     "projectImageTooLarge": "Billedet er for stort. Vælg venligst en fil under 10MB.",
     "projectImageUpload": "Fejl ved upload af billede. Prøv venligst en mindre fil eller et andet format.",
-    "bannerSaveFailed": "Fejl ved gemme banner"
+    "bannerSaveFailed": "Fejl ved gemme banner",
+    "loginFailed": "Login mislykkedes. Prøv venligst igen.",
+    "generalError": "Der opstod en fejl. Prøv venligst igen.",
+    "viewNameRequired": "Visningsnavn er påkrævet",
+    "viewSaveFailed": "Fejl ved gemning af visning. Prøv venligst igen."
   },
   "inbox": {
     "title": "Indbakke",
@@ -810,7 +832,9 @@
     "loadMoreError": "Kunne ikke indlæse flere elementer",
     "loading": "Indlæser...",
     "loadMore": "Indlæs flere indbakkeelementer",
-    "showingItems": "Viser {{current}} af {{total}} elementer"
+    "showingItems": "Viser {{current}} af {{total}} elementer",
+    "removeTag": "Fjern tag",
+    "removeProject": "Fjern projekt"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Næste bedste handling",
     "focusTask": "Mest indflydelsesrige opgave",
     "focusHint": "Flytter denne opgave til i gang og i dag",
-    "noNextAction": "Alt klart - ingen udestående opgaver."
+    "noNextAction": "Alt klart - ingen udestående opgaver.",
+    "selectDueDatePlaceholder": "Vælg forfaldsdato",
+    "goalTitle": "Mål"
   },
   "projectItem": {
     "edit": "Rediger",
@@ -1088,7 +1114,14 @@
     "error": "Fejl ved indlæsning af områdedetaljer.",
     "notFound": "Område ikke fundet.",
     "details": "Områdeoplysninger",
-    "viewProjects": "Se projekter i {{name}}"
+    "viewProjects": "Se projekter i {{name}}",
+    "goalTitlePlaceholder": "Mål titel",
+    "goalWhyPlaceholder": "Hvorfor dette er vigtigt (valgfrit)",
+    "editGoal": "Rediger mål",
+    "deleteGoal": "Slet mål",
+    "moveBackToUnlinked": "Flyt tilbage til ikke-linket",
+    "horizonSeason": "Sæson",
+    "horizonYear": "År"
   },
   "notes": {
     "loading": "Indlæser noter...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Slet note {{noteTitle}}",
     "deleteNoteTitle": "Slet note {{noteTitle}}",
     "editNoteAriaLabel": "Rediger note {{noteTitle}}",
-    "editNoteTitle": "Rediger note {{noteTitle}}"
+    "editNoteTitle": "Rediger note {{noteTitle}}",
+    "titlePlaceholder": "Notat titel...",
+    "contentPlaceholder": "Skriv dit notatindhold her... (Markdown understøttet)",
+    "focusMode": "Fokus tilstand",
+    "noteOptions": "Notatindstillinger",
+    "clickToEdit": "Klik for at redigere",
+    "contentPlaceholderFocus": "Skriv dit notat... (Markdown understøttet)",
+    "contentPlaceholderMarkdown": "Skriv dit indhold ved hjælp af Markdown formatering...\n\nEksempler:\n# Overskrift\n**Fed tekst**\n*Kursiv tekst*\n- Listeelement\n```kode```"
   },
   "tags": {
     "loading": "Indlæser tags...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Systemtags",
     "systemTagDescription": "Oprettet automatisk af appen. De driver indbyggede funktioner og kan ikke omdøbes eller slettes.",
     "userTag": "Brugertags",
-    "userTagDescription": "Dine egne tags til organisering af opgaver, noter og projekter."
+    "userTagDescription": "Dine egne tags til organisering af opgaver, noter og projekter.",
+    "systemTags": "System Tags",
+    "systemTagsDescription": "Automatisk styret · Kan ikke slettes eller omdøbes",
+    "system": "System",
+    "customize": "Tilpas"
   },
   "recurrence": {
     "none": "Ingen",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Prioritet:",
     "dueLabel": "Forfalder:",
     "tags": "Tags",
-    "recurring": "Gentagende"
+    "recurring": "Gentagende",
+    "saveAsSmartView": "Gem som Smart View",
+    "viewNamePlaceholder": "Indtast visningsnavn",
+    "viewNameLabel": "Visningsnavn",
+    "viewWillSave": "Denne visning vil gemmes:",
+    "saveView": "Gem visning",
+    "filtersLabel": "Filtre:",
+    "searchLabel": "Søg:"
   },
   "search": {
     "placeholder": "Søg opgaver, projekter, noter...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Afsluttet og færdig",
     "cancelled": "Annulleret",
     "cancelled_desc": "Vil ikke blive færdiggjort"
+  },
+  "habits": {
+    "completeHabit": "Fuldfør vane"
+  },
+  "aiAssistant": {
+    "title": "AI Assistent",
+    "generatedAt": "Genereret kl. {{time}}",
+    "emptyState": "Klik på 'Generer resumé' for at få dit AI-drevne daglige resumé.",
+    "focusForToday": "Fokus for i dag",
+    "priorityActions": "Prioriterede handlinger",
+    "taskInsightsTitle": "AI Indsigter",
+    "projectInsightsTitle": "AI Indsigter",
+    "taskInsight": "Om denne opgave",
+    "taskNextStep": "Næste skridt",
+    "taskBreakdown": "Hvordan man griber det an",
+    "projectInsight": "Om dette projekt",
+    "projectNextAction": "Næste handling",
+    "projectHealth": "Projektstatus",
+    "watchOut": "Pas på",
+    "suggestedLinks": "Forslåede links",
+    "generate": "Generer kort",
+    "regenerate": "Regenerer",
+    "generating": "Genererer...",
+    "errorDefault": "Kunne ikke generere indsigt. Prøv venligst igen.",
+    "lowContextTitle": "Ikke nok kontekst til et godt forslag",
+    "lowContextHint": "Tilføj en beskrivelse, noter, tags eller tildel et projekt for at få bedre indsigt. Du kan stadig generere nedenfor.",
+    "generateAnyway": "Generer alligevel",
+    "statTotal": "Total",
+    "statDone": "Færdig",
+    "statActive": "Aktiv",
+    "statOverdue": "Forfaldet"
   }
 }

--- a/public/locales/de/translation.json
+++ b/public/locales/de/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Ja, verwerfen",
     "uploading": "Hochladen...",
     "refresh": "Aktualisieren",
-    "unlinking": "Trennen..."
+    "unlinking": "Trennen...",
+    "preview": "Vorschau",
+    "download": "Herunterladen",
+    "exitFocusMode": "Fokusmodus beenden",
+    "searchTimezones": "Zeitzonen suchen...",
+    "dismiss": "Schließen"
   },
   "sidebar": {
     "dashboard": "Dashboard",
@@ -58,7 +63,10 @@
     "unpinView": "Ansicht lösen",
     "pinView": "Ansicht anheften",
     "eisenhower": "Eisenhower-Matrix",
-    "kanban": "Kanban-Board"
+    "kanban": "Kanban-Board",
+    "addHabitAriaLabel": "Gewohnheit hinzufügen",
+    "addHabitTitle": "Gewohnheit hinzufügen",
+    "toggleDarkMode": "Dunkelmodus umschalten"
   },
   "navigation": {
     "home": "Startseite",
@@ -68,7 +76,11 @@
     "settings": "Einstellungen",
     "about": "Über",
     "logout": "Abmelden",
-    "backupRestore": "Sichern & Wiederherstellen"
+    "backupRestore": "Sichern & Wiederherstellen",
+    "toggleSearch": "Suche umschalten",
+    "quickInboxCapture": "Schnelle Posteingangserfassung",
+    "userMenu": "Benutzermenü",
+    "search": "Suche"
   },
   "settings": {
     "todayPageSettings": "Heute-Seite Einstellungen",
@@ -181,7 +193,9 @@
       "waiting": "Warten",
       "done": "Erledigt",
       "dropHere": "Hier ablegen"
-    }
+    },
+    "chaseUp": "Nachverfolgen",
+    "habit": "Gewohnheit"
   },
   "timeline": {
     "activityTimeline": "Aktivitätsverlauf",
@@ -362,7 +376,11 @@
     "failedToSaveTag": "Speichern des Tags fehlgeschlagen.",
     "projectImageTooLarge": "Bild ist zu groß. Bitte wählen Sie eine Datei unter 10MB.",
     "projectImageUpload": "Hochladen des Bildes fehlgeschlagen. Bitte versuchen Sie eine kleinere Datei oder ein anderes Format.",
-    "bannerSaveFailed": "Speichern des Banners fehlgeschlagen"
+    "bannerSaveFailed": "Speichern des Banners fehlgeschlagen",
+    "loginFailed": "Anmeldung fehlgeschlagen. Bitte erneut versuchen.",
+    "generalError": "Ein Fehler ist aufgetreten. Bitte erneut versuchen.",
+    "viewNameRequired": "Der Ansichtsname ist erforderlich",
+    "viewSaveFailed": "Speichern der Ansicht fehlgeschlagen. Bitte versuchen Sie es erneut."
   },
   "success": {
     "noteUpdated": "Notiz erfolgreich aktualisiert!",
@@ -389,7 +407,14 @@
     "deleteNoteAriaLabel": "Notiz {{noteTitle}} löschen",
     "deleteNoteTitle": "Notiz {{noteTitle}} löschen",
     "editNoteAriaLabel": "Notiz {{noteTitle}} bearbeiten",
-    "editNoteTitle": "Notiz {{noteTitle}} bearbeiten"
+    "editNoteTitle": "Notiz {{noteTitle}} bearbeiten",
+    "titlePlaceholder": "Notiztitel...",
+    "contentPlaceholder": "Schreiben Sie hier den Inhalt Ihrer Notiz... (Markdown unterstützt)",
+    "focusMode": "Fokusmodus",
+    "noteOptions": "Notizoptionen",
+    "clickToEdit": "Klicken Sie zum Bearbeiten",
+    "contentPlaceholderFocus": "Schreiben Sie Ihre Notiz... (Markdown unterstützt)",
+    "contentPlaceholderMarkdown": "Schreiben Sie Ihren Inhalt mit Markdown-Formatierung...\n\nBeispiele:\n# Überschrift\n**Fetter Text**\n*Kursiver Text*\n- Listenpunkt\n```code```"
   },
   "recurrence": {
     "none": "Keine",
@@ -451,7 +476,9 @@
     "loadMoreError": "Fehler beim Laden weiterer Elemente",
     "loading": "Wird geladen...",
     "loadMore": "Weitere Posteingangsartikel laden",
-    "showingItems": "Zeige {{current}} von {{total}} Elementen"
+    "showingItems": "Zeige {{current}} von {{total}} Elementen",
+    "removeTag": "Tag entfernen",
+    "removeProject": "Projekt entfernen"
   },
   "project": {
     "projectImage": "Projektbild",
@@ -746,7 +773,9 @@
       "serverSettings": "Servereinstellungen",
       "syncSettings": "Synchronisationseinstellungen",
       "setupSuccess": "Kalender erfolgreich konfiguriert!",
-      "setupFailed": "Kalender konnte nicht erstellt werden"
+      "setupFailed": "Kalender konnte nicht erstellt werden",
+      "serverUrlPlaceholder": "https://caldav.beispiel.com",
+      "calendarPathPlaceholder": "/kalender/benutzer/aufgaben"
     },
     "conflictResolver": {
       "title": "Synchronisationskonflikte lösen",
@@ -781,7 +810,9 @@
       "intervalError": "Das Synchronisierungsintervall muss zwischen 1 und 1440 Minuten liegen",
       "updateSuccess": "Kalender erfolgreich aktualisiert",
       "updateError": "Fehler beim Aktualisieren des Kalenders"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@benutzername1, 123456789, @benutzername2"
   },
   "nextTask": {
     "suggestion": "Da nichts in Bearbeitung ist, wie wäre es, mit diesem zu beginnen",
@@ -1148,7 +1179,9 @@
     "nextUp": "Nächste beste Aktion",
     "focusTask": "Einflussreichste Aufgabe",
     "focusHint": "Verschiebt diese Aufgabe zu „In Bearbeitung\" und „Heute\"",
-    "noNextAction": "Alles klar - keine ausstehenden Aufgaben."
+    "noNextAction": "Alles klar - keine ausstehenden Aufgaben.",
+    "selectDueDatePlaceholder": "Fälligkeitsdatum auswählen",
+    "goalTitle": "Ziel"
   },
   "projectItem": {
     "edit": "Bearbeiten",
@@ -1180,7 +1213,14 @@
     "error": "Fehler beim Laden der Bereichsdetails.",
     "notFound": "Bereich nicht gefunden.",
     "details": "Bereichsdetails",
-    "viewProjects": "Projekte in {{name}} anzeigen"
+    "viewProjects": "Projekte in {{name}} anzeigen",
+    "goalTitlePlaceholder": "Zieltitel",
+    "goalWhyPlaceholder": "Warum das wichtig ist (optional)",
+    "editGoal": "Ziel bearbeiten",
+    "deleteGoal": "Ziel löschen",
+    "moveBackToUnlinked": "Zurück zu nicht verknüpft bewegen",
+    "horizonSeason": "Saison",
+    "horizonYear": "Jahr"
   },
   "tags": {
     "loading": "Tags laden...",
@@ -1204,7 +1244,11 @@
     "systemTag": "System-Tags",
     "systemTagDescription": "Wird automatisch von der App erstellt. Sie steuern integrierte Funktionen und können nicht umbenannt oder gelöscht werden.",
     "userTag": "Benutzertags",
-    "userTagDescription": "Ihre eigenen Tags zur Organisation von Aufgaben, Notizen und Projekten."
+    "userTagDescription": "Ihre eigenen Tags zur Organisation von Aufgaben, Notizen und Projekten.",
+    "systemTags": "System-Tags",
+    "systemTagsDescription": "Automatisch verwaltet · Können nicht gelöscht oder umbenannt werden",
+    "system": "System",
+    "customize": "Anpassen"
   },
   "pomodoro": {
     "play": "Abspielen",
@@ -1408,7 +1452,14 @@
     "priorityLabel": "Priorität:",
     "dueLabel": "Fällig:",
     "tags": "Tags",
-    "recurring": "Wiederkehrend"
+    "recurring": "Wiederkehrend",
+    "saveAsSmartView": "Als intelligente Ansicht speichern",
+    "viewNamePlaceholder": "Geben Sie den Ansichtsname ein",
+    "viewNameLabel": "Ansichtsname",
+    "viewWillSave": "Diese Ansicht wird gespeichert:",
+    "saveView": "Ansicht speichern",
+    "filtersLabel": "Filter:",
+    "searchLabel": "Suche:"
   },
   "search": {
     "placeholder": "Aufgaben, Projekte, Notizen suchen...",
@@ -1565,5 +1616,36 @@
     "done_desc": "Fertig und abgeschlossen",
     "cancelled": "Abgebrochen",
     "cancelled_desc": "Wird nicht abgeschlossen"
+  },
+  "habits": {
+    "completeHabit": "Gewohnheit abschließen"
+  },
+  "aiAssistant": {
+    "title": "KI-Assistent",
+    "generatedAt": "Generiert um {{time}}",
+    "emptyState": "Klicken Sie auf 'Brief generieren', um Ihre KI-gestützte tägliche Zusammenfassung zu erhalten.",
+    "focusForToday": "Fokus für heute",
+    "priorityActions": "Prioritätsaktionen",
+    "taskInsightsTitle": "KI-Einblicke",
+    "projectInsightsTitle": "KI-Einblicke",
+    "taskInsight": "Über diese Aufgabe",
+    "taskNextStep": "Nächster Schritt",
+    "taskBreakdown": "Wie man es angeht",
+    "projectInsight": "Über dieses Projekt",
+    "projectNextAction": "Nächste Aktion",
+    "projectHealth": "Projektgesundheit",
+    "watchOut": "Vorsicht",
+    "suggestedLinks": "Vorgeschlagene Links",
+    "generate": "Brief generieren",
+    "regenerate": "Regenerieren",
+    "generating": "Wird generiert...",
+    "errorDefault": "Fehler beim Generieren von Einblicken. Bitte versuchen Sie es erneut.",
+    "lowContextTitle": "Nicht genug Kontext für einen großartigen Vorschlag",
+    "lowContextHint": "Fügen Sie eine Beschreibung, Notizen, Tags hinzu oder weisen Sie ein Projekt zu, um bessere Einblicke zu erhalten. Sie können trotzdem unten generieren.",
+    "generateAnyway": "Trotzdem generieren",
+    "statTotal": "Gesamt",
+    "statDone": "Erledigt",
+    "statActive": "Aktiv",
+    "statOverdue": "Überfällig"
   }
 }

--- a/public/locales/el/translation.json
+++ b/public/locales/el/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Ναι, απόρριψη",
     "uploading": "Ανεβάζω...",
     "refresh": "Ανανέωση",
-    "unlinking": "Αποσύνδεση..."
+    "unlinking": "Αποσύνδεση...",
+    "preview": "Προεπισκόπηση",
+    "download": "Λήψη",
+    "exitFocusMode": "Έξοδος από τη λειτουργία εστίασης",
+    "searchTimezones": "Αναζήτηση ζωνών ώρας...",
+    "dismiss": "Απόρριψη"
   },
   "sidebar": {
     "dashboard": "Πίνακας Ελέγχου",
@@ -58,7 +63,10 @@
     "unpinView": "Αφαίρεση καρφώματος προβολής",
     "pinView": "Καρφίτσωμα προβολής",
     "eisenhower": "Μηχανισμός Eisenhower",
-    "kanban": "Πίνακας Kanban"
+    "kanban": "Πίνακας Kanban",
+    "addHabitAriaLabel": "Προσθήκη Συνήθειας",
+    "addHabitTitle": "Προσθήκη Συνήθειας",
+    "toggleDarkMode": "Εναλλαγή Σκοτεινής Λειτουργίας"
   },
   "navigation": {
     "home": "Αρχική",
@@ -68,7 +76,11 @@
     "settings": "Ρυθμίσεις",
     "about": "Σχετικά",
     "logout": "Αποσύνδεση",
-    "backupRestore": "Αντίγραφα ασφαλείας & Επαναφορά"
+    "backupRestore": "Αντίγραφα ασφαλείας & Επαναφορά",
+    "toggleSearch": "Εναλλαγή Αναζήτησης",
+    "quickInboxCapture": "Γρήγορη Καταγραφή Εισερχομένων",
+    "userMenu": "Μενού Χρήστη",
+    "search": "Αναζήτηση"
   },
   "settings": {
     "todayPageSettings": "Ρυθμίσεις Σελίδας Σήμερα",
@@ -402,7 +414,9 @@
       "serverSettings": "Ρυθμίσεις Διακομιστή",
       "syncSettings": "Ρυθμίσεις Συγχρονισμού",
       "setupSuccess": "Το ημερολόγιο ρυθμίστηκε επιτυχώς!",
-      "setupFailed": "Αποτυχία δημιουργίας ημερολογίου"
+      "setupFailed": "Αποτυχία δημιουργίας ημερολογίου",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "Επίλυση Συγκρούσεων Συγχρονισμού",
@@ -437,7 +451,9 @@
       "intervalError": "Η διάρκεια συγχρονισμού πρέπει να είναι μεταξύ 1 και 1440 λεπτών",
       "updateSuccess": "Το ημερολόγιο ενημερώθηκε με επιτυχία",
       "updateError": "Αποτυχία ενημέρωσης ημερολογίου"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "errors": {
     "required": "Αυτό το πεδίο είναι υποχρεωτικό",
@@ -465,7 +481,11 @@
     "networkError": "Σφάλμα δικτύου, παρακαλώ ελέγξτε τη σύνδεσή σας",
     "projectImageTooLarge": "Η εικόνα είναι πολύ μεγάλη. Παρακαλώ επιλέξτε ένα αρχείο κάτω από 10MB.",
     "projectImageUpload": "Αποτυχία ανέβασμα εικόνας. Παρακαλώ δοκιμάστε ένα μικρότερο αρχείο ή διαφορετική μορφή.",
-    "bannerSaveFailed": "Αποτυχία αποθήκευσης πανό"
+    "bannerSaveFailed": "Αποτυχία αποθήκευσης πανό",
+    "loginFailed": "Η σύνδεση απέτυχε. Παρακαλώ δοκιμάστε ξανά.",
+    "generalError": "Παρουσιάστηκε σφάλμα. Παρακαλώ δοκιμάστε ξανά.",
+    "viewNameRequired": "Απαιτείται όνομα προβολής",
+    "viewSaveFailed": "Αποτυχία αποθήκευσης προβολής. Παρακαλώ δοκιμάστε ξανά."
   },
   "dropdown": {
     "createNew": "Δημιουργία Νέου",
@@ -555,7 +575,9 @@
       "waiting": "Αναμονή",
       "done": "Ολοκληρώθηκε",
       "dropHere": "Αφήστε εδώ"
-    }
+    },
+    "chaseUp": "Επικοινωνία",
+    "habit": "Συνήθεια"
   },
   "timeline": {
     "activityTimeline": "Χρονοδιάγραμμα Δραστηριότητας",
@@ -661,7 +683,9 @@
     "nextUp": "Επόμενη καλύτερη ενέργεια",
     "focusTask": "Πιο σημαντική εργασία",
     "focusHint": "Μετακινεί αυτήν την εργασία σε εξέλιξη και σήμερα",
-    "noNextAction": "Όλα καθαρά-καμία εκκρεμής εργασία."
+    "noNextAction": "Όλα καθαρά-καμία εκκρεμής εργασία.",
+    "selectDueDatePlaceholder": "Επιλέξτε προθεσμία",
+    "goalTitle": "Στόχος"
   },
   "notes": {
     "loading": "Φόρτωση σημειώσεων...",
@@ -672,7 +696,14 @@
     "deleteNoteAriaLabel": "Διαγραφή σημείωσης {{noteTitle}}",
     "deleteNoteTitle": "Διαγραφή σημείωσης {{noteTitle}}",
     "editNoteAriaLabel": "Επεξεργασία σημείωσης {{noteTitle}}",
-    "editNoteTitle": "Επεξεργασία σημείωσης {{noteTitle}}"
+    "editNoteTitle": "Επεξεργασία σημείωσης {{noteTitle}}",
+    "titlePlaceholder": "Τίτλος σημείωσης...",
+    "contentPlaceholder": "Γράψτε το περιεχόμενο της σημείωσής σας εδώ... (Υποστηρίζεται Markdown)",
+    "focusMode": "Λειτουργία εστίασης",
+    "noteOptions": "Επιλογές σημείωσης",
+    "clickToEdit": "Κάντε κλικ για επεξεργασία",
+    "contentPlaceholderFocus": "Γράψτε τη σημείωσή σας... (Υποστηρίζεται Markdown)",
+    "contentPlaceholderMarkdown": "Γράψτε το περιεχόμενό σας χρησιμοποιώντας μορφοποίηση Markdown...\n\nΠαραδείγματα:\n# Τίτλος\n**Έντονο κείμενο**\n*Πλάγιο κείμενο*\n- Στοιχείο λίστας\n```κώδικας```"
   },
   "projectItem": {
     "edit": "Επεξεργασία",
@@ -1046,7 +1077,9 @@
     "loadMoreError": "Αποτυχία φόρτωσης περισσότερων στοιχείων",
     "loading": "Φόρτωση...",
     "loadMore": "Φόρτωση περισσότερων στοιχείων εισερχομένων",
-    "showingItems": "Εμφάνιση {{current}} από {{total}} στοιχεία"
+    "showingItems": "Εμφάνιση {{current}} από {{total}} στοιχεία",
+    "removeTag": "Αφαίρεση ετικέτας",
+    "removeProject": "Αφαίρεση έργου"
   },
   "success": {
     "noteUpdated": "Η σημείωση ενημερώθηκε με επιτυχία!",
@@ -1076,7 +1109,14 @@
     "error": "Σφάλμα φόρτωσης λεπτομερειών περιοχής.",
     "notFound": "Η περιοχή δεν βρέθηκε.",
     "details": "Λεπτομέρειες Περιοχής",
-    "viewProjects": "Προβολή Έργων στην {{name}}"
+    "viewProjects": "Προβολή Έργων στην {{name}}",
+    "goalTitlePlaceholder": "Τίτλος στόχου",
+    "goalWhyPlaceholder": "Γιατί αυτό έχει σημασία (προαιρετικό)",
+    "editGoal": "Επεξεργασία στόχου",
+    "deleteGoal": "Διαγραφή στόχου",
+    "moveBackToUnlinked": "Μετακίνηση πίσω σε μη συνδεδεμένα",
+    "horizonSeason": "Σεζόν",
+    "horizonYear": "Έτος"
   },
   "tags": {
     "loading": "Φόρτωση ετικετών...",
@@ -1100,7 +1140,11 @@
     "systemTag": "Σύστημα ετικετών",
     "systemTagDescription": "Δημιουργούνται αυτόματα από την εφαρμογή. Υποστηρίζουν τις ενσωματωμένες δυνατότητες και δεν μπορούν να μετονομαστούν ή να διαγραφούν.",
     "userTag": "Ετικέτες χρήστη",
-    "userTagDescription": "Οι δικές σας ετικέτες για την οργάνωση εργασιών, σημειώσεων και έργων."
+    "userTagDescription": "Οι δικές σας ετικέτες για την οργάνωση εργασιών, σημειώσεων και έργων.",
+    "systemTags": "Συστήματα Ετικετών",
+    "systemTagsDescription": "Διαχειρίζεται αυτόματα · Δεν μπορεί να διαγραφεί ή να μετονομαστεί",
+    "system": "Σύστημα",
+    "customize": "Προσαρμογή"
   },
   "note": {
     "title": "Τίτλος",
@@ -1403,7 +1447,14 @@
     "priorityLabel": "Προτεραιότητα:",
     "dueLabel": "Λήξη:",
     "tags": "Ετικέτες",
-    "recurring": "Επαναλαμβανόμενο"
+    "recurring": "Επαναλαμβανόμενο",
+    "saveAsSmartView": "Αποθήκευση ως Έξυπνη Προβολή",
+    "viewNamePlaceholder": "Εισάγετε το όνομα της προβολής",
+    "viewNameLabel": "Όνομα Προβολής",
+    "viewWillSave": "Αυτή η προβολή θα αποθηκευτεί:",
+    "saveView": "Αποθήκευση Προβολής",
+    "filtersLabel": "Φίλτρα:",
+    "searchLabel": "Αναζήτηση:"
   },
   "search": {
     "placeholder": "Αναζήτηση εργασιών, έργων, σημειώσεων...",
@@ -1560,5 +1611,36 @@
     "done_desc": "Ολοκληρωμένο και τελειωμένο",
     "cancelled": "Ακυρώθηκε",
     "cancelled_desc": "Δεν θα ολοκληρωθεί"
+  },
+  "habits": {
+    "completeHabit": "Ολοκλήρωση συνήθειας"
+  },
+  "aiAssistant": {
+    "title": "Βοηθός AI",
+    "generatedAt": "Δημιουργήθηκε στις {{time}}",
+    "emptyState": "Κάντε κλικ στο 'Δημιουργία Περίληψης' για να λάβετε την καθημερινή σας περίληψη με τη βοήθεια AI.",
+    "focusForToday": "Επικέντρωση για σήμερα",
+    "priorityActions": "Προτεραιότητες δράσεις",
+    "taskInsightsTitle": "Ευρήματα AI",
+    "projectInsightsTitle": "Ευρήματα AI",
+    "taskInsight": "Σχετικά με αυτήν την εργασία",
+    "taskNextStep": "Επόμενο βήμα",
+    "taskBreakdown": "Πώς να το προσεγγίσετε",
+    "projectInsight": "Σχετικά με αυτό το έργο",
+    "projectNextAction": "Επόμενη ενέργεια",
+    "projectHealth": "Κατάσταση έργου",
+    "watchOut": "Προσοχή",
+    "suggestedLinks": "Προτεινόμενοι σύνδεσμοι",
+    "generate": "Δημιουργία Περίληψης",
+    "regenerate": "Αναδημιουργία",
+    "generating": "Δημιουργία...",
+    "errorDefault": "Αποτυχία δημιουργίας πληροφοριών. Παρακαλώ δοκιμάστε ξανά.",
+    "lowContextTitle": "Δεν υπάρχει αρκετό πλαίσιο για μια καλή πρόταση",
+    "lowContextHint": "Προσθέστε μια περιγραφή, σημειώσεις, ετικέτες ή αναθέστε ένα έργο για να λάβετε καλύτερες πληροφορίες. Μπορείτε να δημιουργήσετε παρακάτω.",
+    "generateAnyway": "Δημιουργία ούτως ή άλλως",
+    "statTotal": "Σύνολο",
+    "statDone": "Ολοκληρώθηκε",
+    "statActive": "Ενεργό",
+    "statOverdue": "Καθυστερημένο"
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -192,7 +192,9 @@
     "tasks": "tasks",
     "showingItems": "Showing {{current}} of {{total}} tasks",
     "noCompletedTasksToday": "No completed tasks today.",
-    "markAsDone": "Mark as done"
+    "markAsDone": "Mark as done",
+    "chaseUp": "Chase up",
+    "habit": "Habit"
   },
   "timeline": {
     "activityTimeline": "Activity Timeline",
@@ -315,6 +317,8 @@
     "pollingError": "Error managing Telegram polling",
     "startPollingFailed": "Failed to start polling",
     "stopPollingFailed": "Failed to stop polling",
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2",
     "openTelegram": "Open in Telegram",
     "openInTelegram": "open in telegram",
     "testTelegramMessage": "Test Telegram",
@@ -468,7 +472,9 @@
       "serverSettings": "Server Settings",
       "syncSettings": "Sync Settings",
       "setupSuccess": "Calendar configured successfully!",
-      "setupFailed": "Failed to create calendar"
+      "setupFailed": "Failed to create calendar",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "Resolve Sync Conflicts",
@@ -1042,6 +1048,8 @@
     "focusTask": "Most impactful task",
     "focusHint": "Shifts this task to in progress and today",
     "noNextAction": "All clear-no outstanding tasks.",
+    "selectDueDatePlaceholder": "Select due date",
+    "goalTitle": "Goal",
     "filters": {
       "active": "Active",
       "inactive": "Inactive",
@@ -1098,7 +1106,14 @@
     "error": "Error loading area details.",
     "notFound": "Area not found.",
     "details": "Area Details",
-    "viewProjects": "View Projects in {{name}}"
+    "viewProjects": "View Projects in {{name}}",
+    "goalTitlePlaceholder": "Goal title",
+    "goalWhyPlaceholder": "Why this matters (optional)",
+    "editGoal": "Edit goal",
+    "deleteGoal": "Delete goal",
+    "moveBackToUnlinked": "Move back to unlinked",
+    "horizonSeason": "Season",
+    "horizonYear": "Year"
   },
   "notes": {
     "loading": "Loading notes...",
@@ -1115,7 +1130,8 @@
     "focusMode": "Focus mode",
     "noteOptions": "Note options",
     "clickToEdit": "Click to edit",
-    "contentPlaceholderFocus": "Write your note... (Markdown supported)"
+    "contentPlaceholderFocus": "Write your note... (Markdown supported)",
+    "contentPlaceholderMarkdown": "Write your content using Markdown formatting...\n\nExamples:\n# Heading\n**Bold text**\n*Italic text*\n- List item\n```code```"
   },
   "tags": {
     "loading": "Loading tags...",
@@ -1144,6 +1160,9 @@
     "viewTasksWithTag": "View tasks with this tag",
     "typeToAdd": "Type to add a tag",
     "noItemsWithTag": "No items found with this tag"
+  },
+  "habits": {
+    "completeHabit": "Complete habit"
   },
   "recurrence": {
     "none": "None",
@@ -1421,7 +1440,9 @@
     "viewNamePlaceholder": "Enter view name",
     "viewNameLabel": "View Name",
     "viewWillSave": "This view will save:",
-    "saveView": "Save View"
+    "saveView": "Save View",
+    "filtersLabel": "Filters:",
+    "searchLabel": "Search:"
   },
   "search": {
     "placeholder": "Search tasks, projects, notes...",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Sí, descartar",
     "uploading": "Subiendo...",
     "refresh": "Actualizar",
-    "unlinking": "Desvinculando..."
+    "unlinking": "Desvinculando...",
+    "preview": "Vista previa",
+    "download": "Descargar",
+    "exitFocusMode": "Salir del modo de enfoque",
+    "searchTimezones": "Buscar zonas horarias...",
+    "dismiss": "Descartar"
   },
   "sidebar": {
     "dashboard": "Tablero",
@@ -58,7 +63,10 @@
     "unpinView": "Desanclar vista",
     "pinView": "Anclar vista",
     "eisenhower": "Matriz de Eisenhower",
-    "kanban": "Tablero Kanban"
+    "kanban": "Tablero Kanban",
+    "addHabitAriaLabel": "Agregar hábito",
+    "addHabitTitle": "Agregar hábito",
+    "toggleDarkMode": "Alternar modo oscuro"
   },
   "navigation": {
     "home": "Inicio",
@@ -68,7 +76,11 @@
     "settings": "Ajustes",
     "about": "Acerca de",
     "logout": "Cerrar Sesión",
-    "backupRestore": "Copia de seguridad y restauración"
+    "backupRestore": "Copia de seguridad y restauración",
+    "toggleSearch": "Alternar búsqueda",
+    "quickInboxCapture": "Captura rápida de bandeja de entrada",
+    "userMenu": "Menú de usuario",
+    "search": "Buscar"
   },
   "settings": {
     "todayPageSettings": "Configuración de Página Hoy",
@@ -402,7 +414,9 @@
       "serverSettings": "Configuraciones del Servidor",
       "syncSettings": "Configuraciones de Sincronización",
       "setupSuccess": "¡Calendario configurado exitosamente!",
-      "setupFailed": "Error al crear el calendario"
+      "setupFailed": "Error al crear el calendario",
+      "serverUrlPlaceholder": "https://caldav.ejemplo.com",
+      "calendarPathPlaceholder": "/calendarios/usuario/tareas"
     },
     "conflictResolver": {
       "title": "Resolver Conflictos de Sincronización",
@@ -437,7 +451,9 @@
       "intervalError": "El intervalo de sincronización debe estar entre 1 y 1440 minutos",
       "updateSuccess": "Calendario actualizado con éxito",
       "updateError": "Error al actualizar el calendario"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@nombredeusuario1, 123456789, @nombredeusuario2"
   },
   "errors": {
     "required": "Este campo es obligatorio",
@@ -465,7 +481,11 @@
     "failedToSaveTag": "No se pudo guardar la etiqueta.",
     "projectImageTooLarge": "La imagen es demasiado grande. Por favor, elige un archivo de menos de 10MB.",
     "projectImageUpload": "Error al subir la imagen. Por favor, intenta con un archivo más pequeño o un formato diferente.",
-    "bannerSaveFailed": "Error al guardar el banner"
+    "bannerSaveFailed": "Error al guardar el banner",
+    "loginFailed": "Error de inicio de sesión. Por favor, inténtalo de nuevo.",
+    "generalError": "Ocurrió un error. Por favor, inténtalo de nuevo.",
+    "viewNameRequired": "Se requiere un nombre de vista",
+    "viewSaveFailed": "Error al guardar la vista. Por favor, inténtalo de nuevo."
   },
   "dropdown": {
     "createNew": "Crear Nuevo",
@@ -555,7 +575,9 @@
       "waiting": "Esperando",
       "done": "Hecho",
       "dropHere": "Suelta aquí"
-    }
+    },
+    "chaseUp": "Perseguir",
+    "habit": "Hábito"
   },
   "timeline": {
     "activityTimeline": "Línea de Tiempo de Actividad",
@@ -647,7 +669,9 @@
     "nextUp": "Siguiente mejor acción",
     "focusTask": "Tarea más impactante",
     "focusHint": "Mueve esta tarea a en progreso y hoy",
-    "noNextAction": "Todo despejado: no hay tareas pendientes."
+    "noNextAction": "Todo despejado: no hay tareas pendientes.",
+    "selectDueDatePlaceholder": "Seleccionar fecha de vencimiento",
+    "goalTitle": "Objetivo"
   },
   "projectItem": {
     "edit": "Editar",
@@ -1018,7 +1042,9 @@
     "loadMoreError": "Error al cargar más elementos",
     "loading": "Cargando...",
     "loadMore": "Cargar más elementos de la bandeja de entrada",
-    "showingItems": "Mostrando {{current}} de {{total}} elementos"
+    "showingItems": "Mostrando {{current}} de {{total}} elementos",
+    "removeTag": "Eliminar etiqueta",
+    "removeProject": "Eliminar proyecto"
   },
   "areas": {
     "title": "Áreas",
@@ -1032,7 +1058,14 @@
     "error": "Error al cargar detalles del área.",
     "notFound": "Área no encontrada.",
     "details": "Detalles del Área",
-    "viewProjects": "Ver Proyectos en {{name}}"
+    "viewProjects": "Ver Proyectos en {{name}}",
+    "goalTitlePlaceholder": "Título del objetivo",
+    "goalWhyPlaceholder": "Por qué es importante (opcional)",
+    "editGoal": "Editar objetivo",
+    "deleteGoal": "Eliminar objetivo",
+    "moveBackToUnlinked": "Mover de vuelta a no vinculado",
+    "horizonSeason": "Temporada",
+    "horizonYear": "Año"
   },
   "notes": {
     "loading": "Cargando notas...",
@@ -1043,7 +1076,14 @@
     "deleteNoteAriaLabel": "Eliminar nota {{noteTitle}}",
     "deleteNoteTitle": "Eliminar nota {{noteTitle}}",
     "editNoteAriaLabel": "Editar nota {{noteTitle}}",
-    "editNoteTitle": "Editar nota {{noteTitle}}"
+    "editNoteTitle": "Editar nota {{noteTitle}}",
+    "titlePlaceholder": "Título de la nota...",
+    "contentPlaceholder": "Escribe el contenido de tu nota aquí... (Markdown soportado)",
+    "focusMode": "Modo de enfoque",
+    "noteOptions": "Opciones de nota",
+    "clickToEdit": "Haz clic para editar",
+    "contentPlaceholderFocus": "Escribe tu nota... (Markdown soportado)",
+    "contentPlaceholderMarkdown": "Escribe tu contenido utilizando formato Markdown...\n\nEjemplos:\n# Encabezado\n**Texto en negrita**\n*Texto en cursiva*\n- Elemento de lista\n```código```"
   },
   "tags": {
     "loading": "Cargando etiquetas...",
@@ -1067,7 +1107,11 @@
     "systemTag": "Etiquetas del sistema",
     "systemTagDescription": "Creado automáticamente por la aplicación. Potencian las funciones integradas y no se pueden renombrar ni eliminar.",
     "userTag": "Etiquetas de usuario",
-    "userTagDescription": "Tus propias etiquetas para organizar tareas, notas y proyectos."
+    "userTagDescription": "Tus propias etiquetas para organizar tareas, notas y proyectos.",
+    "systemTags": "Etiquetas del sistema",
+    "systemTagsDescription": "Gestionadas automáticamente · No se pueden eliminar ni renombrar",
+    "system": "Sistema",
+    "customize": "Personalizar"
   },
   "note": {
     "title": "Título",
@@ -1386,7 +1430,14 @@
     "priorityLabel": "Prioridad:",
     "dueLabel": "Vence:",
     "tags": "Etiquetas",
-    "recurring": "Recurrente"
+    "recurring": "Recurrente",
+    "saveAsSmartView": "Guardar como Vista Inteligente",
+    "viewNamePlaceholder": "Ingrese el nombre de la vista",
+    "viewNameLabel": "Nombre de la Vista",
+    "viewWillSave": "Esta vista se guardará:",
+    "saveView": "Guardar Vista",
+    "filtersLabel": "Filtros:",
+    "searchLabel": "Buscar:"
   },
   "search": {
     "placeholder": "Buscar tareas, proyectos, notas...",
@@ -1543,5 +1594,36 @@
     "done_desc": "Terminado y hecho",
     "cancelled": "Cancelado",
     "cancelled_desc": "No se completará"
+  },
+  "habits": {
+    "completeHabit": "Completar hábito"
+  },
+  "aiAssistant": {
+    "title": "Asistente de IA",
+    "generatedAt": "Generado a las {{time}}",
+    "emptyState": "Haga clic en 'Generar Resumen' para obtener su resumen diario impulsado por IA.",
+    "focusForToday": "Enfoque para hoy",
+    "priorityActions": "Acciones prioritarias",
+    "taskInsightsTitle": "Perspectivas de IA",
+    "projectInsightsTitle": "Perspectivas de IA",
+    "taskInsight": "Acerca de esta tarea",
+    "taskNextStep": "Próximo paso",
+    "taskBreakdown": "Cómo abordarlo",
+    "projectInsight": "Acerca de este proyecto",
+    "projectNextAction": "Próxima acción",
+    "projectHealth": "Salud del proyecto",
+    "watchOut": "Cuidado",
+    "suggestedLinks": "Enlaces sugeridos",
+    "generate": "Generar resumen",
+    "regenerate": "Regenerar",
+    "generating": "Generando...",
+    "errorDefault": "No se pudieron generar ideas. Por favor, inténtalo de nuevo.",
+    "lowContextTitle": "No hay suficiente contexto para una gran sugerencia",
+    "lowContextHint": "Agrega una descripción, notas, etiquetas o asigna un proyecto para obtener mejores ideas. Aún puedes generar a continuación.",
+    "generateAnyway": "Generar de todos modos",
+    "statTotal": "Total",
+    "statDone": "Hecho",
+    "statActive": "Activo",
+    "statOverdue": "Atrasado"
   }
 }

--- a/public/locales/fi/translation.json
+++ b/public/locales/fi/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Kyllä, hylkää",
     "uploading": "Lähetetään...",
     "refresh": "Päivitä",
-    "unlinking": "Irrottaminen..."
+    "unlinking": "Irrottaminen...",
+    "preview": "Esikatselu",
+    "download": "Lataa",
+    "exitFocusMode": "Poistu keskittymistilasta",
+    "searchTimezones": "Etsi aikavyöhykkeitä...",
+    "dismiss": "Hylkää"
   },
   "sidebar": {
     "dashboard": "Ohjauspaneeli",
@@ -58,7 +63,10 @@
     "unpinView": "Irrota näkymä",
     "pinView": "Kiinnitä näkymä",
     "eisenhower": "Eisenhower-matriisi",
-    "kanban": "Kanban-taulu"
+    "kanban": "Kanban-taulu",
+    "addHabitAriaLabel": "Lisää tapa",
+    "addHabitTitle": "Lisää tapa",
+    "toggleDarkMode": "Vaihda tummalle tilalle"
   },
   "navigation": {
     "home": "Koti",
@@ -68,7 +76,11 @@
     "settings": "Asetukset",
     "about": "Tietoja",
     "logout": "Kirjaudu ulos",
-    "backupRestore": "Varmuuskopioi & Palauta"
+    "backupRestore": "Varmuuskopioi & Palauta",
+    "toggleSearch": "Vaihda haku",
+    "quickInboxCapture": "Nopea saapuneet-tallennus",
+    "userMenu": "Käyttäjävalikko",
+    "search": "Haku"
   },
   "settings": {
     "todayPageSettings": "Tänään-sivun asetukset",
@@ -181,7 +193,9 @@
       "waiting": "Odottaa",
       "done": "Valmis",
       "dropHere": "Tiputa tähän"
-    }
+    },
+    "chaseUp": "Seuraa perään",
+    "habit": "Tapa"
   },
   "timeline": {
     "activityTimeline": "Toiminta-aikajana",
@@ -503,7 +517,9 @@
       "serverSettings": "Palvelimen asetukset",
       "syncSettings": "Synkronoinnin asetukset",
       "setupSuccess": "Kalenteri on konfiguroitu onnistuneesti!",
-      "setupFailed": "Kalenterin luominen epäonnistui"
+      "setupFailed": "Kalenterin luominen epäonnistui",
+      "serverUrlPlaceholder": "https://caldav.esimerkki.com",
+      "calendarPathPlaceholder": "/kalenterit/käyttäjä/tehtävät"
     },
     "conflictResolver": {
       "title": "Ratkaise synkronointikonfliktit",
@@ -538,7 +554,9 @@
       "intervalError": "Synkronointivälin on oltava 1–1440 minuutin välillä",
       "updateSuccess": "Kalenteri päivitetty onnistuneesti",
       "updateError": "Kalenterin päivittäminen epäonnistui"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@käyttäjänimi1, 123456789, @käyttäjänimi2"
   },
   "productivity": {
     "stalledProjects": "Jumiutuneet projektit",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Projektin tallentaminen epäonnistui.",
     "projectImageTooLarge": "Kuva on liian suuri. Valitse tiedosto, joka on alle 10MB.",
     "projectImageUpload": "Kuvan lataaminen epäonnistui. Kokeile pienempää tiedostoa tai toista formaattia.",
-    "bannerSaveFailed": "Bannerin tallentaminen epäonnistui"
+    "bannerSaveFailed": "Bannerin tallentaminen epäonnistui",
+    "loginFailed": "Kirjautuminen epäonnistui. Yritä uudelleen.",
+    "generalError": "Tapahtui virhe. Yritä uudelleen.",
+    "viewNameRequired": "Näkymän nimi on pakollinen",
+    "viewSaveFailed": "Näkymän tallentaminen epäonnistui. Yritä uudelleen."
   },
   "inbox": {
     "title": "Saapuneet",
@@ -810,7 +832,9 @@
     "loadMoreError": "Lisätietojen lataaminen epäonnistui",
     "loading": "Ladataan...",
     "loadMore": "Lataa lisää saapuneita kohteita",
-    "showingItems": "Näytetään {{current}} / {{total}} kohteista"
+    "showingItems": "Näytetään {{current}} / {{total}} kohteista",
+    "removeTag": "Poista tunniste",
+    "removeProject": "Poista projekti"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Seuraava paras toiminto",
     "focusTask": "Vaikuttavin tehtävä",
     "focusHint": "Siirtää tehtävän tilaan käynnissä ja tänään",
-    "noNextAction": "Kaikki kunnossa - ei avoimia tehtäviä."
+    "noNextAction": "Kaikki kunnossa - ei avoimia tehtäviä.",
+    "selectDueDatePlaceholder": "Valitse eräpäivä",
+    "goalTitle": "Tavoite"
   },
   "projectItem": {
     "edit": "Muokkaa",
@@ -1088,7 +1114,14 @@
     "error": "Virhe alueen tietojen lataamisessa.",
     "notFound": "Aluetta ei löytynyt.",
     "details": "Alueen tiedot",
-    "viewProjects": "Näytä projektit {{name}}"
+    "viewProjects": "Näytä projektit {{name}}",
+    "goalTitlePlaceholder": "Tavoitteen otsikko",
+    "goalWhyPlaceholder": "Miksi tämä on tärkeää (valinnainen)",
+    "editGoal": "Muokkaa tavoitetta",
+    "deleteGoal": "Poista tavoite",
+    "moveBackToUnlinked": "Siirrä takaisin linkittämättömiin",
+    "horizonSeason": "Kauden",
+    "horizonYear": "Vuosi"
   },
   "notes": {
     "loading": "Ladataan muistiinpanoja...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Poista muistiinpano {{noteTitle}}",
     "deleteNoteTitle": "Poista muistiinpano {{noteTitle}}",
     "editNoteAriaLabel": "Muokkaa muistiinpanoa {{noteTitle}}",
-    "editNoteTitle": "Muokkaa muistiinpanoa {{noteTitle}}"
+    "editNoteTitle": "Muokkaa muistiinpanoa {{noteTitle}}",
+    "titlePlaceholder": "Muistion otsikko...",
+    "contentPlaceholder": "Kirjoita muistiosi sisältö tähän... (Markdown tuettu)",
+    "focusMode": "Keskittymistila",
+    "noteOptions": "Muistion asetukset",
+    "clickToEdit": "Napsauta muokataksesi",
+    "contentPlaceholderFocus": "Kirjoita muistiosi... (Markdown tuettu)",
+    "contentPlaceholderMarkdown": "Kirjoita sisältösi käyttäen Markdown-muotoilua...\n\nEsimerkit:\n# Otsikko\n**Lihavoitu teksti**\n*Kursivoitu teksti*\n- Luettelokohta\n```koodi```"
   },
   "tags": {
     "loading": "Ladataan tageja...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Järjestelmän tunnisteet",
     "systemTagDescription": "Sovelluksen automaattisesti luomat. Ne tukevat sisäänrakennettuja ominaisuuksia, eikä niitä voi nimetä uudelleen tai poistaa.",
     "userTag": "Käyttäjän tunnisteet",
-    "userTagDescription": "Omat tunnisteesi tehtävien, muistiinpanojen ja projektien järjestämiseen."
+    "userTagDescription": "Omat tunnisteesi tehtävien, muistiinpanojen ja projektien järjestämiseen.",
+    "systemTags": "Järjestelmän tunnisteet",
+    "systemTagsDescription": "Automaattisesti hallittu · Ei voi poistaa tai nimetä uudelleen",
+    "system": "Järjestelmä",
+    "customize": "Mukauta"
   },
   "recurrence": {
     "none": "Ei mitään",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Prioriteetti:",
     "dueLabel": "Eräpäivä:",
     "tags": "Tunnisteet",
-    "recurring": "Toistuva"
+    "recurring": "Toistuva",
+    "saveAsSmartView": "Tallenna älynäkymänä",
+    "viewNamePlaceholder": "Syötä näkymän nimi",
+    "viewNameLabel": "Näkymän nimi",
+    "viewWillSave": "Tämä näkymä tallennetaan:",
+    "saveView": "Tallenna näkymä",
+    "filtersLabel": "Suodattimet:",
+    "searchLabel": "Haku:"
   },
   "search": {
     "placeholder": "Hae tehtäviä, projekteja, muistiinpanoja...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Valmis ja tehty",
     "cancelled": "Peruutettu",
     "cancelled_desc": "Ei tule valmistumaan"
+  },
+  "habits": {
+    "completeHabit": "Valmis tapa"
+  },
+  "aiAssistant": {
+    "title": "AI-avustaja",
+    "generatedAt": "Luotu {{time}}",
+    "emptyState": "Napsauta 'Luo yhteenveto' saadaksesi päivittäisen yhteenvedon, joka on tehty AI:n avulla.",
+    "focusForToday": "Tänään keskitytään",
+    "priorityActions": "Tärkeitä toimia",
+    "taskInsightsTitle": "AI-näkemykset",
+    "projectInsightsTitle": "AI-näkemykset",
+    "taskInsight": "Tietoja tästä tehtävästä",
+    "taskNextStep": "Seuraava vaihe",
+    "taskBreakdown": "Miten lähestyä sitä",
+    "projectInsight": "Tietoa tästä projektista",
+    "projectNextAction": "Seuraava toimenpide",
+    "projectHealth": "Projektin tila",
+    "watchOut": "Varo",
+    "suggestedLinks": "Ehdotetut linkit",
+    "generate": "Luo tiivistelmä",
+    "regenerate": "Luo uudelleen",
+    "generating": "Luodaan...",
+    "errorDefault": "Oivallusten luominen epäonnistui. Yritä uudelleen.",
+    "lowContextTitle": "Ei tarpeeksi kontekstia hyvälle ehdotukselle",
+    "lowContextHint": "Lisää kuvaus, muistiinpanoja, tageja tai määritä projekti saadaksesi parempia oivalluksia. Voit silti luoda alla.",
+    "generateAnyway": "Luo silti",
+    "statTotal": "Yhteensä",
+    "statDone": "Valmis",
+    "statActive": "Aktiivinen",
+    "statOverdue": "Erääntynyt"
   }
 }

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Oui, abandonner",
     "uploading": "Téléchargement...",
     "refresh": "Rafraîchir",
-    "unlinking": "Dissociation..."
+    "unlinking": "Dissociation...",
+    "preview": "Aperçu",
+    "download": "Télécharger",
+    "exitFocusMode": "Quitter le mode focus",
+    "searchTimezones": "Rechercher des fuseaux horaires...",
+    "dismiss": "Ignorer"
   },
   "sidebar": {
     "dashboard": "Tableau de bord",
@@ -58,7 +63,10 @@
     "unpinView": "Détacher la vue",
     "pinView": "Épingler la vue",
     "eisenhower": "Matrice d'Eisenhower",
-    "kanban": "Tableau Kanban"
+    "kanban": "Tableau Kanban",
+    "addHabitAriaLabel": "Ajouter une habitude",
+    "addHabitTitle": "Ajouter une habitude",
+    "toggleDarkMode": "Basculer en mode sombre"
   },
   "navigation": {
     "home": "Accueil",
@@ -68,7 +76,11 @@
     "settings": "Paramètres",
     "about": "À propos",
     "logout": "Déconnexion",
-    "backupRestore": "Sauvegarde & Restauration"
+    "backupRestore": "Sauvegarde & Restauration",
+    "toggleSearch": "Basculer la recherche",
+    "quickInboxCapture": "Capture rapide de la boîte de réception",
+    "userMenu": "Menu utilisateur",
+    "search": "Rechercher"
   },
   "settings": {
     "todayPageSettings": "Paramètres de la page Aujourd'hui",
@@ -181,7 +193,9 @@
       "waiting": "En attente",
       "done": "Terminé",
       "dropHere": "Déposez ici"
-    }
+    },
+    "chaseUp": "Relancer",
+    "habit": "Habitude"
   },
   "timeline": {
     "activityTimeline": "Chronologie d'Activité",
@@ -503,7 +517,9 @@
       "serverSettings": "Paramètres du serveur",
       "syncSettings": "Paramètres de synchronisation",
       "setupSuccess": "Calendrier configuré avec succès !",
-      "setupFailed": "Échec de la création du calendrier"
+      "setupFailed": "Échec de la création du calendrier",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/utilisateur/tâches"
     },
     "conflictResolver": {
       "title": "Résoudre les conflits de synchronisation",
@@ -538,7 +554,9 @@
       "intervalError": "L'intervalle de synchronisation doit être compris entre 1 et 1440 minutes",
       "updateSuccess": "Calendrier mis à jour avec succès",
       "updateError": "Échec de la mise à jour du calendrier"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@nom_utilisateur1, 123456789, @nom_utilisateur2"
   },
   "productivity": {
     "stalledProjects": "Projets Bloqués",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Échec de l'enregistrement du projet.",
     "projectImageTooLarge": "L'image est trop grande. Veuillez choisir un fichier de moins de 10 Mo.",
     "projectImageUpload": "Échec du téléchargement de l'image. Veuillez essayer un fichier plus petit ou un format différent.",
-    "bannerSaveFailed": "Échec de l'enregistrement de la bannière"
+    "bannerSaveFailed": "Échec de l'enregistrement de la bannière",
+    "loginFailed": "Échec de la connexion. Veuillez réessayer.",
+    "generalError": "Une erreur est survenue. Veuillez réessayer.",
+    "viewNameRequired": "Le nom de la vue est requis",
+    "viewSaveFailed": "Échec de l'enregistrement de la vue. Veuillez réessayer."
   },
   "inbox": {
     "title": "Boîte de réception",
@@ -810,7 +832,9 @@
     "loadMoreError": "Échec du chargement de plus d'éléments",
     "loading": "Chargement...",
     "loadMore": "Charger plus d'éléments dans la boîte de réception",
-    "showingItems": "Affichage de {{current}} sur {{total}} éléments"
+    "showingItems": "Affichage de {{current}} sur {{total}} éléments",
+    "removeTag": "Supprimer l'étiquette",
+    "removeProject": "Supprimer le projet"
   },
   "dateFormats": {
     "long": "EEEE, d MMMM yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Meilleure action suivante",
     "focusTask": "Tâche la plus impactante",
     "focusHint": "Déplace cette tâche vers en cours et aujourd'hui",
-    "noNextAction": "Tout est clair - aucune tâche en attente."
+    "noNextAction": "Tout est clair - aucune tâche en attente.",
+    "selectDueDatePlaceholder": "Sélectionner la date d'échéance",
+    "goalTitle": "Objectif"
   },
   "projectItem": {
     "edit": "Modifier",
@@ -1088,7 +1114,14 @@
     "error": "Erreur lors du chargement des détails de la zone.",
     "notFound": "Zone non trouvée.",
     "details": "Détails de la zone",
-    "viewProjects": "Voir les projets dans {{name}}"
+    "viewProjects": "Voir les projets dans {{name}}",
+    "goalTitlePlaceholder": "Titre de l'objectif",
+    "goalWhyPlaceholder": "Pourquoi cela est important (facultatif)",
+    "editGoal": "Modifier l'objectif",
+    "deleteGoal": "Supprimer l'objectif",
+    "moveBackToUnlinked": "Revenir à non lié",
+    "horizonSeason": "Saison",
+    "horizonYear": "Année"
   },
   "notes": {
     "loading": "Chargement des notes...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Supprimer la note {{noteTitle}}",
     "deleteNoteTitle": "Supprimer la note {{noteTitle}}",
     "editNoteAriaLabel": "Modifier la note {{noteTitle}}",
-    "editNoteTitle": "Modifier la note {{noteTitle}}"
+    "editNoteTitle": "Modifier la note {{noteTitle}}",
+    "titlePlaceholder": "Titre de la note...",
+    "contentPlaceholder": "Écrivez le contenu de votre note ici... (Markdown supporté)",
+    "focusMode": "Mode concentration",
+    "noteOptions": "Options de la note",
+    "clickToEdit": "Cliquez pour modifier",
+    "contentPlaceholderFocus": "Écrivez votre note... (Markdown supporté)",
+    "contentPlaceholderMarkdown": "Écrivez votre contenu en utilisant le formatage Markdown...\n\nExemples:\n# Titre\n**Texte en gras**\n*Texte en italique*\n- Élément de liste\n```code```"
   },
   "tags": {
     "loading": "Chargement des étiquettes...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Étiquettes système",
     "systemTagDescription": "Créées automatiquement par l'application. Elles alimentent les fonctionnalités intégrées et ne peuvent pas être renommées ou supprimées.",
     "userTag": "Étiquettes utilisateur",
-    "userTagDescription": "Vos propres étiquettes pour organiser les tâches, les notes et les projets."
+    "userTagDescription": "Vos propres étiquettes pour organiser les tâches, les notes et les projets.",
+    "systemTags": "Étiquettes système",
+    "systemTagsDescription": "Géré automatiquement · Ne peut pas être supprimé ou renommé",
+    "system": "Système",
+    "customize": "Personnaliser"
   },
   "recurrence": {
     "none": "Aucun",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Priorité :",
     "dueLabel": "Échéance :",
     "tags": "Étiquettes",
-    "recurring": "Récurrent"
+    "recurring": "Récurrent",
+    "saveAsSmartView": "Enregistrer en tant que Vue Intelligente",
+    "viewNamePlaceholder": "Entrez le nom de la vue",
+    "viewNameLabel": "Nom de la Vue",
+    "viewWillSave": "Cette vue sera enregistrée :",
+    "saveView": "Enregistrer la Vue",
+    "filtersLabel": "Filtres :",
+    "searchLabel": "Recherche :"
   },
   "search": {
     "placeholder": "Rechercher des tâches, des projets, des notes...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Fini et terminé",
     "cancelled": "Annulé",
     "cancelled_desc": "Ne sera pas terminé"
+  },
+  "habits": {
+    "completeHabit": "Compléter l'habitude"
+  },
+  "aiAssistant": {
+    "title": "Assistant IA",
+    "generatedAt": "Généré à {{time}}",
+    "emptyState": "Cliquez sur 'Générer un Résumé' pour obtenir votre résumé quotidien alimenté par l'IA.",
+    "focusForToday": "Concentration pour aujourd'hui",
+    "priorityActions": "Actions prioritaires",
+    "taskInsightsTitle": "Aperçus IA",
+    "projectInsightsTitle": "Aperçus IA",
+    "taskInsight": "À propos de cette tâche",
+    "taskNextStep": "Prochaine étape",
+    "taskBreakdown": "Comment l'aborder",
+    "projectInsight": "À propos de ce projet",
+    "projectNextAction": "Prochaine action",
+    "projectHealth": "Santé du projet",
+    "watchOut": "Attention",
+    "suggestedLinks": "Liens suggérés",
+    "generate": "Générer le brief",
+    "regenerate": "Régénérer",
+    "generating": "Génération en cours...",
+    "errorDefault": "Échec de la génération des insights. Veuillez réessayer.",
+    "lowContextTitle": "Pas assez de contexte pour une bonne suggestion",
+    "lowContextHint": "Ajoutez une description, des notes, des étiquettes ou assignez un projet pour obtenir de meilleurs insights. Vous pouvez toujours générer ci-dessous.",
+    "generateAnyway": "Générer quand même",
+    "statTotal": "Total",
+    "statDone": "Fait",
+    "statActive": "Actif",
+    "statOverdue": "En retard"
   }
 }

--- a/public/locales/id/translation.json
+++ b/public/locales/id/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Ya, buang",
     "uploading": "Mengunggah...",
     "refresh": "Segarkan",
-    "unlinking": "Menghapus tautan..."
+    "unlinking": "Menghapus tautan...",
+    "preview": "Pratonton",
+    "download": "Unduh",
+    "exitFocusMode": "Keluar dari mode fokus",
+    "searchTimezones": "Cari zona waktu...",
+    "dismiss": "Tutup"
   },
   "sidebar": {
     "dashboard": "Dasbor",
@@ -58,7 +63,10 @@
     "unpinView": "Lepaskan tampilan",
     "pinView": "Sematkan tampilan",
     "eisenhower": "Matriks Eisenhower",
-    "kanban": "Papan Kanban"
+    "kanban": "Papan Kanban",
+    "addHabitAriaLabel": "Tambahkan Kebiasaan",
+    "addHabitTitle": "Tambahkan Kebiasaan",
+    "toggleDarkMode": "Beralih ke Mode Gelap"
   },
   "navigation": {
     "home": "Beranda",
@@ -68,7 +76,11 @@
     "settings": "Pengaturan",
     "about": "Tentang",
     "logout": "Keluar",
-    "backupRestore": "Cadangkan & Pulihkan"
+    "backupRestore": "Cadangkan & Pulihkan",
+    "toggleSearch": "Beralih ke Pencarian",
+    "quickInboxCapture": "Tangkap Kotak Masuk Cepat",
+    "userMenu": "Menu Pengguna",
+    "search": "Cari"
   },
   "settings": {
     "todayPageSettings": "Pengaturan Halaman Hari Ini",
@@ -181,7 +193,9 @@
       "waiting": "Menunggu",
       "done": "Selesai",
       "dropHere": "Jatuhkan di sini"
-    }
+    },
+    "chaseUp": "Tindak Lanjut",
+    "habit": "Kebiasaan"
   },
   "timeline": {
     "activityTimeline": "Garis Waktu Aktivitas",
@@ -503,7 +517,9 @@
       "serverSettings": "Pengaturan Server",
       "syncSettings": "Pengaturan Sinkronisasi",
       "setupSuccess": "Kalender berhasil dikonfigurasi!",
-      "setupFailed": "Gagal membuat kalender"
+      "setupFailed": "Gagal membuat kalender",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "Selesaikan Konflik Sinkronisasi",
@@ -538,7 +554,9 @@
       "intervalError": "Interval sinkronisasi harus antara 1 dan 1440 menit",
       "updateSuccess": "Kalender berhasil diperbarui",
       "updateError": "Gagal memperbarui kalender"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "productivity": {
     "stalledProjects": "Proyek Terhenti",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Gagal untuk menyimpan proyek.",
     "projectImageTooLarge": "Gambar terlalu besar. Silakan pilih file di bawah 10MB.",
     "projectImageUpload": "Gagal mengunggah gambar. Silakan coba file yang lebih kecil atau format yang berbeda.",
-    "bannerSaveFailed": "Gagal menyimpan spanduk"
+    "bannerSaveFailed": "Gagal menyimpan spanduk",
+    "loginFailed": "Gagal masuk. Silakan coba lagi.",
+    "generalError": "Terjadi kesalahan. Silakan coba lagi.",
+    "viewNameRequired": "Nama tampilan diperlukan",
+    "viewSaveFailed": "Gagal menyimpan tampilan. Silakan coba lagi."
   },
   "inbox": {
     "title": "Kotak Masuk",
@@ -810,7 +832,9 @@
     "loadMoreError": "Gagal memuat lebih banyak item",
     "loading": "Memuat...",
     "loadMore": "Muat lebih banyak item kotak masuk",
-    "showingItems": "Menampilkan {{current}} dari {{total}} item"
+    "showingItems": "Menampilkan {{current}} dari {{total}} item",
+    "removeTag": "Hapus tag",
+    "removeProject": "Hapus proyek"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Tindakan terbaik selanjutnya",
     "focusTask": "Tugas paling berdampak",
     "focusHint": "Memindahkan tugas ini ke sedang berlangsung dan hari ini",
-    "noNextAction": "Semua bersih-tidak ada tugas tertunda."
+    "noNextAction": "Semua bersih-tidak ada tugas tertunda.",
+    "selectDueDatePlaceholder": "Pilih tanggal jatuh tempo",
+    "goalTitle": "Tujuan"
   },
   "projectItem": {
     "edit": "Sunting",
@@ -1088,7 +1114,14 @@
     "error": "Kesalahan memuat detail area.",
     "notFound": "Area tidak ditemukan.",
     "details": "Detail Area",
-    "viewProjects": "Lihat Proyek di {{name}}"
+    "viewProjects": "Lihat Proyek di {{name}}",
+    "goalTitlePlaceholder": "Judul tujuan",
+    "goalWhyPlaceholder": "Mengapa ini penting (opsional)",
+    "editGoal": "Edit tujuan",
+    "deleteGoal": "Hapus tujuan",
+    "moveBackToUnlinked": "Kembali ke tidak terhubung",
+    "horizonSeason": "Musim",
+    "horizonYear": "Tahun"
   },
   "notes": {
     "loading": "Memuat catatan...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Hapus catatan {{noteTitle}}",
     "deleteNoteTitle": "Hapus catatan {{noteTitle}}",
     "editNoteAriaLabel": "Edit catatan {{noteTitle}}",
-    "editNoteTitle": "Edit catatan {{noteTitle}}"
+    "editNoteTitle": "Edit catatan {{noteTitle}}",
+    "titlePlaceholder": "Judul catatan...",
+    "contentPlaceholder": "Tulis konten catatan Anda di sini... (Markdown didukung)",
+    "focusMode": "Mode fokus",
+    "noteOptions": "Opsi catatan",
+    "clickToEdit": "Klik untuk mengedit",
+    "contentPlaceholderFocus": "Tulis catatan Anda... (Markdown didukung)",
+    "contentPlaceholderMarkdown": "Tulis konten Anda menggunakan format Markdown...\n\nContoh:\n# Judul\n**Teks tebal**\n*Teks miring*\n- Item daftar\n```kode```"
   },
   "tags": {
     "loading": "Memuat tag...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Tag sistem",
     "systemTagDescription": "Dibuat secara otomatis oleh aplikasi. Mereka mendukung fitur bawaan dan tidak dapat diubah namanya atau dihapus.",
     "userTag": "Tag pengguna",
-    "userTagDescription": "Tag Anda sendiri untuk mengorganisir tugas, catatan, dan proyek."
+    "userTagDescription": "Tag Anda sendiri untuk mengorganisir tugas, catatan, dan proyek.",
+    "systemTags": "Tag Sistem",
+    "systemTagsDescription": "Dikelola secara otomatis · Tidak dapat dihapus atau dinamai ulang",
+    "system": "Sistem",
+    "customize": "Kustomisasi"
   },
   "recurrence": {
     "none": "Tidak ada",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Prioritas:",
     "dueLabel": "Jatuh Tempo:",
     "tags": "Tag",
-    "recurring": "Berulang"
+    "recurring": "Berulang",
+    "saveAsSmartView": "Simpan sebagai Tampilan Cerdas",
+    "viewNamePlaceholder": "Masukkan nama tampilan",
+    "viewNameLabel": "Nama Tampilan",
+    "viewWillSave": "Tampilan ini akan disimpan:",
+    "saveView": "Simpan Tampilan",
+    "filtersLabel": "Filter:",
+    "searchLabel": "Cari:"
   },
   "search": {
     "placeholder": "Cari tugas, proyek, catatan...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Telah selesai dan selesai",
     "cancelled": "Dibatalkan",
     "cancelled_desc": "Tidak akan diselesaikan"
+  },
+  "habits": {
+    "completeHabit": "Selesaikan kebiasaan"
+  },
+  "aiAssistant": {
+    "title": "Asisten AI",
+    "generatedAt": "Dihasilkan pada {{time}}",
+    "emptyState": "Klik 'Hasilkan Ringkasan' untuk mendapatkan ringkasan harian yang didukung AI.",
+    "focusForToday": "Fokus untuk hari ini",
+    "priorityActions": "Tindakan prioritas",
+    "taskInsightsTitle": "Wawasan AI",
+    "projectInsightsTitle": "Wawasan AI",
+    "taskInsight": "Tentang tugas ini",
+    "taskNextStep": "Langkah selanjutnya",
+    "taskBreakdown": "Cara mendekatinya",
+    "projectInsight": "Tentang proyek ini",
+    "projectNextAction": "Tindakan selanjutnya",
+    "projectHealth": "Kesehatan proyek",
+    "watchOut": "Hati-hati",
+    "suggestedLinks": "Tautan yang disarankan",
+    "generate": "Hasilkan Ringkasan",
+    "regenerate": "Hasilkan ulang",
+    "generating": "Menghasilkan...",
+    "errorDefault": "Gagal menghasilkan wawasan. Silakan coba lagi.",
+    "lowContextTitle": "Tidak cukup konteks untuk saran yang baik",
+    "lowContextHint": "Tambahkan deskripsi, catatan, tag, atau tetapkan proyek untuk mendapatkan wawasan yang lebih baik. Anda masih bisa menghasilkan di bawah.",
+    "generateAnyway": "Hasilkan saja",
+    "statTotal": "Total",
+    "statDone": "Selesai",
+    "statActive": "Aktif",
+    "statOverdue": "Terlambat"
   }
 }

--- a/public/locales/it/translation.json
+++ b/public/locales/it/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Sì, scarta",
     "uploading": "Caricamento...",
     "refresh": "Aggiorna",
-    "unlinking": "Disconnettendo..."
+    "unlinking": "Disconnettendo...",
+    "preview": "Anteprima",
+    "download": "Scarica",
+    "exitFocusMode": "Esci dalla modalità di concentrazione",
+    "searchTimezones": "Cerca fusi orari...",
+    "dismiss": "Ignora"
   },
   "sidebar": {
     "dashboard": "Dashboard",
@@ -58,7 +63,10 @@
     "unpinView": "Sblocca visualizzazione",
     "pinView": "Fissa visualizzazione",
     "eisenhower": "Matrice di Eisenhower",
-    "kanban": "Bacheca Kanban"
+    "kanban": "Bacheca Kanban",
+    "addHabitAriaLabel": "Aggiungi Abitudine",
+    "addHabitTitle": "Aggiungi Abitudine",
+    "toggleDarkMode": "Attiva Modalità Scura"
   },
   "navigation": {
     "home": "Home",
@@ -68,7 +76,11 @@
     "settings": "Impostazioni",
     "about": "Informazioni",
     "logout": "Disconnetti",
-    "backupRestore": "Backup e Ripristino"
+    "backupRestore": "Backup e Ripristino",
+    "toggleSearch": "Attiva Ricerca",
+    "quickInboxCapture": "Cattura Veloce della Posta in Arrivo",
+    "userMenu": "Menu Utente",
+    "search": "Cerca"
   },
   "settings": {
     "todayPageSettings": "Impostazioni Pagina Oggi",
@@ -181,7 +193,9 @@
       "waiting": "In attesa",
       "done": "Fatto",
       "dropHere": "Trascina qui"
-    }
+    },
+    "chaseUp": "Insegui",
+    "habit": "Abitudine"
   },
   "timeline": {
     "activityTimeline": "Timeline delle Attività",
@@ -503,7 +517,9 @@
       "serverSettings": "Impostazioni del Server",
       "syncSettings": "Impostazioni di Sincronizzazione",
       "setupSuccess": "Calendario configurato con successo!",
-      "setupFailed": "Impossibile creare il calendario"
+      "setupFailed": "Impossibile creare il calendario",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "Risolvi i Conflitti di Sincronizzazione",
@@ -538,7 +554,9 @@
       "intervalError": "L'intervallo di sincronizzazione deve essere compreso tra 1 e 1440 minuti",
       "updateSuccess": "Calendario aggiornato con successo",
       "updateError": "Impossibile aggiornare il calendario"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "productivity": {
     "stalledProjects": "Progetti Bloccati",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Impossibile salvare il progetto.",
     "projectImageTooLarge": "L'immagine è troppo grande. Si prega di scegliere un file di dimensioni inferiori a 10MB.",
     "projectImageUpload": "Caricamento dell'immagine non riuscito. Si prega di provare un file più piccolo o un formato diverso.",
-    "bannerSaveFailed": "Salvataggio del banner non riuscito"
+    "bannerSaveFailed": "Salvataggio del banner non riuscito",
+    "viewNameRequired": "Il nome della vista è obbligatorio",
+    "viewSaveFailed": "Salvataggio della vista non riuscito. Riprova.",
+    "loginFailed": "Accesso non riuscito. Per favore riprova.",
+    "generalError": "Si è verificato un errore. Per favore riprova."
   },
   "inbox": {
     "title": "Inbox",
@@ -810,7 +832,9 @@
     "loadMoreError": "Impossibile caricare ulteriori elementi",
     "loading": "Caricamento...",
     "loadMore": "Carica ulteriori elementi della posta in arrivo",
-    "showingItems": "Mostrando {{current}} di {{total}} elementi"
+    "showingItems": "Mostrando {{current}} di {{total}} elementi",
+    "removeTag": "Rimuovi etichetta",
+    "removeProject": "Rimuovi progetto"
   },
   "dateFormats": {
     "long": "EEEE, d MMMM yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Prossima azione migliore",
     "focusTask": "Attività più impattante",
     "focusHint": "Sposta questa attività su in corso e oggi",
-    "noNextAction": "Tutto a posto-nessuna attività in sospeso."
+    "noNextAction": "Tutto a posto-nessuna attività in sospeso.",
+    "selectDueDatePlaceholder": "Seleziona la data di scadenza",
+    "goalTitle": "Obiettivo"
   },
   "projectItem": {
     "edit": "Modifica",
@@ -1088,7 +1114,14 @@
     "error": "Errore nel caricamento dei dettagli dell'area.",
     "notFound": "Area non trovata.",
     "details": "Dettagli Area",
-    "viewProjects": "Visualizza Progetti in {{name}}"
+    "viewProjects": "Visualizza Progetti in {{name}}",
+    "goalTitlePlaceholder": "Titolo dell'obiettivo",
+    "goalWhyPlaceholder": "Perché è importante (opzionale)",
+    "editGoal": "Modifica obiettivo",
+    "deleteGoal": "Elimina obiettivo",
+    "moveBackToUnlinked": "Sposta di nuovo a non collegato",
+    "horizonSeason": "Stagione",
+    "horizonYear": "Anno"
   },
   "notes": {
     "loading": "Caricamento note...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Elimina nota {{noteTitle}}",
     "deleteNoteTitle": "Elimina nota {{noteTitle}}",
     "editNoteAriaLabel": "Modifica nota {{noteTitle}}",
-    "editNoteTitle": "Modifica nota {{noteTitle}}"
+    "editNoteTitle": "Modifica nota {{noteTitle}}",
+    "titlePlaceholder": "Titolo della nota...",
+    "contentPlaceholder": "Scrivi qui il contenuto della tua nota... (Markdown supportato)",
+    "focusMode": "Modalità di concentrazione",
+    "noteOptions": "Opzioni nota",
+    "clickToEdit": "Clicca per modificare",
+    "contentPlaceholderFocus": "Scrivi la tua nota... (Markdown supportato)",
+    "contentPlaceholderMarkdown": "Scrivi il tuo contenuto utilizzando la formattazione Markdown...\n\nEsempi:\n# Intestazione\n**Testo in grassetto**\n*Testo in corsivo*\n- Elemento della lista\n```codice```"
   },
   "tags": {
     "loading": "Caricamento tag...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Tag di sistema",
     "systemTagDescription": "Creati automaticamente dall'app. Alimentano le funzionalità integrate e non possono essere rinominati o eliminati.",
     "userTag": "Tag utente",
-    "userTagDescription": "I tuoi tag per organizzare attività, note e progetti."
+    "userTagDescription": "I tuoi tag per organizzare attività, note e progetti.",
+    "systemTags": "Tag di sistema",
+    "systemTagsDescription": "Gestiti automaticamente · Non possono essere eliminati o rinominati",
+    "system": "Sistema",
+    "customize": "Personalizza"
   },
   "recurrence": {
     "none": "Nessuna",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Priorità:",
     "dueLabel": "Scadenza:",
     "tags": "Tag",
-    "recurring": "Ricorrente"
+    "recurring": "Ricorrente",
+    "saveAsSmartView": "Salva come Smart View",
+    "viewNamePlaceholder": "Inserisci il nome della vista",
+    "viewNameLabel": "Nome della Vista",
+    "viewWillSave": "Questa vista verrà salvata:",
+    "saveView": "Salva Vista",
+    "filtersLabel": "Filtri:",
+    "searchLabel": "Cerca:"
   },
   "search": {
     "placeholder": "Cerca attività, progetti, note...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Finito e completato",
     "cancelled": "Annullato",
     "cancelled_desc": "Non sarà completato"
+  },
+  "habits": {
+    "completeHabit": "Completa l'abitudine"
+  },
+  "aiAssistant": {
+    "title": "Assistente AI",
+    "generatedAt": "Generato alle {{time}}",
+    "emptyState": "Clicca su 'Genera Riepilogo' per ottenere il tuo riepilogo giornaliero potenziato dall'AI.",
+    "focusForToday": "Focus per oggi",
+    "priorityActions": "Azioni prioritarie",
+    "taskInsightsTitle": "Approfondimenti AI",
+    "projectInsightsTitle": "Approfondimenti AI",
+    "taskInsight": "Informazioni su questo compito",
+    "taskNextStep": "Passo successivo",
+    "taskBreakdown": "Come affrontarlo",
+    "projectInsight": "Informazioni su questo progetto",
+    "projectNextAction": "Prossima azione",
+    "projectHealth": "Salute del progetto",
+    "watchOut": "Attenzione",
+    "suggestedLinks": "Link suggeriti",
+    "generate": "Genera Brief",
+    "regenerate": "Rigenera",
+    "generating": "Generando...",
+    "errorDefault": "Impossibile generare informazioni. Riprova.",
+    "lowContextTitle": "Non abbastanza contesto per un'ottima suggerimento",
+    "lowContextHint": "Aggiungi una descrizione, note, tag o assegna un progetto per ottenere informazioni migliori. Puoi comunque generare qui sotto.",
+    "generateAnyway": "Genera comunque",
+    "statTotal": "Totale",
+    "statDone": "Fatto",
+    "statActive": "Attivo",
+    "statOverdue": "Scaduto"
   }
 }

--- a/public/locales/jp/translation.json
+++ b/public/locales/jp/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "はい、破棄する",
     "uploading": "アップロード中...",
     "refresh": "更新",
-    "unlinking": "リンク解除中..."
+    "unlinking": "リンク解除中...",
+    "preview": "プレビュー",
+    "download": "ダウンロード",
+    "exitFocusMode": "フォーカスモードを終了",
+    "searchTimezones": "タイムゾーンを検索...",
+    "dismiss": "閉じる"
   },
   "sidebar": {
     "dashboard": "ダッシュボード",
@@ -58,7 +63,10 @@
     "unpinView": "ピン留めを外す",
     "pinView": "ピン留めする",
     "eisenhower": "アイゼンハワーマトリックス",
-    "kanban": "カンバンボード"
+    "kanban": "カンバンボード",
+    "addHabitAriaLabel": "習慣を追加",
+    "addHabitTitle": "習慣を追加",
+    "toggleDarkMode": "ダークモードを切り替え"
   },
   "navigation": {
     "home": "ホーム",
@@ -68,7 +76,11 @@
     "settings": "設定",
     "about": "について",
     "logout": "ログアウト",
-    "backupRestore": "バックアップと復元"
+    "backupRestore": "バックアップと復元",
+    "toggleSearch": "検索を切り替え",
+    "quickInboxCapture": "クイックインボックスキャプチャ",
+    "userMenu": "ユーザーメニュー",
+    "search": "検索"
   },
   "settings": {
     "todayPageSettings": "今日のページ設定",
@@ -181,7 +193,9 @@
       "waiting": "待機中",
       "done": "完了",
       "dropHere": "ここにドロップ"
-    }
+    },
+    "chaseUp": "フォローアップ",
+    "habit": "習慣"
   },
   "timeline": {
     "activityTimeline": "アクティビティタイムライン",
@@ -503,7 +517,9 @@
       "serverSettings": "サーバー設定",
       "syncSettings": "同期設定",
       "setupSuccess": "カレンダーが正常に設定されました！",
-      "setupFailed": "カレンダーの作成に失敗しました"
+      "setupFailed": "カレンダーの作成に失敗しました",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "同期の競合を解決する",
@@ -538,7 +554,9 @@
       "intervalError": "同期間隔は1分から1440分の間でなければなりません",
       "updateSuccess": "カレンダーが正常に更新されました",
       "updateError": "カレンダーの更新に失敗しました"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "nextTask": {
     "suggestion": "進行中のものがないので、こちらから始めてみませんか",
@@ -725,7 +743,11 @@
     "failedToSaveTag": "タグの保存に失敗しました。",
     "projectImageTooLarge": "画像が大きすぎます。10MB未満のファイルを選択してください。",
     "projectImageUpload": "画像のアップロードに失敗しました。より小さいファイルまたは異なる形式を試してください。",
-    "bannerSaveFailed": "バナーの保存に失敗しました"
+    "bannerSaveFailed": "バナーの保存に失敗しました",
+    "loginFailed": "ログインに失敗しました。再試行してください。",
+    "generalError": "エラーが発生しました。再試行してください。",
+    "viewNameRequired": "ビュー名は必須です",
+    "viewSaveFailed": "ビューの保存に失敗しました。もう一度お試しください。"
   },
   "success": {
     "noteUpdated": "ノートが正常に更新されました！",
@@ -826,7 +848,9 @@
     "nextUp": "次の最善の行動",
     "focusTask": "最も影響力のあるタスク",
     "focusHint": "このタスクを進行中と今日に移動",
-    "noNextAction": "すべて完了-未処理のタスクはありません。"
+    "noNextAction": "すべて完了-未処理のタスクはありません。",
+    "selectDueDatePlaceholder": "期限日を選択",
+    "goalTitle": "目標"
   },
   "projectItem": {
     "edit": "編集",
@@ -858,7 +882,14 @@
     "error": "エリア詳細の読み込みエラー。",
     "notFound": "エリアが見つかりません。",
     "details": "エリア詳細",
-    "viewProjects": "{{name}}のプロジェクトを表示"
+    "viewProjects": "{{name}}のプロジェクトを表示",
+    "goalTitlePlaceholder": "目標タイトル",
+    "goalWhyPlaceholder": "なぜこれが重要なのか（任意）",
+    "editGoal": "目標を編集",
+    "deleteGoal": "目標を削除",
+    "moveBackToUnlinked": "リンクされていない状態に戻す",
+    "horizonSeason": "シーズン",
+    "horizonYear": "年"
   },
   "notes": {
     "loading": "ノートを読み込み中...",
@@ -869,7 +900,14 @@
     "editNoteAriaLabel": "ノート {{noteTitle}} を編集",
     "editNoteTitle": "ノート {{noteTitle}} の編集",
     "error": "ノートの読み込みエラー",
-    "searchPlaceholder": "ノートを検索..."
+    "searchPlaceholder": "ノートを検索...",
+    "titlePlaceholder": "ノートタイトル...",
+    "contentPlaceholder": "ノートの内容をここに書いてください...（Markdown対応）",
+    "focusMode": "フォーカスモード",
+    "noteOptions": "ノートオプション",
+    "clickToEdit": "クリックして編集",
+    "contentPlaceholderFocus": "ノートを書いてください...（Markdown対応）",
+    "contentPlaceholderMarkdown": "Markdown形式で内容を書いてください...\n\n例:\n# 見出し\n**太字テキスト**\n*斜体テキスト*\n- リスト項目\n```コード```"
   },
   "tags": {
     "loading": "タグを読み込み中...",
@@ -893,7 +931,11 @@
     "systemTag": "システムタグ",
     "systemTagDescription": "アプリによって自動的に作成されます。組み込み機能を支え、名前を変更したり削除したりすることはできません。",
     "userTag": "ユーザータグ",
-    "userTagDescription": "タスク、ノート、プロジェクトを整理するためのあなた自身のタグ。"
+    "userTagDescription": "タスク、ノート、プロジェクトを整理するためのあなた自身のタグ。",
+    "systemTags": "システムタグ",
+    "systemTagsDescription": "自動管理 · 削除または名前変更できません",
+    "system": "システム",
+    "customize": "カスタマイズ"
   },
   "recurrence": {
     "none": "なし",
@@ -955,7 +997,9 @@
     "loadMoreError": "アイテムの読み込みに失敗しました",
     "loading": "読み込み中...",
     "loadMore": "さらにインボックスアイテムを読み込む",
-    "showingItems": "{{total}}アイテム中{{current}}を表示しています"
+    "showingItems": "{{total}}アイテム中{{current}}を表示しています",
+    "removeTag": "タグを削除",
+    "removeProject": "プロジェクトを削除"
   },
   "project": {
     "projectImage": "プロジェクト画像",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "優先度:",
     "dueLabel": "期限:",
     "tags": "タグ",
-    "recurring": "定期的"
+    "recurring": "定期的",
+    "saveAsSmartView": "スマートビューとして保存",
+    "viewNamePlaceholder": "ビュー名を入力",
+    "viewNameLabel": "ビュー名",
+    "viewWillSave": "このビューは保存されます:",
+    "saveView": "ビューを保存",
+    "filtersLabel": "フィルター:",
+    "searchLabel": "検索:"
   },
   "search": {
     "placeholder": "タスク、プロジェクト、ノートを検索...",
@@ -1556,5 +1607,36 @@
     "done_desc": "終了しました",
     "cancelled": "キャンセル",
     "cancelled_desc": "完了しません"
+  },
+  "habits": {
+    "completeHabit": "習慣を完了する"
+  },
+  "aiAssistant": {
+    "title": "AIアシスタント",
+    "generatedAt": "生成日時: {{time}}",
+    "emptyState": "'要約を生成'をクリックして、AIによる日次要約を取得します。",
+    "focusForToday": "今日の焦点",
+    "priorityActions": "優先アクション",
+    "taskInsightsTitle": "AIインサイト",
+    "projectInsightsTitle": "AIインサイト",
+    "taskInsight": "このタスクについて",
+    "taskNextStep": "次のステップ",
+    "taskBreakdown": "どのようにアプローチするか",
+    "projectInsight": "このプロジェクトについて",
+    "projectNextAction": "次のアクション",
+    "projectHealth": "プロジェクトの健康状態",
+    "watchOut": "注意してください",
+    "suggestedLinks": "推奨リンク",
+    "generate": "ブリーフを生成",
+    "regenerate": "再生成",
+    "generating": "生成中...",
+    "errorDefault": "インサイトの生成に失敗しました。もう一度お試しください。",
+    "lowContextTitle": "優れた提案に対するコンテキストが不足しています",
+    "lowContextHint": "より良いインサイトを得るために、説明、ノート、タグを追加するか、プロジェクトを割り当ててください。それでも下に生成できます。",
+    "generateAnyway": "とにかく生成する",
+    "statTotal": "合計",
+    "statDone": "完了",
+    "statActive": "アクティブ",
+    "statOverdue": "期限切れ"
   }
 }

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "네, 버리기",
     "uploading": "업로드 중...",
     "refresh": "새로 고침",
-    "unlinking": "연결 해제 중..."
+    "unlinking": "연결 해제 중...",
+    "preview": "미리보기",
+    "download": "다운로드",
+    "exitFocusMode": "포커스 모드 종료",
+    "searchTimezones": "시간대 검색...",
+    "dismiss": "해제"
   },
   "sidebar": {
     "dashboard": "대시보드",
@@ -58,7 +63,10 @@
     "unpinView": "뷰 고정 해제",
     "pinView": "뷰 고정",
     "eisenhower": "아이젠하워 매트릭스",
-    "kanban": "칸반 보드"
+    "kanban": "칸반 보드",
+    "addHabitAriaLabel": "습관 추가",
+    "addHabitTitle": "습관 추가",
+    "toggleDarkMode": "다크 모드 전환"
   },
   "navigation": {
     "home": "홈",
@@ -68,7 +76,11 @@
     "settings": "설정",
     "about": "정보",
     "logout": "로그아웃",
-    "backupRestore": "백업 및 복원"
+    "backupRestore": "백업 및 복원",
+    "toggleSearch": "검색 전환",
+    "quickInboxCapture": "빠른 인박스 캡처",
+    "userMenu": "사용자 메뉴",
+    "search": "검색"
   },
   "settings": {
     "todayPageSettings": "오늘 페이지 설정",
@@ -181,7 +193,9 @@
       "waiting": "대기 중",
       "done": "완료",
       "dropHere": "여기에 드롭"
-    }
+    },
+    "chaseUp": "추적",
+    "habit": "습관"
   },
   "timeline": {
     "activityTimeline": "활동 타임라인",
@@ -503,7 +517,9 @@
       "serverSettings": "서버 설정",
       "syncSettings": "동기화 설정",
       "setupSuccess": "일정이 성공적으로 구성되었습니다!",
-      "setupFailed": "일정을 생성하지 못했습니다"
+      "setupFailed": "일정을 생성하지 못했습니다",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "동기화 충돌 해결",
@@ -538,7 +554,9 @@
       "intervalError": "동기화 간격은 1분에서 1440분 사이여야 합니다",
       "updateSuccess": "캘린더가 성공적으로 업데이트되었습니다",
       "updateError": "캘린더 업데이트에 실패했습니다"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "productivity": {
     "stalledProjects": "정체된 프로젝트",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "프로젝트를 저장하는 데 실패했습니다.",
     "projectImageTooLarge": "이미지가 너무 큽니다. 10MB 이하의 파일을 선택하세요.",
     "projectImageUpload": "이미지 업로드에 실패했습니다. 더 작은 파일이나 다른 형식을 시도하세요.",
-    "bannerSaveFailed": "배너 저장에 실패했습니다."
+    "bannerSaveFailed": "배너 저장에 실패했습니다.",
+    "loginFailed": "로그인에 실패했습니다. 다시 시도해 주세요.",
+    "generalError": "오류가 발생했습니다. 다시 시도해 주세요.",
+    "viewNameRequired": "뷰 이름은 필수입니다",
+    "viewSaveFailed": "뷰 저장에 실패했습니다. 다시 시도해 주세요."
   },
   "inbox": {
     "title": "받은 편지함",
@@ -810,7 +832,9 @@
     "loadMoreError": "더 많은 항목을 불러오지 못했습니다",
     "loading": "로딩 중...",
     "loadMore": "더 많은 받은 편지함 항목 불러오기",
-    "showingItems": "{{current}} / {{total}} 항목 표시 중"
+    "showingItems": "{{current}} / {{total}} 항목 표시 중",
+    "removeTag": "태그 제거",
+    "removeProject": "프로젝트 제거"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "다음 최선의 조치",
     "focusTask": "가장 영향력 있는 작업",
     "focusHint": "이 작업을 진행 중 및 오늘로 이동",
-    "noNextAction": "모두 완료 - 미완료 작업 없음."
+    "noNextAction": "모두 완료 - 미완료 작업 없음.",
+    "selectDueDatePlaceholder": "마감일 선택",
+    "goalTitle": "목표"
   },
   "projectItem": {
     "edit": "편집",
@@ -1088,7 +1114,14 @@
     "error": "영역 세부정보 로딩 오류.",
     "notFound": "영역을 찾을 수 없습니다.",
     "details": "영역 세부정보",
-    "viewProjects": "{{name}}의 프로젝트 보기"
+    "viewProjects": "{{name}}의 프로젝트 보기",
+    "goalTitlePlaceholder": "목표 제목",
+    "goalWhyPlaceholder": "이유 (선택 사항)",
+    "editGoal": "목표 수정",
+    "deleteGoal": "목표 삭제",
+    "moveBackToUnlinked": "연결되지 않은 상태로 되돌리기",
+    "horizonSeason": "계절",
+    "horizonYear": "연도"
   },
   "notes": {
     "loading": "노트 로딩 중...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "노트 {{noteTitle}} 삭제",
     "deleteNoteTitle": "노트 {{noteTitle}} 삭제",
     "editNoteAriaLabel": "노트 {{noteTitle}} 편집",
-    "editNoteTitle": "노트 {{noteTitle}} 편집"
+    "editNoteTitle": "노트 {{noteTitle}} 편집",
+    "titlePlaceholder": "노트 제목...",
+    "contentPlaceholder": "여기에 노트 내용을 작성하세요... (Markdown 지원)",
+    "focusMode": "집중 모드",
+    "noteOptions": "노트 옵션",
+    "clickToEdit": "수정하려면 클릭",
+    "contentPlaceholderFocus": "노트를 작성하세요... (Markdown 지원)",
+    "contentPlaceholderMarkdown": "Markdown 형식을 사용하여 내용을 작성하세요...\n\n예시:\n# 제목\n**굵은 텍스트**\n*기울임 텍스트*\n- 목록 항목\n```코드```"
   },
   "tags": {
     "loading": "태그 로딩 중...",
@@ -1123,7 +1163,11 @@
     "systemTag": "시스템 태그",
     "systemTagDescription": "앱에 의해 자동으로 생성됩니다. 내장 기능을 지원하며 이름을 변경하거나 삭제할 수 없습니다.",
     "userTag": "사용자 태그",
-    "userTagDescription": "작업, 메모 및 프로젝트를 정리하기 위한 개인 태그입니다."
+    "userTagDescription": "작업, 메모 및 프로젝트를 정리하기 위한 개인 태그입니다.",
+    "systemTags": "시스템 태그",
+    "systemTagsDescription": "자동으로 관리됨 · 삭제하거나 이름을 변경할 수 없음",
+    "system": "시스템",
+    "customize": "사용자 정의"
   },
   "recurrence": {
     "none": "없음",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "우선순위:",
     "dueLabel": "마감:",
     "tags": "태그",
-    "recurring": "반복"
+    "recurring": "반복",
+    "saveAsSmartView": "스마트 뷰로 저장",
+    "viewNamePlaceholder": "뷰 이름 입력",
+    "viewNameLabel": "뷰 이름",
+    "viewWillSave": "이 뷰가 저장됩니다:",
+    "saveView": "뷰 저장",
+    "filtersLabel": "필터:",
+    "searchLabel": "검색:"
   },
   "search": {
     "placeholder": "작업, 프로젝트, 노트 검색...",
@@ -1556,5 +1607,36 @@
     "done_desc": "끝났고 완료됨",
     "cancelled": "취소됨",
     "cancelled_desc": "완료되지 않을 것임"
+  },
+  "habits": {
+    "completeHabit": "습관 완료"
+  },
+  "aiAssistant": {
+    "title": "AI 어시스턴트",
+    "generatedAt": "생성된 시간: {{time}}",
+    "emptyState": "'요약 생성'을 클릭하여 AI 기반의 일일 요약을 받으세요.",
+    "focusForToday": "오늘의 집중 사항",
+    "priorityActions": "우선 작업",
+    "taskInsightsTitle": "AI 통찰",
+    "projectInsightsTitle": "AI 통찰",
+    "taskInsight": "이 작업에 대한 정보",
+    "taskNextStep": "다음 단계",
+    "taskBreakdown": "어떻게 접근할 것인가",
+    "projectInsight": "이 프로젝트에 대하여",
+    "projectNextAction": "다음 작업",
+    "projectHealth": "프로젝트 상태",
+    "watchOut": "주의하세요",
+    "suggestedLinks": "추천 링크",
+    "generate": "브리프 생성",
+    "regenerate": "다시 생성",
+    "generating": "생성 중...",
+    "errorDefault": "인사이트 생성을 실패했습니다. 다시 시도해 주세요.",
+    "lowContextTitle": "훌륭한 제안을 위한 컨텍스트가 부족합니다",
+    "lowContextHint": "더 나은 인사이트를 얻기 위해 설명, 노트, 태그를 추가하거나 프로젝트를 할당하세요. 아래에서 여전히 생성할 수 있습니다.",
+    "generateAnyway": "어쨌든 생성",
+    "statTotal": "총계",
+    "statDone": "완료",
+    "statActive": "활성",
+    "statOverdue": "기한 초과"
   }
 }

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Ja, negeren",
     "uploading": "Uploaden...",
     "refresh": "Vernieuwen",
-    "unlinking": "Ontkoppelen..."
+    "unlinking": "Ontkoppelen...",
+    "preview": "Voorbeeld",
+    "download": "Downloaden",
+    "exitFocusMode": "Verlaat de focusmodus",
+    "searchTimezones": "Zoek tijdzones...",
+    "dismiss": "Afwijzen"
   },
   "sidebar": {
     "dashboard": "Dashboard",
@@ -58,7 +63,10 @@
     "unpinView": "Weergave losmaken",
     "pinView": "Weergave vastzetten",
     "eisenhower": "Eisenhower Matrix",
-    "kanban": "Kanban Bord"
+    "kanban": "Kanban Bord",
+    "addHabitAriaLabel": "Voeg Gewoonte Toe",
+    "addHabitTitle": "Voeg Gewoonte Toe",
+    "toggleDarkMode": "Schakel Donkere Modus In"
   },
   "navigation": {
     "home": "Home",
@@ -68,7 +76,11 @@
     "settings": "Instellingen",
     "about": "Over",
     "logout": "Uitloggen",
-    "backupRestore": "Back-up & Herstellen"
+    "backupRestore": "Back-up & Herstellen",
+    "toggleSearch": "Schakel Zoeken In",
+    "quickInboxCapture": "Snelle Inbox Vastlegging",
+    "userMenu": "Gebruikersmenu",
+    "search": "Zoeken"
   },
   "settings": {
     "todayPageSettings": "Instellingen Vandaag Pagina",
@@ -181,7 +193,9 @@
       "waiting": "Wachten",
       "done": "Voltooid",
       "dropHere": "Hier neerzetten"
-    }
+    },
+    "chaseUp": "Opvolgen",
+    "habit": "Gewoonte"
   },
   "timeline": {
     "activityTimeline": "Activiteit Tijdlijn",
@@ -503,7 +517,9 @@
       "serverSettings": "Serverinstellingen",
       "syncSettings": "Synchronisatie-instellingen",
       "setupSuccess": "Kalender succesvol geconfigureerd!",
-      "setupFailed": "Mislukt om kalender aan te maken"
+      "setupFailed": "Mislukt om kalender aan te maken",
+      "serverUrlPlaceholder": "https://caldav.voorbeeld.com",
+      "calendarPathPlaceholder": "/calendars/gebruiker/taken"
     },
     "conflictResolver": {
       "title": "Synchronisatieconflicten oplossen",
@@ -538,7 +554,9 @@
       "intervalError": "Synchronisatie-interval moet tussen 1 en 1440 minuten liggen",
       "updateSuccess": "Kalender succesvol bijgewerkt",
       "updateError": "Kon kalender niet bijwerken"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@gebruikersnaam1, 123456789, @gebruikersnaam2"
   },
   "productivity": {
     "stalledProjects": "Stagnerende Projecten",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Het opslaan van het project is mislukt.",
     "projectImageTooLarge": "Afbeelding is te groot. Kies een bestand onder de 10MB.",
     "projectImageUpload": "Uploaden van afbeelding mislukt. Probeer een kleiner bestand of een ander formaat.",
-    "bannerSaveFailed": "Opslaan van banner mislukt"
+    "bannerSaveFailed": "Opslaan van banner mislukt",
+    "loginFailed": "Inloggen mislukt. Probeer het opnieuw.",
+    "generalError": "Er is een fout opgetreden. Probeer het opnieuw.",
+    "viewNameRequired": "Bekijknaam is vereist",
+    "viewSaveFailed": "Opslaan van de weergave is mislukt. Probeer het opnieuw."
   },
   "inbox": {
     "title": "Inbox",
@@ -810,7 +832,9 @@
     "loadMoreError": "Kon meer items niet laden",
     "loading": "Laden...",
     "loadMore": "Laad meer inboxitems",
-    "showingItems": "Toont {{current}} van {{total}} items"
+    "showingItems": "Toont {{current}} van {{total}} items",
+    "removeTag": "Verwijder tag",
+    "removeProject": "Verwijder project"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Volgende beste actie",
     "focusTask": "Meest impactvolle taak",
     "focusHint": "Verplaatst deze taak naar lopend en vandaag",
-    "noNextAction": "Alles klaar - geen openstaande taken."
+    "noNextAction": "Alles klaar - geen openstaande taken.",
+    "selectDueDatePlaceholder": "Selecteer vervaldatum",
+    "goalTitle": "Doel"
   },
   "projectItem": {
     "edit": "Bewerken",
@@ -1088,7 +1114,14 @@
     "error": "Fout bij het laden van gebiedsdetails.",
     "notFound": "Gebied niet gevonden.",
     "details": "Gebiedsdetails",
-    "viewProjects": "Bekijk projecten in {{name}}"
+    "viewProjects": "Bekijk projecten in {{name}}",
+    "goalTitlePlaceholder": "Doeltitel",
+    "goalWhyPlaceholder": "Waarom dit belangrijk is (optioneel)",
+    "editGoal": "Bewerk doel",
+    "deleteGoal": "Verwijder doel",
+    "moveBackToUnlinked": "Terugzetten naar niet-gekoppeld",
+    "horizonSeason": "Seizoen",
+    "horizonYear": "Jaar"
   },
   "notes": {
     "loading": "Bezig met het laden van notities...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Verwijder notitie {{noteTitle}}",
     "deleteNoteTitle": "Verwijder notitie {{noteTitle}}",
     "editNoteAriaLabel": "Bewerk notitie {{noteTitle}}",
-    "editNoteTitle": "Bewerk notitie {{noteTitle}}"
+    "editNoteTitle": "Bewerk notitie {{noteTitle}}",
+    "titlePlaceholder": "Notitietitel...",
+    "contentPlaceholder": "Schrijf hier de inhoud van je notitie... (Markdown ondersteund)",
+    "focusMode": "Focusmodus",
+    "noteOptions": "Notitie-opties",
+    "clickToEdit": "Klik om te bewerken",
+    "contentPlaceholderFocus": "Schrijf je notitie... (Markdown ondersteund)",
+    "contentPlaceholderMarkdown": "Schrijf je inhoud met Markdown-opmaak...\n\nVoorbeelden:\n# Kop\n**Vetgedrukte tekst**\n*Schuingedrukte tekst*\n- Lijstitem\n```code```"
   },
   "tags": {
     "loading": "Tags laden...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Systeemtags",
     "systemTagDescription": "Automatisch aangemaakt door de app. Ze ondersteunen ingebouwde functies en kunnen niet worden hernoemd of verwijderd.",
     "userTag": "Gebruikerstags",
-    "userTagDescription": "Je eigen tags voor het organiseren van taken, notities en projecten."
+    "userTagDescription": "Je eigen tags voor het organiseren van taken, notities en projecten.",
+    "systemTags": "Systeem Tags",
+    "systemTagsDescription": "Automatisch beheerd · Kan niet worden verwijderd of hernoemd",
+    "system": "Systeem",
+    "customize": "Aanpassen"
   },
   "recurrence": {
     "none": "Geen",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Prioriteit:",
     "dueLabel": "Vervaldatum:",
     "tags": "Tags",
-    "recurring": "Herhalend"
+    "recurring": "Herhalend",
+    "saveAsSmartView": "Opslaan als Slimme Weergave",
+    "viewNamePlaceholder": "Voer de weergavenaam in",
+    "viewNameLabel": "Weergavenaam",
+    "viewWillSave": "Deze weergave zal opslaan:",
+    "saveView": "Weergave Opslaan",
+    "filtersLabel": "Filters:",
+    "searchLabel": "Zoeken:"
   },
   "search": {
     "placeholder": "Zoek taken, projecten, notities...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Afgerond en voltooid",
     "cancelled": "Geannuleerd",
     "cancelled_desc": "Zal niet worden voltooid"
+  },
+  "habits": {
+    "completeHabit": "Gewoonte voltooien"
+  },
+  "aiAssistant": {
+    "title": "AI Assistent",
+    "generatedAt": "Gegenereerd op {{time}}",
+    "emptyState": "Klik op 'Genereer Samenvatting' om je AI-gestuurde dagelijkse samenvatting te krijgen.",
+    "focusForToday": "Focus voor vandaag",
+    "priorityActions": "Prioriteitsacties",
+    "taskInsightsTitle": "AI Inzichten",
+    "projectInsightsTitle": "AI Inzichten",
+    "taskInsight": "Over deze taak",
+    "taskNextStep": "Volgende stap",
+    "taskBreakdown": "Hoe het aan te pakken",
+    "projectInsight": "Over dit project",
+    "projectNextAction": "Volgende actie",
+    "projectHealth": "Projectgezondheid",
+    "watchOut": "Pas op",
+    "suggestedLinks": "Voorgestelde links",
+    "generate": "Genereer Brief",
+    "regenerate": "Regenereren",
+    "generating": "Genereren...",
+    "errorDefault": "Het genereren van inzichten is mislukt. Probeer het opnieuw.",
+    "lowContextTitle": "Niet genoeg context voor een geweldige suggestie",
+    "lowContextHint": "Voeg een beschrijving, notities, tags toe of wijs een project toe om betere inzichten te krijgen. Je kunt hieronder nog steeds genereren.",
+    "generateAnyway": "Toch genereren",
+    "statTotal": "Totaal",
+    "statDone": "Voltooid",
+    "statActive": "Actief",
+    "statOverdue": "Te laat"
   }
 }

--- a/public/locales/no/translation.json
+++ b/public/locales/no/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Ja, forkast",
     "uploading": "Laster opp...",
     "refresh": "Oppdater",
-    "unlinking": "Fjerner kobling..."
+    "unlinking": "Fjerner kobling...",
+    "preview": "Forhåndsvisning",
+    "download": "Last ned",
+    "exitFocusMode": "Avslutt fokusmodus",
+    "searchTimezones": "Søk etter tidssoner...",
+    "dismiss": "Avvis"
   },
   "sidebar": {
     "dashboard": "Dashbord",
@@ -58,7 +63,10 @@
     "unpinView": "Fjern feste fra visning",
     "pinView": "Fest visning",
     "eisenhower": "Eisenhower-matrise",
-    "kanban": "Kanban-tavle"
+    "kanban": "Kanban-tavle",
+    "addHabitAriaLabel": "Legg til vane",
+    "addHabitTitle": "Legg til vane",
+    "toggleDarkMode": "Bytt til mørk modus"
   },
   "navigation": {
     "home": "Hjem",
@@ -68,7 +76,11 @@
     "settings": "Innstillinger",
     "about": "Om",
     "logout": "Logg ut",
-    "backupRestore": "Sikkerhetskopiering og gjenoppretting"
+    "backupRestore": "Sikkerhetskopiering og gjenoppretting",
+    "toggleSearch": "Bytt søk",
+    "quickInboxCapture": "Rask innboksfangst",
+    "userMenu": "Brukermeny",
+    "search": "Søk"
   },
   "settings": {
     "todayPageSettings": "Innstillinger for Dagens Side",
@@ -182,7 +194,9 @@
       "waiting": "Venter",
       "done": "Ferdig",
       "dropHere": "Slipp her"
-    }
+    },
+    "chaseUp": "Følge opp",
+    "habit": "Vane"
   },
   "timeline": {
     "activityTimeline": "Aktivitetslinje",
@@ -504,7 +518,9 @@
       "syncIntervalHelp": "Hvor ofte skal det synkroniseres automatisk (5-1440 minutter)",
       "conflictPolicy": "Konfliktløsning",
       "manual": "Spør meg (manuell løsning)",
-      "lastWriteWins": "Sist endret vinner (automatisk)"
+      "lastWriteWins": "Sist endret vinner (automatisk)",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/kalendere/bruker/oppgaver"
     },
     "conflictResolver": {
       "title": "Løs synkroniseringskonflikter",
@@ -539,7 +555,9 @@
       "intervalError": "Synkroniseringsintervall må være mellom 1 og 1440 minutter",
       "updateSuccess": "Kalender oppdatert",
       "updateError": "Kunne ikke oppdatere kalender"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@brukernavn1, 123456789, @brukernavn2"
   },
   "productivity": {
     "stalledProjects": "Stagnerte prosjekter",
@@ -778,7 +796,11 @@
     "projectSaveFailed": "Kunne ikke lagre prosjekt.",
     "projectImageTooLarge": "Bildet er for stort. Vennligst velg en fil under 10MB.",
     "projectImageUpload": "Kunne ikke laste opp bildet. Vennligst prøv en mindre fil eller et annet format.",
-    "bannerSaveFailed": "Kunne ikke lagre banner"
+    "bannerSaveFailed": "Kunne ikke lagre banner",
+    "loginFailed": "Innlogging feilet. Vennligst prøv igjen.",
+    "generalError": "En feil oppstod. Vennligst prøv igjen.",
+    "viewNameRequired": "Visningsnavn er påkrevd",
+    "viewSaveFailed": "Kunne ikke lagre visning. Vennligst prøv igjen."
   },
   "inbox": {
     "title": "Innboks",
@@ -811,7 +833,9 @@
     "loadMoreError": "Kunne ikke laste flere elementer",
     "loading": "Laster...",
     "loadMore": "Last flere innboks-elementer",
-    "showingItems": "Viser {{current}} av {{total}} elementer"
+    "showingItems": "Viser {{current}} av {{total}} elementer",
+    "removeTag": "Fjern tag",
+    "removeProject": "Fjern prosjekt"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1057,7 +1081,9 @@
     "nextUp": "Neste beste handling",
     "focusTask": "Mest innflytelsesrike oppgave",
     "focusHint": "Flytter denne oppgaven til pågående og i dag",
-    "noNextAction": "Alt klart - ingen utestående oppgaver."
+    "noNextAction": "Alt klart - ingen utestående oppgaver.",
+    "selectDueDatePlaceholder": "Velg forfallsdato",
+    "goalTitle": "Mål"
   },
   "projectItem": {
     "edit": "Rediger",
@@ -1089,7 +1115,14 @@
     "error": "Feil ved lasting av område detaljer.",
     "notFound": "Område ikke funnet.",
     "details": "Område Detaljer",
-    "viewProjects": "Se prosjekter i {{name}}"
+    "viewProjects": "Se prosjekter i {{name}}",
+    "goalTitlePlaceholder": "Mål tittel",
+    "goalWhyPlaceholder": "Hvorfor dette er viktig (valgfritt)",
+    "editGoal": "Rediger mål",
+    "deleteGoal": "Slett mål",
+    "moveBackToUnlinked": "Flytt tilbake til ulinket",
+    "horizonSeason": "Sesong",
+    "horizonYear": "År"
   },
   "notes": {
     "loading": "Laster notater...",
@@ -1100,7 +1133,14 @@
     "deleteNoteAriaLabel": "Slett notat {{noteTitle}}",
     "deleteNoteTitle": "Slett notat {{noteTitle}}",
     "editNoteAriaLabel": "Rediger notat {{noteTitle}}",
-    "editNoteTitle": "Rediger notat {{noteTitle}}"
+    "editNoteTitle": "Rediger notat {{noteTitle}}",
+    "titlePlaceholder": "Notattittel...",
+    "contentPlaceholder": "Skriv inn innholdet i notatet ditt her... (Markdown støttet)",
+    "focusMode": "Fokusmodus",
+    "noteOptions": "Notatalternativer",
+    "clickToEdit": "Klikk for å redigere",
+    "contentPlaceholderFocus": "Skriv notatet ditt... (Markdown støttet)",
+    "contentPlaceholderMarkdown": "Skriv innholdet ditt med Markdown-formatering...\n\nEksempler:\n# Overskrift\n**Fet tekst**\n*Kursiv tekst*\n- Listeelement\n```kode```"
   },
   "tags": {
     "loading": "Laster etiketter...",
@@ -1124,7 +1164,11 @@
     "systemTag": "Systemtagger",
     "systemTagDescription": "Opprettet automatisk av appen. De driver innebygde funksjoner og kan ikke omdøpes eller slettes.",
     "userTag": "Brukertagger",
-    "userTagDescription": "Dine egne tagger for å organisere oppgaver, notater og prosjekter."
+    "userTagDescription": "Dine egne tagger for å organisere oppgaver, notater og prosjekter.",
+    "systemTags": "Systemetiketter",
+    "systemTagsDescription": "Automatisk administrert · Kan ikke slettes eller omdøpes",
+    "system": "System",
+    "customize": "Tilpass"
   },
   "recurrence": {
     "none": "Ingen",
@@ -1400,7 +1444,14 @@
     "priorityLabel": "Prioritet:",
     "dueLabel": "Forfall:",
     "tags": "Tags",
-    "recurring": "Gjentakende"
+    "recurring": "Gjentakende",
+    "saveAsSmartView": "Lagre som Smart Visning",
+    "viewNamePlaceholder": "Skriv inn visningsnavn",
+    "viewNameLabel": "Visningsnavn",
+    "viewWillSave": "Denne visningen vil lagres:",
+    "saveView": "Lagre Visning",
+    "filtersLabel": "Filtre:",
+    "searchLabel": "Søk:"
   },
   "search": {
     "placeholder": "Søk etter oppgaver, prosjekter, notater...",
@@ -1580,6 +1631,17 @@
     "lowContextTitle": "Ikke nok kontekst for et godt forslag",
     "lowContextHint": "Legg til en beskrivelse, notater, tagger eller tildel et prosjekt for å få bedre innsikt. Du kan fortsatt generere nedenfor.",
     "generateAnyway": "Generer uansett",
-    "show": "Vis"
+    "show": "Vis",
+    "projectInsightsTitle": "AI Innsikter",
+    "projectInsight": "Om dette prosjektet",
+    "projectNextAction": "Neste handling",
+    "projectHealth": "Prosjektstatus",
+    "statTotal": "Totalt",
+    "statDone": "Ferdig",
+    "statActive": "Aktiv",
+    "statOverdue": "Forsinket"
+  },
+  "habits": {
+    "completeHabit": "Fullfør vane"
   }
 }

--- a/public/locales/pl/translation.json
+++ b/public/locales/pl/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Tak, porzuć",
     "uploading": "Przesyłanie...",
     "refresh": "Odśwież",
-    "unlinking": "Odłączanie..."
+    "unlinking": "Odłączanie...",
+    "preview": "Podgląd",
+    "download": "Pobierz",
+    "exitFocusMode": "Wyjdź z trybu skupienia",
+    "searchTimezones": "Szukaj stref czasowych...",
+    "dismiss": "Odrzuć"
   },
   "sidebar": {
     "dashboard": "Panel sterowania",
@@ -58,7 +63,10 @@
     "unpinView": "Odprzypnij widok",
     "pinView": "Przypnij widok",
     "eisenhower": "Macierz Eisenhowera",
-    "kanban": "Tablica Kanban"
+    "kanban": "Tablica Kanban",
+    "addHabitAriaLabel": "Dodaj Nawyk",
+    "addHabitTitle": "Dodaj Nawyk",
+    "toggleDarkMode": "Przełącz tryb ciemny"
   },
   "navigation": {
     "home": "Strona główna",
@@ -68,7 +76,11 @@
     "settings": "Ustawienia",
     "about": "O aplikacji",
     "logout": "Wyloguj się",
-    "backupRestore": "Kopia zapasowa i przywracanie"
+    "backupRestore": "Kopia zapasowa i przywracanie",
+    "toggleSearch": "Przełącz wyszukiwanie",
+    "quickInboxCapture": "Szybkie przechwytywanie skrzynki odbiorczej",
+    "userMenu": "Menu użytkownika",
+    "search": "Szukaj"
   },
   "settings": {
     "todayPageSettings": "Ustawienia strony dzisiaj",
@@ -181,7 +193,9 @@
       "waiting": "Oczekiwanie",
       "done": "Zrobione",
       "dropHere": "Upuść tutaj"
-    }
+    },
+    "chaseUp": "Przypomnij",
+    "habit": "Nawyk"
   },
   "timeline": {
     "activityTimeline": "Oś czasu aktywności",
@@ -503,7 +517,9 @@
       "serverSettings": "Ustawienia serwera",
       "syncSettings": "Ustawienia synchronizacji",
       "setupSuccess": "Kalendarz skonfigurowany pomyślnie!",
-      "setupFailed": "Nie udało się utworzyć kalendarza"
+      "setupFailed": "Nie udało się utworzyć kalendarza",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "Rozwiązywanie konfliktów synchronizacji",
@@ -538,7 +554,9 @@
       "intervalError": "Interwał synchronizacji musi wynosić od 1 do 1440 minut",
       "updateSuccess": "Kalendarz zaktualizowany pomyślnie",
       "updateError": "Nie udało się zaktualizować kalendarza"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "productivity": {
     "stalledProjects": "Zatrzymane projekty",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Nie udało się zapisać projektu.",
     "projectImageTooLarge": "Obraz jest zbyt duży. Wybierz plik o rozmiarze poniżej 10MB.",
     "projectImageUpload": "Nie udało się przesłać obrazu. Spróbuj mniejszego pliku lub innego formatu.",
-    "bannerSaveFailed": "Nie udało się zapisać banera"
+    "bannerSaveFailed": "Nie udało się zapisać banera",
+    "loginFailed": "Logowanie nie powiodło się. Proszę spróbować ponownie.",
+    "generalError": "Wystąpił błąd. Proszę spróbować ponownie.",
+    "viewNameRequired": "Nazwa widoku jest wymagana",
+    "viewSaveFailed": "Nie udało się zapisać widoku. Proszę spróbować ponownie."
   },
   "inbox": {
     "title": "Skrzynka odbiorcza",
@@ -810,7 +832,9 @@
     "loadMoreError": "Nie udało się załadować więcej elementów",
     "loading": "Ładowanie...",
     "loadMore": "Załaduj więcej elementów skrzynki odbiorczej",
-    "showingItems": "Wyświetlanie {{current}} z {{total}} elementów"
+    "showingItems": "Wyświetlanie {{current}} z {{total}} elementów",
+    "removeTag": "Usuń tag",
+    "removeProject": "Usuń projekt"
   },
   "dateFormats": {
     "long": "EEEE, d MMMM yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Następne najlepsze działanie",
     "focusTask": "Najbardziej wpływowe zadanie",
     "focusHint": "Przenosi to zadanie do w toku i dzisiaj",
-    "noNextAction": "Wszystko jasne - brak zaległych zadań."
+    "noNextAction": "Wszystko jasne - brak zaległych zadań.",
+    "selectDueDatePlaceholder": "Wybierz datę wymagalności",
+    "goalTitle": "Cel"
   },
   "projectItem": {
     "edit": "Edytuj",
@@ -1088,7 +1114,14 @@
     "error": "Błąd podczas ładowania szczegółów obszaru.",
     "notFound": "Obszar nie został znaleziony.",
     "details": "Szczegóły obszaru",
-    "viewProjects": "Zobacz projekty w {{name}}"
+    "viewProjects": "Zobacz projekty w {{name}}",
+    "goalTitlePlaceholder": "Tytuł celu",
+    "goalWhyPlaceholder": "Dlaczego to jest ważne (opcjonalnie)",
+    "editGoal": "Edytuj cel",
+    "deleteGoal": "Usuń cel",
+    "moveBackToUnlinked": "Przenieś z powrotem do niepowiązanych",
+    "horizonSeason": "Sezon",
+    "horizonYear": "Rok"
   },
   "notes": {
     "loading": "Ładowanie notatek...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Usuń notatkę {{noteTitle}}",
     "deleteNoteTitle": "Usuń notatkę {{noteTitle}}",
     "editNoteAriaLabel": "Edytuj notatkę {{noteTitle}}",
-    "editNoteTitle": "Edytuj notatkę {{noteTitle}}"
+    "editNoteTitle": "Edytuj notatkę {{noteTitle}}",
+    "titlePlaceholder": "Tytuł notatki...",
+    "contentPlaceholder": "Napisz treść swojej notatki tutaj... (obsługuje Markdown)",
+    "focusMode": "Tryb skupienia",
+    "noteOptions": "Opcje notatki",
+    "clickToEdit": "Kliknij, aby edytować",
+    "contentPlaceholderFocus": "Napisz swoją notatkę... (obsługuje Markdown)",
+    "contentPlaceholderMarkdown": "Napisz swoją treść używając formatowania Markdown...\n\nPrzykłady:\n# Nagłówek\n**Pogrubiony tekst**\n*Kursywa*\n- Element listy\n```kod```"
   },
   "tags": {
     "loading": "Ładowanie tagów...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Tagi systemowe",
     "systemTagDescription": "Tworzone automatycznie przez aplikację. Napędzają wbudowane funkcje i nie mogą być zmieniane ani usuwane.",
     "userTag": "Tagi użytkownika",
-    "userTagDescription": "Twoje własne tagi do organizowania zadań, notatek i projektów."
+    "userTagDescription": "Twoje własne tagi do organizowania zadań, notatek i projektów.",
+    "systemTags": "Tagi systemowe",
+    "systemTagsDescription": "Zarządzane automatycznie · Nie można usunąć ani zmienić nazwy",
+    "system": "System",
+    "customize": "Dostosuj"
   },
   "recurrence": {
     "none": "Brak",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Priorytet:",
     "dueLabel": "Termin:",
     "tags": "Tagi",
-    "recurring": "Powtarzające się"
+    "recurring": "Powtarzające się",
+    "saveAsSmartView": "Zapisz jako Smart View",
+    "viewNamePlaceholder": "Wprowadź nazwę widoku",
+    "viewNameLabel": "Nazwa widoku",
+    "viewWillSave": "Ten widok zostanie zapisany:",
+    "saveView": "Zapisz widok",
+    "filtersLabel": "Filtry:",
+    "searchLabel": "Szukaj:"
   },
   "search": {
     "placeholder": "Szukaj zadań, projektów, notatek...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Zakończono i wykonano",
     "cancelled": "Anulowane",
     "cancelled_desc": "Nie zostanie ukończone"
+  },
+  "habits": {
+    "completeHabit": "Zakończ nawyk"
+  },
+  "aiAssistant": {
+    "title": "Asystent AI",
+    "generatedAt": "Wygenerowane o {{time}}",
+    "emptyState": "Kliknij 'Generuj podsumowanie', aby uzyskać codzienne podsumowanie zasilane przez AI.",
+    "focusForToday": "Skupienie na dzisiaj",
+    "priorityActions": "Priorytetowe działania",
+    "taskInsightsTitle": "Wnioski AI",
+    "projectInsightsTitle": "Wnioski AI",
+    "taskInsight": "O tym zadaniu",
+    "taskNextStep": "Następny krok",
+    "taskBreakdown": "Jak to podejść",
+    "projectInsight": "O tym projekcie",
+    "projectNextAction": "Następna akcja",
+    "projectHealth": "Stan projektu",
+    "watchOut": "Uważaj",
+    "suggestedLinks": "Zalecane linki",
+    "generate": "Generuj podsumowanie",
+    "regenerate": "Regeneruj",
+    "generating": "Generowanie...",
+    "errorDefault": "Nie udało się wygenerować informacji. Proszę spróbować ponownie.",
+    "lowContextTitle": "Niewystarczający kontekst do świetnej sugestii",
+    "lowContextHint": "Dodaj opis, notatki, tagi lub przypisz projekt, aby uzyskać lepsze informacje. Możesz nadal generować poniżej.",
+    "generateAnyway": "Generuj mimo to",
+    "statTotal": "Razem",
+    "statDone": "Zrobione",
+    "statActive": "Aktywne",
+    "statOverdue": "Przeterminowane"
   }
 }

--- a/public/locales/pt/translation.json
+++ b/public/locales/pt/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Sim, descartar",
     "uploading": "Carregando...",
     "refresh": "Atualizar",
-    "unlinking": "Desvinculando..."
+    "unlinking": "Desvinculando...",
+    "preview": "Prévia",
+    "download": "Baixar",
+    "exitFocusMode": "Sair do modo de foco",
+    "searchTimezones": "Pesquisar fusos horários...",
+    "dismiss": "Dispensar"
   },
   "sidebar": {
     "dashboard": "Painel",
@@ -58,7 +63,10 @@
     "unpinView": "Desafixar visão",
     "pinView": "Fixar visão",
     "eisenhower": "Matriz de Eisenhower",
-    "kanban": "Quadro Kanban"
+    "kanban": "Quadro Kanban",
+    "addHabitAriaLabel": "Adicionar Hábito",
+    "addHabitTitle": "Adicionar Hábito",
+    "toggleDarkMode": "Alternar Modo Escuro"
   },
   "navigation": {
     "home": "Início",
@@ -68,7 +76,11 @@
     "settings": "Configurações",
     "about": "Sobre",
     "logout": "Sair",
-    "backupRestore": "Backup e Restauração"
+    "backupRestore": "Backup e Restauração",
+    "toggleSearch": "Alternar Pesquisa",
+    "quickInboxCapture": "Captura Rápida da Caixa de Entrada",
+    "userMenu": "Menu do Usuário",
+    "search": "Pesquisar"
   },
   "settings": {
     "todayPageSettings": "Configurações da Página de Hoje",
@@ -181,7 +193,9 @@
       "waiting": "Aguardando",
       "done": "Concluído",
       "dropHere": "Solte aqui"
-    }
+    },
+    "chaseUp": "Cobrar",
+    "habit": "Hábito"
   },
   "timeline": {
     "activityTimeline": "Linha do Tempo de Atividades",
@@ -503,7 +517,9 @@
       "serverSettings": "Configurações do Servidor",
       "syncSettings": "Configurações de Sincronização",
       "setupSuccess": "Calendário configurado com sucesso!",
-      "setupFailed": "Falha ao criar o calendário"
+      "setupFailed": "Falha ao criar o calendário",
+      "serverUrlPlaceholder": "https://caldav.exemplo.com",
+      "calendarPathPlaceholder": "/calendários/usuário/tarefas"
     },
     "conflictResolver": {
       "title": "Resolver Conflitos de Sincronização",
@@ -538,7 +554,9 @@
       "intervalError": "O intervalo de sincronização deve estar entre 1 e 1440 minutos",
       "updateSuccess": "Calendário atualizado com sucesso",
       "updateError": "Falha ao atualizar calendário"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "productivity": {
     "stalledProjects": "Projetos Parados",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Falha ao salvar o projeto.",
     "projectImageTooLarge": "A imagem é muito grande. Por favor, escolha um arquivo com menos de 10MB.",
     "projectImageUpload": "Falha ao carregar a imagem. Por favor, tente um arquivo menor ou um formato diferente.",
-    "bannerSaveFailed": "Falha ao salvar o banner"
+    "bannerSaveFailed": "Falha ao salvar o banner",
+    "loginFailed": "Falha no login. Por favor, tente novamente.",
+    "generalError": "Ocorreu um erro. Por favor, tente novamente.",
+    "viewNameRequired": "O nome da visualização é obrigatório",
+    "viewSaveFailed": "Falha ao salvar a visualização. Por favor, tente novamente."
   },
   "inbox": {
     "title": "Caixa de Entrada",
@@ -810,7 +832,9 @@
     "loadMoreError": "Falha ao carregar mais itens",
     "loading": "Carregando...",
     "loadMore": "Carregar mais itens da caixa de entrada",
-    "showingItems": "Mostrando {{current}} de {{total}} itens"
+    "showingItems": "Mostrando {{current}} de {{total}} itens",
+    "removeTag": "Remover etiqueta",
+    "removeProject": "Remover projeto"
   },
   "dateFormats": {
     "long": "EEEE, d 'de' MMMM 'de' yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Próxima melhor ação",
     "focusTask": "Tarefa mais impactante",
     "focusHint": "Move esta tarefa para em andamento e hoje",
-    "noNextAction": "Tudo limpo - sem tarefas pendentes."
+    "noNextAction": "Tudo limpo - sem tarefas pendentes.",
+    "selectDueDatePlaceholder": "Selecione a data de vencimento",
+    "goalTitle": "Meta"
   },
   "projectItem": {
     "edit": "Editar",
@@ -1088,7 +1114,14 @@
     "error": "Erro ao carregar detalhes da área.",
     "notFound": "Área não encontrada.",
     "details": "Detalhes da Área",
-    "viewProjects": "Ver Projetos em {{name}}"
+    "viewProjects": "Ver Projetos em {{name}}",
+    "goalTitlePlaceholder": "Título da meta",
+    "goalWhyPlaceholder": "Por que isso é importante (opcional)",
+    "editGoal": "Editar meta",
+    "deleteGoal": "Excluir meta",
+    "moveBackToUnlinked": "Mover de volta para não vinculado",
+    "horizonSeason": "Estação",
+    "horizonYear": "Ano"
   },
   "notes": {
     "loading": "Carregando notas...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Excluir nota {{noteTitle}}",
     "deleteNoteTitle": "Excluir nota {{noteTitle}}",
     "editNoteAriaLabel": "Editar nota {{noteTitle}}",
-    "editNoteTitle": "Editar nota {{noteTitle}}"
+    "editNoteTitle": "Editar nota {{noteTitle}}",
+    "titlePlaceholder": "Título da nota...",
+    "contentPlaceholder": "Escreva o conteúdo da sua nota aqui... (Markdown suportado)",
+    "focusMode": "Modo de foco",
+    "noteOptions": "Opções da nota",
+    "clickToEdit": "Clique para editar",
+    "contentPlaceholderFocus": "Escreva sua nota... (Markdown suportado)",
+    "contentPlaceholderMarkdown": "Escreva seu conteúdo usando a formatação Markdown...\n\nExemplos:\n# Cabeçalho\n**Texto em negrito**\n*Texto em itálico*\n- Item da lista\n```código```"
   },
   "tags": {
     "loading": "Carregando tags...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Etiquetas do sistema",
     "systemTagDescription": "Criadas automaticamente pelo aplicativo. Elas alimentam recursos integrados e não podem ser renomeadas ou excluídas.",
     "userTag": "Etiquetas do usuário",
-    "userTagDescription": "Suas próprias etiquetas para organizar tarefas, notas e projetos."
+    "userTagDescription": "Suas próprias etiquetas para organizar tarefas, notas e projetos.",
+    "systemTags": "Tags do Sistema",
+    "systemTagsDescription": "Gerenciado automaticamente · Não pode ser deletado ou renomeado",
+    "system": "Sistema",
+    "customize": "Personalizar"
   },
   "recurrence": {
     "none": "Nenhum",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Prioridade:",
     "dueLabel": "Vencimento:",
     "tags": "Tags",
-    "recurring": "Recorrente"
+    "recurring": "Recorrente",
+    "saveAsSmartView": "Salvar como Visão Inteligente",
+    "viewNamePlaceholder": "Digite o nome da visão",
+    "viewNameLabel": "Nome da Visão",
+    "viewWillSave": "Esta visão será salva:",
+    "saveView": "Salvar Visão",
+    "filtersLabel": "Filtros:",
+    "searchLabel": "Pesquisar:"
   },
   "search": {
     "placeholder": "Pesquisar tarefas, projetos, notas...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Finalizado e concluído",
     "cancelled": "Cancelado",
     "cancelled_desc": "Não será concluído"
+  },
+  "habits": {
+    "completeHabit": "Completar hábito"
+  },
+  "aiAssistant": {
+    "title": "Assistente de IA",
+    "generatedAt": "Gerado em {{time}}",
+    "emptyState": "Clique em 'Gerar Resumo' para obter seu resumo diário com suporte de IA.",
+    "focusForToday": "Foco para hoje",
+    "priorityActions": "Ações prioritárias",
+    "taskInsightsTitle": "Insights de IA",
+    "projectInsightsTitle": "Insights de IA",
+    "taskInsight": "Sobre esta tarefa",
+    "taskNextStep": "Próximo passo",
+    "taskBreakdown": "Como abordá-lo",
+    "projectInsight": "Sobre este projeto",
+    "projectNextAction": "Próxima ação",
+    "projectHealth": "Saúde do projeto",
+    "watchOut": "Cuidado",
+    "suggestedLinks": "Links sugeridos",
+    "generate": "Gerar Resumo",
+    "regenerate": "Regenerar",
+    "generating": "Gerando...",
+    "errorDefault": "Falha ao gerar insights. Por favor, tente novamente.",
+    "lowContextTitle": "Contexto insuficiente para uma ótima sugestão",
+    "lowContextHint": "Adicione uma descrição, notas, tags ou atribua um projeto para obter melhores insights. Você ainda pode gerar abaixo.",
+    "generateAnyway": "Gerar mesmo assim",
+    "statTotal": "Total",
+    "statDone": "Concluído",
+    "statActive": "Ativo",
+    "statOverdue": "Atrasado"
   }
 }

--- a/public/locales/ro/translation.json
+++ b/public/locales/ro/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Da, renunță",
     "uploading": "Se încarcă...",
     "refresh": "Reîmprospătare",
-    "unlinking": "Dezlegare..."
+    "unlinking": "Dezlegare...",
+    "preview": "Previzualizare",
+    "download": "Descarcă",
+    "exitFocusMode": "Ieși din modul de concentrare",
+    "searchTimezones": "Caută fusuri orare...",
+    "dismiss": "Respinge"
   },
   "sidebar": {
     "dashboard": "Tabloul de bord",
@@ -58,7 +63,10 @@
     "unpinView": "Deblochează vizualizarea",
     "pinView": "Fixează vizualizarea",
     "eisenhower": "Matricea Eisenhower",
-    "kanban": "Tabloul Kanban"
+    "kanban": "Tabloul Kanban",
+    "addHabitAriaLabel": "Adaugă obicei",
+    "addHabitTitle": "Adaugă obicei",
+    "toggleDarkMode": "Comută modul întunecat"
   },
   "navigation": {
     "home": "Acasă",
@@ -68,7 +76,11 @@
     "settings": "Setări",
     "about": "Despre",
     "logout": "Deconectare",
-    "backupRestore": "Backup și Restaurare"
+    "backupRestore": "Backup și Restaurare",
+    "toggleSearch": "Comută căutarea",
+    "quickInboxCapture": "Captură rapidă din inbox",
+    "userMenu": "Meniu utilizator",
+    "search": "Caută"
   },
   "settings": {
     "todayPageSettings": "Setări Pagina de Azi",
@@ -181,7 +193,9 @@
       "waiting": "Așteptare",
       "done": "Finalizat",
       "dropHere": "Aruncă aici"
-    }
+    },
+    "chaseUp": "Urmărește",
+    "habit": "Obicei"
   },
   "timeline": {
     "activityTimeline": "Cronologia activităților",
@@ -503,7 +517,9 @@
       "serverSettings": "Setări Server",
       "syncSettings": "Setări Sincronizare",
       "setupSuccess": "Calendar configurat cu succes!",
-      "setupFailed": "Crearea calendarului a eșuat"
+      "setupFailed": "Crearea calendarului a eșuat",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "Rezolvă Conflictele de Sincronizare",
@@ -538,7 +554,9 @@
       "intervalError": "Intervalul de sincronizare trebuie să fie între 1 și 1440 de minute",
       "updateSuccess": "Calendar actualizat cu succes",
       "updateError": "Actualizarea calendarului a eșuat"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "productivity": {
     "stalledProjects": "Proiecte Blocate",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Nu s-a putut salva proiectul.",
     "projectImageTooLarge": "Imaginea este prea mare. Te rugăm să alegi un fișier de sub 10MB.",
     "projectImageUpload": "Încărcarea imaginii a eșuat. Te rugăm să încerci un fișier mai mic sau un format diferit.",
-    "bannerSaveFailed": "Salvarea bannerului a eșuat"
+    "bannerSaveFailed": "Salvarea bannerului a eșuat",
+    "loginFailed": "Autentificarea a eșuat. Te rugăm să încerci din nou.",
+    "generalError": "A apărut o eroare. Te rugăm să încerci din nou.",
+    "viewNameRequired": "Numele vizualizării este necesar",
+    "viewSaveFailed": "Salvarea vizualizării a eșuat. Te rugăm să încerci din nou."
   },
   "inbox": {
     "title": "Căsuța de primire",
@@ -810,7 +832,9 @@
     "loadMoreError": "Eșec la încărcarea mai multor elemente",
     "loading": "Se încarcă...",
     "loadMore": "Încărcați mai multe elemente din inbox",
-    "showingItems": "Afișare {{current}} din {{total}} elemente"
+    "showingItems": "Afișare {{current}} din {{total}} elemente",
+    "removeTag": "Șterge eticheta",
+    "removeProject": "Șterge proiectul"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Următoarea cea mai bună acțiune",
     "focusTask": "Sarcina cu cel mai mare impact",
     "focusHint": "Mută această sarcină la în progres și astăzi",
-    "noNextAction": "Totul în regulă - nicio sarcină în așteptare."
+    "noNextAction": "Totul în regulă - nicio sarcină în așteptare.",
+    "selectDueDatePlaceholder": "Selectează data limită",
+    "goalTitle": "Obiectiv"
   },
   "projectItem": {
     "edit": "Editează",
@@ -1088,7 +1114,14 @@
     "error": "Eroare la încărcarea detaliilor ariei.",
     "notFound": "Aria nu a fost găsită.",
     "details": "Detalii Arie",
-    "viewProjects": "Vezi Proiecte în {{name}}"
+    "viewProjects": "Vezi Proiecte în {{name}}",
+    "goalTitlePlaceholder": "Titlul obiectivului",
+    "goalWhyPlaceholder": "De ce este important (opțional)",
+    "editGoal": "Editează obiectivul",
+    "deleteGoal": "Șterge obiectivul",
+    "moveBackToUnlinked": "Mută înapoi la neconectat",
+    "horizonSeason": "Sezon",
+    "horizonYear": "An"
   },
   "notes": {
     "loading": "Se încarcă notițele...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Șterge nota {{noteTitle}}",
     "deleteNoteTitle": "Șterge nota {{noteTitle}}",
     "editNoteAriaLabel": "Editează nota {{noteTitle}}",
-    "editNoteTitle": "Editează nota {{noteTitle}}"
+    "editNoteTitle": "Editează nota {{noteTitle}}",
+    "titlePlaceholder": "Titlul notei...",
+    "contentPlaceholder": "Scrie conținutul notei aici... (Markdown acceptat)",
+    "focusMode": "Mod de concentrare",
+    "noteOptions": "Opțiuni notă",
+    "clickToEdit": "Click pentru a edita",
+    "contentPlaceholderFocus": "Scrie nota ta... (Markdown acceptat)",
+    "contentPlaceholderMarkdown": "Scrie conținutul tău folosind formatarea Markdown...\n\nExemple:\n# Titlu\n**Text îngroșat**\n*Text italic*\n- Element de listă\n```cod```"
   },
   "tags": {
     "loading": "Se încarcă etichetele...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Etichete de sistem",
     "systemTagDescription": "Create automat de aplicație. Acestea activează funcții încorporate și nu pot fi redenumite sau șterse.",
     "userTag": "Etichete de utilizator",
-    "userTagDescription": "Etichetele tale pentru organizarea sarcinilor, notelor și proiectelor."
+    "userTagDescription": "Etichetele tale pentru organizarea sarcinilor, notelor și proiectelor.",
+    "systemTags": "Etichete de sistem",
+    "systemTagsDescription": "Gestionate automat · Nu pot fi șterse sau redenumite",
+    "system": "Sistem",
+    "customize": "Personalizează"
   },
   "recurrence": {
     "none": "Niciuna",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Prioritate:",
     "dueLabel": "Termen:",
     "tags": "Etichete",
-    "recurring": "Recurent"
+    "recurring": "Recurent",
+    "saveAsSmartView": "Salvează ca Vedere Inteligentă",
+    "viewNamePlaceholder": "Introdu numele vederii",
+    "viewNameLabel": "Numele Vederii",
+    "viewWillSave": "Această vedere va salva:",
+    "saveView": "Salvează Vederea",
+    "filtersLabel": "Filtre:",
+    "searchLabel": "Caută:"
   },
   "search": {
     "placeholder": "Caută sarcini, proiecte, note...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Terminată și finalizată",
     "cancelled": "Anulat",
     "cancelled_desc": "Nu va fi finalizat"
+  },
+  "habits": {
+    "completeHabit": "Finalizare obicei"
+  },
+  "aiAssistant": {
+    "title": "Asistent AI",
+    "generatedAt": "Generat la {{time}}",
+    "emptyState": "Click pe 'Generează Rezumat' pentru a obține rezumatul zilnic alimentat de AI.",
+    "focusForToday": "Concentrează-te pe astăzi",
+    "priorityActions": "Acțiuni prioritare",
+    "taskInsightsTitle": "Informații AI",
+    "projectInsightsTitle": "Informații AI",
+    "taskInsight": "Despre această sarcină",
+    "taskNextStep": "Pasul următor",
+    "taskBreakdown": "Cum să abordăm",
+    "projectInsight": "Despre acest proiect",
+    "projectNextAction": "Următoarea acțiune",
+    "projectHealth": "Starea proiectului",
+    "watchOut": "Fii atent",
+    "suggestedLinks": "Linkuri sugerate",
+    "generate": "Generare Breif",
+    "regenerate": "Regenerare",
+    "generating": "Generare...",
+    "errorDefault": "Generarea de informații a eșuat. Te rugăm să încerci din nou.",
+    "lowContextTitle": "Nu este suficient context pentru o sugestie bună",
+    "lowContextHint": "Adaugă o descriere, note, etichete sau atribuie un proiect pentru a obține informații mai bune. Poți genera în continuare mai jos.",
+    "generateAnyway": "Generare oricum",
+    "statTotal": "Total",
+    "statDone": "Finalizat",
+    "statActive": "Activ",
+    "statOverdue": "Întârziat"
   }
 }

--- a/public/locales/ru/translation.json
+++ b/public/locales/ru/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Да, отменить",
     "uploading": "Загрузка...",
     "refresh": "Обновить",
-    "unlinking": "Отвязываем..."
+    "unlinking": "Отвязываем...",
+    "preview": "Предварительный просмотр",
+    "download": "Скачать",
+    "exitFocusMode": "Выйти из режима фокуса",
+    "searchTimezones": "Поиск часовых поясов...",
+    "dismiss": "Закрыть"
   },
   "sidebar": {
     "dashboard": "Панель управления",
@@ -58,7 +63,10 @@
     "unpinView": "Открепить представление",
     "pinView": "Закрепить представление",
     "eisenhower": "Матрица Эйзенхауэра",
-    "kanban": "Доска Канбан"
+    "kanban": "Доска Канбан",
+    "addHabitAriaLabel": "Добавить привычку",
+    "addHabitTitle": "Добавить привычку",
+    "toggleDarkMode": "Переключить темный режим"
   },
   "navigation": {
     "home": "Главная",
@@ -68,7 +76,11 @@
     "settings": "Настройки",
     "about": "О программе",
     "logout": "Выход",
-    "backupRestore": "Резервное копирование и восстановление"
+    "backupRestore": "Резервное копирование и восстановление",
+    "toggleSearch": "Переключить поиск",
+    "quickInboxCapture": "Быстрое захватывание входящих",
+    "userMenu": "Меню пользователя",
+    "search": "Поиск"
   },
   "settings": {
     "todayPageSettings": "Настройки страницы «Сегодня»",
@@ -181,7 +193,9 @@
       "waiting": "Ожидание",
       "done": "Выполнено",
       "dropHere": "Перетащите сюда"
-    }
+    },
+    "chaseUp": "Напомнить",
+    "habit": "Привычка"
   },
   "timeline": {
     "activityTimeline": "Хронология активности",
@@ -503,7 +517,9 @@
       "serverSettings": "Настройки сервера",
       "syncSettings": "Настройки синхронизации",
       "setupSuccess": "Календарь успешно настроен!",
-      "setupFailed": "Не удалось создать календарь"
+      "setupFailed": "Не удалось создать календарь",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "Разрешение конфликтов синхронизации",
@@ -538,7 +554,9 @@
       "intervalError": "Интервал синхронизации должен быть от 1 до 1440 минут",
       "updateSuccess": "Календарь успешно обновлён",
       "updateError": "Не удалось обновить календарь"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "productivity": {
     "stalledProjects": "Приостановленные проекты",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Не удалось сохранить проект.",
     "projectImageTooLarge": "Изображение слишком большое. Пожалуйста, выберите файл размером менее 10 МБ.",
     "projectImageUpload": "Не удалось загрузить изображение. Пожалуйста, попробуйте использовать файл меньшего размера или другой формат.",
-    "bannerSaveFailed": "Не удалось сохранить баннер"
+    "bannerSaveFailed": "Не удалось сохранить баннер",
+    "viewNameRequired": "Название представления обязательно",
+    "viewSaveFailed": "Не удалось сохранить представление. Пожалуйста, попробуйте снова.",
+    "loginFailed": "Ошибка входа. Пожалуйста, попробуйте снова.",
+    "generalError": "Произошла ошибка. Пожалуйста, попробуйте снова."
   },
   "inbox": {
     "title": "Входящие",
@@ -810,7 +832,9 @@
     "loadMoreError": "Не удалось загрузить больше элементов",
     "loading": "Загрузка...",
     "loadMore": "Загрузить больше элементов в почтовом ящике",
-    "showingItems": "Показано {{current}} из {{total}} элементов"
+    "showingItems": "Показано {{current}} из {{total}} элементов",
+    "removeTag": "Удалить тег",
+    "removeProject": "Удалить проект"
   },
   "dateFormats": {
     "long": "EEEE, d MMMM, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Следующее лучшее действие",
     "focusTask": "Наиболее важная задача",
     "focusHint": "Переносит задачу в „Выполняется\" и „Сегодня\"",
-    "noNextAction": "Все выполнено - нет невыполненных задач."
+    "noNextAction": "Все выполнено - нет невыполненных задач.",
+    "selectDueDatePlaceholder": "Выберите дату выполнения",
+    "goalTitle": "Цель"
   },
   "projectItem": {
     "edit": "Редактировать",
@@ -1088,7 +1114,14 @@
     "error": "Ошибка загрузки деталей области.",
     "notFound": "Область не найдена.",
     "details": "Детали области",
-    "viewProjects": "Просмотреть проекты в {{name}}"
+    "viewProjects": "Просмотреть проекты в {{name}}",
+    "goalTitlePlaceholder": "Название цели",
+    "goalWhyPlaceholder": "Почему это важно (необязательно)",
+    "editGoal": "Редактировать цель",
+    "deleteGoal": "Удалить цель",
+    "moveBackToUnlinked": "Переместить обратно в не связанные",
+    "horizonSeason": "Сезон",
+    "horizonYear": "Год"
   },
   "notes": {
     "loading": "Загрузка заметок...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Удалить заметку {{noteTitle}}",
     "deleteNoteTitle": "Удалить заметку {{noteTitle}}",
     "editNoteAriaLabel": "Редактировать заметку {{noteTitle}}",
-    "editNoteTitle": "Редактировать заметку {{noteTitle}}"
+    "editNoteTitle": "Редактировать заметку {{noteTitle}}",
+    "titlePlaceholder": "Название заметки...",
+    "contentPlaceholder": "Напишите содержание вашей заметки здесь... (поддерживается Markdown)",
+    "focusMode": "Режим фокуса",
+    "noteOptions": "Опции заметки",
+    "clickToEdit": "Нажмите, чтобы редактировать",
+    "contentPlaceholderFocus": "Напишите вашу заметку... (поддерживается Markdown)",
+    "contentPlaceholderMarkdown": "Напишите ваше содержание, используя форматирование Markdown...\n\nПримеры:\n# Заголовок\n**Жирный текст**\n*Курсивный текст*\n- Элемент списка\n```код```"
   },
   "tags": {
     "loading": "Загрузка тегов...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Системные теги",
     "systemTagDescription": "Созданы автоматически приложением. Они обеспечивают работу встроенных функций и не могут быть переименованы или удалены.",
     "userTag": "Пользовательские теги",
-    "userTagDescription": "Ваши собственные теги для организации задач, заметок и проектов."
+    "userTagDescription": "Ваши собственные теги для организации задач, заметок и проектов.",
+    "systemTags": "Системные теги",
+    "systemTagsDescription": "Автоматически управляемые · Не могут быть удалены или переименованы",
+    "system": "Система",
+    "customize": "Настроить"
   },
   "recurrence": {
     "none": "Нет",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Приоритет:",
     "dueLabel": "Срок:",
     "tags": "Теги",
-    "recurring": "Повторяющийся"
+    "recurring": "Повторяющийся",
+    "saveAsSmartView": "Сохранить как Умный вид",
+    "viewNamePlaceholder": "Введите название вида",
+    "viewNameLabel": "Название вида",
+    "viewWillSave": "Этот вид будет сохранён:",
+    "saveView": "Сохранить вид",
+    "filtersLabel": "Фильтры:",
+    "searchLabel": "Поиск:"
   },
   "search": {
     "placeholder": "Поиск задач, проектов, заметок...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Закончено и выполнено",
     "cancelled": "Отменено",
     "cancelled_desc": "Не будет завершено"
+  },
+  "habits": {
+    "completeHabit": "Завершить привычку"
+  },
+  "aiAssistant": {
+    "title": "AI Ассистент",
+    "generatedAt": "Сгенерировано в {{time}}",
+    "emptyState": "Нажмите 'Сгенерировать краткое содержание', чтобы получить ваше ежедневное резюме с поддержкой ИИ.",
+    "focusForToday": "Фокус на сегодня",
+    "priorityActions": "Приоритетные действия",
+    "taskInsightsTitle": "Инсайты ИИ",
+    "projectInsightsTitle": "Инсайты ИИ",
+    "taskInsight": "Об этой задаче",
+    "taskNextStep": "Следующий шаг",
+    "taskBreakdown": "Как к этому подойти",
+    "projectInsight": "Об этом проекте",
+    "projectNextAction": "Следующее действие",
+    "projectHealth": "Состояние проекта",
+    "watchOut": "Будьте осторожны",
+    "suggestedLinks": "Предложенные ссылки",
+    "generate": "Сгенерировать бриф",
+    "regenerate": "Сгенерировать заново",
+    "generating": "Генерация...",
+    "errorDefault": "Не удалось сгенерировать идеи. Пожалуйста, попробуйте снова.",
+    "lowContextTitle": "Недостаточно контекста для отличного предложения",
+    "lowContextHint": "Добавьте описание, заметки, теги или назначьте проект, чтобы получить лучшие идеи. Вы все равно можете сгенерировать ниже.",
+    "generateAnyway": "Сгенерировать все равно",
+    "statTotal": "Всего",
+    "statDone": "Выполнено",
+    "statActive": "Активно",
+    "statOverdue": "Просрочено"
   }
 }

--- a/public/locales/sl/translation.json
+++ b/public/locales/sl/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Da, zavrzi",
     "uploading": "Nalagam...",
     "refresh": "Osveži",
-    "unlinking": "Odvezovanje..."
+    "unlinking": "Odvezovanje...",
+    "preview": "Predogled",
+    "download": "Prenesi",
+    "exitFocusMode": "Izhod iz načina osredotočenja",
+    "searchTimezones": "Išči časovne pasove...",
+    "dismiss": "Zavrni"
   },
   "sidebar": {
     "dashboard": "Nadzorna plošča",
@@ -58,7 +63,10 @@
     "unpinView": "Odpravi pripenjanje pogleda",
     "pinView": "Pripni pogled",
     "eisenhower": "Eisenhowerjeva matrika",
-    "kanban": "Kanban tabla"
+    "kanban": "Kanban tabla",
+    "addHabitAriaLabel": "Dodaj navado",
+    "addHabitTitle": "Dodaj navado",
+    "toggleDarkMode": "Preklopi temni način"
   },
   "navigation": {
     "home": "Domov",
@@ -68,7 +76,11 @@
     "settings": "Nastavitve",
     "about": "O aplikaciji",
     "logout": "Odjava",
-    "backupRestore": "Varnostna kopija in obnova"
+    "backupRestore": "Varnostna kopija in obnova",
+    "toggleSearch": "Preklopi iskanje",
+    "quickInboxCapture": "Hiter zajem v nabiralniku",
+    "userMenu": "Uporabniški meni",
+    "search": "Išči"
   },
   "settings": {
     "todayPageSettings": "Nastavitve strani Danes",
@@ -181,7 +193,9 @@
       "waiting": "Čakanje",
       "done": "Končano",
       "dropHere": "Spusti tukaj"
-    }
+    },
+    "chaseUp": "Sledi",
+    "habit": "Navada"
   },
   "timeline": {
     "activityTimeline": "Časovnica aktivnosti",
@@ -503,7 +517,9 @@
       "serverSettings": "Nastavitve strežnika",
       "syncSettings": "Nastavitve sinhronizacije",
       "setupSuccess": "Koledar je bil uspešno konfiguriran!",
-      "setupFailed": "Ustvarjanje koledarja ni uspelo"
+      "setupFailed": "Ustvarjanje koledarja ni uspelo",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/koledarji/uporabnik/naloge"
     },
     "conflictResolver": {
       "title": "Reševanje konfliktov sinhronizacije",
@@ -538,7 +554,9 @@
       "intervalError": "Interval sinhronizacije mora biti med 1 in 1440 minutami",
       "updateSuccess": "Koledar je bil uspešno posodobljen",
       "updateError": "Posodobitev koledarja ni uspela"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@uporabnik1, 123456789, @uporabnik2"
   },
   "productivity": {
     "stalledProjects": "Zastali projekti",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Shranjevanje projekta ni uspelo.",
     "projectImageTooLarge": "Slika je prevelika. Izberite datoteko, ki je manjša od 10 MB.",
     "projectImageUpload": "Nalaganje slike ni uspelo. Poskusite z manjšo datoteko ali drugačnim formatom.",
-    "bannerSaveFailed": "Shranjevanje bannerja ni uspelo"
+    "bannerSaveFailed": "Shranjevanje bannerja ni uspelo",
+    "loginFailed": "Prijava ni uspela. Poskusite znova.",
+    "generalError": "Prišlo je do napake. Poskusite znova.",
+    "viewNameRequired": "Ime pogleda je obvezno",
+    "viewSaveFailed": "Shranjevanje pogleda ni uspelo. Poskusite znova."
   },
   "inbox": {
     "title": "Prejeto",
@@ -810,7 +832,9 @@
     "loadMoreError": "Nalaganje dodatnih predmetov ni uspelo",
     "loading": "Nalaganje...",
     "loadMore": "Naloži več predmetov v prejeto",
-    "showingItems": "Prikazujem {{current}} od {{total}} predmetov"
+    "showingItems": "Prikazujem {{current}} od {{total}} predmetov",
+    "removeTag": "Odstrani oznako",
+    "removeProject": "Odstrani projekt"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Naslednje najboljše dejanje",
     "focusTask": "Najbolj vplivna naloga",
     "focusHint": "Premakne to nalogo v v teku in danes",
-    "noNextAction": "Vse jasno - ni neizpolnjenih nalog."
+    "noNextAction": "Vse jasno - ni neizpolnjenih nalog.",
+    "selectDueDatePlaceholder": "Izberite datum zapadlosti",
+    "goalTitle": "Cilj"
   },
   "projectItem": {
     "edit": "Uredi",
@@ -1088,7 +1114,14 @@
     "error": "Napaka pri nalaganju podrobnosti območja.",
     "notFound": "Območje ni bilo najdeno.",
     "details": "Podrobnosti območja",
-    "viewProjects": "Ogled projektov v {{name}}"
+    "viewProjects": "Ogled projektov v {{name}}",
+    "goalTitlePlaceholder": "Naslov cilja",
+    "goalWhyPlaceholder": "Zakaj je to pomembno (neobvezno)",
+    "editGoal": "Uredi cilj",
+    "deleteGoal": "Izbriši cilj",
+    "moveBackToUnlinked": "Premakni nazaj na nepovezano",
+    "horizonSeason": "Sezona",
+    "horizonYear": "Leto"
   },
   "notes": {
     "loading": "Nalaganje opomb...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Izbriši opombo {{noteTitle}}",
     "deleteNoteTitle": "Izbriši opombo {{noteTitle}}",
     "editNoteAriaLabel": "Uredi opombo {{noteTitle}}",
-    "editNoteTitle": "Uredi opombo {{noteTitle}}"
+    "editNoteTitle": "Uredi opombo {{noteTitle}}",
+    "titlePlaceholder": "Naslov opombe...",
+    "contentPlaceholder": "Tukaj napišite vsebino svoje opombe... (podprto Markdown)",
+    "focusMode": "Način osredotočanja",
+    "noteOptions": "Možnosti opombe",
+    "clickToEdit": "Kliknite za urejanje",
+    "contentPlaceholderFocus": "Tukaj napišite svojo opombo... (podprto Markdown)",
+    "contentPlaceholderMarkdown": "Napišite svojo vsebino z uporabo Markdown oblikovanja...\n\nPrimeri:\n# Naslov\n**Krepko besedilo**\n*Poševno besedilo*\n- Element seznama\n```koda```"
   },
   "tags": {
     "loading": "Nalagam oznake...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Sistemske oznake",
     "systemTagDescription": "Ustvarjeno samodejno z aplikacijo. Omogočajo vgrajene funkcije in jih ni mogoče preimenovati ali izbrisati.",
     "userTag": "Oznake uporabnika",
-    "userTagDescription": "Vaše lastne oznake za organizacijo nalog, opomb in projektov."
+    "userTagDescription": "Vaše lastne oznake za organizacijo nalog, opomb in projektov.",
+    "systemTags": "Sistemske oznake",
+    "systemTagsDescription": "Samodejno upravljane · Ne morejo biti izbrisane ali preimenovane",
+    "system": "Sistem",
+    "customize": "Prilagodi"
   },
   "recurrence": {
     "none": "Noben",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Prioriteta:",
     "dueLabel": "Rok:",
     "tags": "Oznake",
-    "recurring": "Ponovno"
+    "recurring": "Ponovno",
+    "saveAsSmartView": "Shrani kot Pametni pogled",
+    "viewNamePlaceholder": "Vnesite ime pogleda",
+    "viewNameLabel": "Ime pogleda",
+    "viewWillSave": "Ta pogled bo shranil:",
+    "saveView": "Shrani pogled",
+    "filtersLabel": "Filtri:",
+    "searchLabel": "Iskanje:"
   },
   "search": {
     "placeholder": "Išči naloge, projekte, zapiske...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Končano in opravljeno",
     "cancelled": "Preklicano",
     "cancelled_desc": "Ne bo dokončano"
+  },
+  "habits": {
+    "completeHabit": "Dokončaj navado"
+  },
+  "aiAssistant": {
+    "title": "AI Pomočnik",
+    "generatedAt": "Ustvarjeno ob {{time}}",
+    "emptyState": "Kliknite 'Ustvari povzetek', da dobite vaš dnevni povzetek, podprt z AI.",
+    "focusForToday": "Osredotočite se na danes",
+    "priorityActions": "Prednostne akcije",
+    "taskInsightsTitle": "AI vpogledi",
+    "projectInsightsTitle": "AI vpogledi",
+    "taskInsight": "O tej nalogi",
+    "taskNextStep": "Naslednji korak",
+    "taskBreakdown": "Kako pristopiti k temu",
+    "projectInsight": "O tem projektu",
+    "projectNextAction": "Naslednja akcija",
+    "projectHealth": "Zdravje projekta",
+    "watchOut": "Pazi",
+    "suggestedLinks": "Predlagane povezave",
+    "generate": "Ustvari povzetek",
+    "regenerate": "Ponovno ustvari",
+    "generating": "Ustvarjanje...",
+    "errorDefault": "Ni uspelo ustvariti vpogledov. Poskusite znova.",
+    "lowContextTitle": "Premalo konteksta za odličen predlog",
+    "lowContextHint": "Dodajte opis, opombe, oznake ali dodelite projekt, da dobite boljše vpoglede. Kljub temu lahko ustvarite spodaj.",
+    "generateAnyway": "Ustvari kljub temu",
+    "statTotal": "Skupaj",
+    "statDone": "Končano",
+    "statActive": "Aktivno",
+    "statOverdue": "Zapadlo"
   }
 }

--- a/public/locales/sv/translation.json
+++ b/public/locales/sv/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Ja, kasta bort",
     "uploading": "Laddar upp...",
     "refresh": "Uppdatera",
-    "unlinking": "Avlänkar..."
+    "unlinking": "Avlänkar...",
+    "preview": "Förhandsgranska",
+    "download": "Ladda ner",
+    "exitFocusMode": "Avsluta fokusläge",
+    "searchTimezones": "Sök tidszoner...",
+    "dismiss": "Avfärda"
   },
   "sidebar": {
     "dashboard": "Dashboard",
@@ -58,7 +63,10 @@
     "unpinView": "Ta bort fästning av vy",
     "pinView": "Fäst vy",
     "eisenhower": "Eisenhower-matris",
-    "kanban": "Kanban-tavla"
+    "kanban": "Kanban-tavla",
+    "addHabitAriaLabel": "Lägg till vana",
+    "addHabitTitle": "Lägg till vana",
+    "toggleDarkMode": "Växla mörkt läge"
   },
   "navigation": {
     "home": "Hem",
@@ -68,7 +76,11 @@
     "settings": "Inställningar",
     "about": "Om",
     "logout": "Logga ut",
-    "backupRestore": "Säkerhetskopiera & Återställ"
+    "backupRestore": "Säkerhetskopiera & Återställ",
+    "toggleSearch": "Växla sök",
+    "quickInboxCapture": "Snabb inkapsling av inkorgen",
+    "userMenu": "Användarmenyn",
+    "search": "Sök"
   },
   "settings": {
     "todayPageSettings": "Inställningar för dagens sida",
@@ -181,7 +193,9 @@
       "waiting": "Väntar",
       "done": "Utförd",
       "dropHere": "Släpp här"
-    }
+    },
+    "chaseUp": "Följ upp",
+    "habit": "Vana"
   },
   "timeline": {
     "activityTimeline": "Aktivitetslinje",
@@ -503,7 +517,9 @@
       "serverSettings": "Serverinställningar",
       "syncSettings": "Synkroniseringsinställningar",
       "setupSuccess": "Kalendern konfigurerades framgångsrikt!",
-      "setupFailed": "Misslyckades med att skapa kalender"
+      "setupFailed": "Misslyckades med att skapa kalender",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/kalendrar/användare/uppgifter"
     },
     "conflictResolver": {
       "title": "Lös synkroniseringskonflikter",
@@ -538,7 +554,9 @@
       "intervalError": "Synkroniseringsintervall måste vara mellan 1 och 1440 minuter",
       "updateSuccess": "Kalendern uppdaterades framgångsrikt",
       "updateError": "Misslyckades med att uppdatera kalendern"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@användarnamn1, 123456789, @användarnamn2"
   },
   "productivity": {
     "stalledProjects": "Stagnerade projekt",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Kunde inte spara projekt.",
     "projectImageTooLarge": "Bilden är för stor. Vänligen välj en fil under 10MB.",
     "projectImageUpload": "Misslyckades med att ladda upp bilden. Vänligen försök med en mindre fil eller ett annat format.",
-    "bannerSaveFailed": "Misslyckades med att spara banner"
+    "bannerSaveFailed": "Misslyckades med att spara banner",
+    "loginFailed": "Inloggning misslyckades. Försök igen.",
+    "generalError": "Ett fel inträffade. Försök igen.",
+    "viewNameRequired": "Visningsnamn krävs",
+    "viewSaveFailed": "Misslyckades med att spara visning. Försök igen."
   },
   "inbox": {
     "title": "Inkorg",
@@ -810,7 +832,9 @@
     "loadMoreError": "Misslyckades med att ladda fler objekt",
     "loading": "Laddar...",
     "loadMore": "Ladda fler inkorgsobjekt",
-    "showingItems": "Visar {{current}} av {{total}} objekt"
+    "showingItems": "Visar {{current}} av {{total}} objekt",
+    "removeTag": "Ta bort tagg",
+    "removeProject": "Ta bort projekt"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Nästa bästa åtgärd",
     "focusTask": "Mest påverkande uppgift",
     "focusHint": "Flyttar denna uppgift till pågående och idag",
-    "noNextAction": "Allt klart - inga utestående uppgifter."
+    "noNextAction": "Allt klart - inga utestående uppgifter.",
+    "selectDueDatePlaceholder": "Välj förfallodatum",
+    "goalTitle": "Mål"
   },
   "projectItem": {
     "edit": "Ändra",
@@ -1088,7 +1114,14 @@
     "error": "Fel vid inläsning av områdesdetaljer.",
     "notFound": "Område hittades inte.",
     "details": "Områdesdetaljer",
-    "viewProjects": "Visa projekt i {{name}}"
+    "viewProjects": "Visa projekt i {{name}}",
+    "goalTitlePlaceholder": "Målnamn",
+    "goalWhyPlaceholder": "Varför detta är viktigt (valfritt)",
+    "editGoal": "Redigera mål",
+    "deleteGoal": "Ta bort mål",
+    "moveBackToUnlinked": "Flytta tillbaka till olänkad",
+    "horizonSeason": "Säsong",
+    "horizonYear": "År"
   },
   "notes": {
     "loading": "Laddar anteckningar...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Ta bort anteckning {{noteTitle}}",
     "deleteNoteTitle": "Ta bort anteckning {{noteTitle}}",
     "editNoteAriaLabel": "Ändra anteckning {{noteTitle}}",
-    "editNoteTitle": "Ändra anteckning {{noteTitle}}"
+    "editNoteTitle": "Ändra anteckning {{noteTitle}}",
+    "titlePlaceholder": "Anteckningens titel...",
+    "contentPlaceholder": "Skriv ditt anteckningsinnehåll här... (Markdown stöds)",
+    "focusMode": "Fokusläge",
+    "noteOptions": "Anteckningsalternativ",
+    "clickToEdit": "Klicka för att redigera",
+    "contentPlaceholderFocus": "Skriv din anteckning... (Markdown stöds)",
+    "contentPlaceholderMarkdown": "Skriv ditt innehåll med Markdown-formatering...\n\nExempel:\n# Rubrik\n**Fet text**\n*Kursiv text*\n- Lista objekt\n```kod```"
   },
   "tags": {
     "loading": "Laddar taggar...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Systemtaggar",
     "systemTagDescription": "Skapad automatiskt av appen. De driver inbyggda funktioner och kan inte döpas om eller tas bort.",
     "userTag": "Användartaggar",
-    "userTagDescription": "Dina egna taggar för att organisera uppgifter, anteckningar och projekt."
+    "userTagDescription": "Dina egna taggar för att organisera uppgifter, anteckningar och projekt.",
+    "systemTags": "Systemtaggar",
+    "systemTagsDescription": "Automatiskt hanterade · Kan inte tas bort eller döpas om",
+    "system": "System",
+    "customize": "Anpassa"
   },
   "recurrence": {
     "none": "Ingen",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Prioritet:",
     "dueLabel": "Förfall:",
     "tags": "Taggar",
-    "recurring": "Återkommande"
+    "recurring": "Återkommande",
+    "saveAsSmartView": "Spara som Smart View",
+    "viewNamePlaceholder": "Ange vy namn",
+    "viewNameLabel": "Vy Namn",
+    "viewWillSave": "Denna vy kommer att spara:",
+    "saveView": "Spara Vy",
+    "filtersLabel": "Filter:",
+    "searchLabel": "Sök:"
   },
   "search": {
     "placeholder": "Sök uppgifter, projekt, anteckningar...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Avslutad och klar",
     "cancelled": "Avbruten",
     "cancelled_desc": "Kommer inte att slutföras"
+  },
+  "habits": {
+    "completeHabit": "Avsluta vana"
+  },
+  "aiAssistant": {
+    "title": "AI-assistent",
+    "generatedAt": "Genererad vid {{time}}",
+    "emptyState": "Klicka på 'Generera sammanfattning' för att få din AI-drivna dagliga sammanfattning.",
+    "focusForToday": "Fokus för idag",
+    "priorityActions": "Prioriterade åtgärder",
+    "taskInsightsTitle": "AI-insikter",
+    "projectInsightsTitle": "AI-insikter",
+    "taskInsight": "Om denna uppgift",
+    "taskNextStep": "Nästa steg",
+    "taskBreakdown": "Hur man närmar sig det",
+    "projectInsight": "Om detta projekt",
+    "projectNextAction": "Nästa åtgärd",
+    "projectHealth": "Projektstatus",
+    "watchOut": "Se upp",
+    "suggestedLinks": "Föreslagna länkar",
+    "generate": "Generera sammanfattning",
+    "regenerate": "Regenerera",
+    "generating": "Genererar...",
+    "errorDefault": "Misslyckades med att generera insikter. Försök igen.",
+    "lowContextTitle": "Inte tillräckligt med kontext för ett bra förslag",
+    "lowContextHint": "Lägg till en beskrivning, anteckningar, taggar eller tilldela ett projekt för att få bättre insikter. Du kan fortfarande generera nedan.",
+    "generateAnyway": "Generera ändå",
+    "statTotal": "Totalt",
+    "statDone": "Utfört",
+    "statActive": "Aktiv",
+    "statOverdue": "Förfallen"
   }
 }

--- a/public/locales/tr/translation.json
+++ b/public/locales/tr/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Evet, iptal et",
     "uploading": "Yükleniyor...",
     "refresh": "Yenile",
-    "unlinking": "Bağlantı kesiliyor..."
+    "unlinking": "Bağlantı kesiliyor...",
+    "preview": "Önizleme",
+    "download": "İndir",
+    "exitFocusMode": "Odak modundan çık",
+    "searchTimezones": "Saat dilimlerini ara...",
+    "dismiss": "Kapat"
   },
   "sidebar": {
     "dashboard": "Gösterge Paneli",
@@ -58,7 +63,10 @@
     "unpinView": "Görünümü sabitlemeyi kaldır",
     "pinView": "Görünümü sabitle",
     "eisenhower": "Eisenhower Matrisi",
-    "kanban": "Kanban Panosu"
+    "kanban": "Kanban Panosu",
+    "addHabitAriaLabel": "Alışkanlık Ekle",
+    "addHabitTitle": "Alışkanlık Ekle",
+    "toggleDarkMode": "Karanlık Modu Aç/Kapat"
   },
   "navigation": {
     "home": "Ana Sayfa",
@@ -68,7 +76,11 @@
     "settings": "Ayarlar",
     "about": "Hakkında",
     "logout": "Çıkış Yap",
-    "backupRestore": "Yedekleme & Geri Yükleme"
+    "backupRestore": "Yedekleme & Geri Yükleme",
+    "toggleSearch": "Aramayı Aç/Kapat",
+    "quickInboxCapture": "Hızlı Gelen Kutusu Yakalama",
+    "userMenu": "Kullanıcı Menüsü",
+    "search": "Ara"
   },
   "settings": {
     "todayPageSettings": "Bugün Sayfası Ayarları",
@@ -181,7 +193,9 @@
       "waiting": "Bekliyor",
       "done": "Tamamlandı",
       "dropHere": "Buraya bırak"
-    }
+    },
+    "chaseUp": "Takip et",
+    "habit": "Alışkanlık"
   },
   "timeline": {
     "activityTimeline": "Etkinlik Zaman Çizelgesi",
@@ -503,7 +517,9 @@
       "serverSettings": "Sunucu Ayarları",
       "syncSettings": "Senkranizasyon Ayarları",
       "setupSuccess": "Takvim başarıyla yapılandırıldı!",
-      "setupFailed": "Takvim oluşturulamadı"
+      "setupFailed": "Takvim oluşturulamadı",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/takvimler/kullanıcı/görevler"
     },
     "conflictResolver": {
       "title": "Senkronizasyon Çatışmalarını Çöz",
@@ -538,7 +554,9 @@
       "intervalError": "Senkronizasyon aralığı 1 ile 1440 dakika arasında olmalıdır",
       "updateSuccess": "Takvim başarıyla güncellendi",
       "updateError": "Takvimi güncelleme başarısız oldu"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@kullanıcıadı1, 123456789, @kullanıcıadı2"
   },
   "productivity": {
     "stalledProjects": "Duraklayan Projeler",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Projeyi kaydetmekte başarısız olundu.",
     "projectImageTooLarge": "Görüntü çok büyük. Lütfen 10MB'den küçük bir dosya seçin.",
     "projectImageUpload": "Görüntü yüklenemedi. Lütfen daha küçük bir dosya veya farklı bir format deneyin.",
-    "bannerSaveFailed": "Afiş kaydedilemedi"
+    "bannerSaveFailed": "Afiş kaydedilemedi",
+    "loginFailed": "Giriş başarısız oldu. Lütfen tekrar deneyin.",
+    "generalError": "Bir hata oluştu. Lütfen tekrar deneyin.",
+    "viewNameRequired": "Görünüm adı gereklidir",
+    "viewSaveFailed": "Görünümü kaydetme başarısız oldu. Lütfen tekrar deneyin."
   },
   "inbox": {
     "title": "Gelen Kutusu",
@@ -810,7 +832,9 @@
     "loadMoreError": "Daha fazla öğe yüklenemedi",
     "loading": "Yükleniyor...",
     "loadMore": "Daha fazla gelen kutusu öğesi yükle",
-    "showingItems": "{{current}} / {{total}} öğe gösteriliyor"
+    "showingItems": "{{current}} / {{total}} öğe gösteriliyor",
+    "removeTag": "Etiketi kaldır",
+    "removeProject": "Projeyi kaldır"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Sonraki en iyi eylem",
     "focusTask": "En etkili görev",
     "focusHint": "Bu görevi devam ediyor ve bugün'e taşır",
-    "noNextAction": "Her şey açık - bekleyen görev yok."
+    "noNextAction": "Her şey açık - bekleyen görev yok.",
+    "selectDueDatePlaceholder": "Son tarihi seç",
+    "goalTitle": "Hedef"
   },
   "projectItem": {
     "edit": "Düzenle",
@@ -1088,7 +1114,14 @@
     "error": "Alan detayları yüklenirken hata oluştu.",
     "notFound": "Alan bulunamadı.",
     "details": "Alan Detayları",
-    "viewProjects": "{{name}}'deki Projeleri Görüntüle"
+    "viewProjects": "{{name}}'deki Projeleri Görüntüle",
+    "goalTitlePlaceholder": "Hedef başlığı",
+    "goalWhyPlaceholder": "Neden önemli? (isteğe bağlı)",
+    "editGoal": "Hedefi düzenle",
+    "deleteGoal": "Hedefi sil",
+    "moveBackToUnlinked": "Bağlantısız olanlara geri taşı",
+    "horizonSeason": "Sezon",
+    "horizonYear": "Yıl"
   },
   "notes": {
     "loading": "Notlar yükleniyor...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Notu sil {{noteTitle}}",
     "deleteNoteTitle": "Notu sil {{noteTitle}}",
     "editNoteAriaLabel": "Notu düzenle {{noteTitle}}",
-    "editNoteTitle": "Notu düzenle {{noteTitle}}"
+    "editNoteTitle": "Notu düzenle {{noteTitle}}",
+    "titlePlaceholder": "Not başlığı...",
+    "contentPlaceholder": "Not içeriğinizi buraya yazın... (Markdown destekleniyor)",
+    "focusMode": "Odak modu",
+    "noteOptions": "Not seçenekleri",
+    "clickToEdit": "Düzenlemek için tıklayın",
+    "contentPlaceholderFocus": "Notunuzu yazın... (Markdown destekleniyor)",
+    "contentPlaceholderMarkdown": "İçeriğinizi Markdown formatında yazın...\n\nÖrnekler:\n# Başlık\n**Kalın metin**\n*İtalik metin*\n- Liste maddesi\n```kod```"
   },
   "tags": {
     "loading": "Etiketler yükleniyor...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Sistem etiketleri",
     "systemTagDescription": "Uygulama tarafından otomatik olarak oluşturulmuştur. Yerleşik özellikleri güçlendirir ve yeniden adlandırılamaz veya silinemez.",
     "userTag": "Kullanıcı etiketleri",
-    "userTagDescription": "Görevleri, notları ve projeleri düzenlemek için kendi etiketleriniz."
+    "userTagDescription": "Görevleri, notları ve projeleri düzenlemek için kendi etiketleriniz.",
+    "systemTags": "Sistem Etiketleri",
+    "systemTagsDescription": "Otomatik olarak yönetilir · Silinemez veya yeniden adlandırılamaz",
+    "system": "Sistem",
+    "customize": "Özelleştir"
   },
   "recurrence": {
     "none": "Yok",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Öncelik:",
     "dueLabel": "Son Tarih:",
     "tags": "Etiketler",
-    "recurring": "Tekrarlayan"
+    "recurring": "Tekrarlayan",
+    "saveAsSmartView": "Akıllı Görünüm Olarak Kaydet",
+    "viewNamePlaceholder": "Görünüm adını girin",
+    "viewNameLabel": "Görünüm Adı",
+    "viewWillSave": "Bu görünüm kaydedilecek:",
+    "saveView": "Görünümü Kaydet",
+    "filtersLabel": "Filtreler:",
+    "searchLabel": "Ara:"
   },
   "search": {
     "placeholder": "Görevleri, projeleri, notları ara...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Bitirildi ve tamamlandı",
     "cancelled": "İptal Edildi",
     "cancelled_desc": "Tamamlanmayacak"
+  },
+  "habits": {
+    "completeHabit": "Alışkanlığı Tamamla"
+  },
+  "aiAssistant": {
+    "title": "Yapay Zeka Asistanı",
+    "generatedAt": "{{time}} tarihinde oluşturuldu",
+    "emptyState": "'Kısa Rapor Oluştur' butonuna tıklayarak yapay zeka destekli günlük özetinizi alın.",
+    "focusForToday": "Bugünkü Odak",
+    "priorityActions": "Öncelikli Eylemler",
+    "taskInsightsTitle": "Yapay Zeka İçgörüleri",
+    "projectInsightsTitle": "Yapay Zeka İçgörüleri",
+    "taskInsight": "Bu görev hakkında",
+    "taskNextStep": "Sonraki adım",
+    "taskBreakdown": "Nasıl yaklaşılır",
+    "projectInsight": "Bu proje hakkında",
+    "projectNextAction": "Sonraki eylem",
+    "projectHealth": "Proje durumu",
+    "watchOut": "Dikkat et",
+    "suggestedLinks": "Önerilen bağlantılar",
+    "generate": "Özet Oluştur",
+    "regenerate": "Yeniden Oluştur",
+    "generating": "Oluşturuluyor...",
+    "errorDefault": "İçgörüler oluşturulamadı. Lütfen tekrar deneyin.",
+    "lowContextTitle": "Harika bir öneri için yeterli bağlam yok",
+    "lowContextHint": "Daha iyi içgörüler elde etmek için bir açıklama, notlar, etiketler ekleyin veya bir proje atayın. Yine de aşağıda oluşturabilirsiniz.",
+    "generateAnyway": "Yine de oluştur",
+    "statTotal": "Toplam",
+    "statDone": "Tamamlandı",
+    "statActive": "Aktif",
+    "statOverdue": "Vadesi geçmiş"
   }
 }

--- a/public/locales/ua/translation.json
+++ b/public/locales/ua/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Так, відкинути",
     "uploading": "Завантаження...",
     "refresh": "Оновити",
-    "unlinking": "Відв'язування..."
+    "unlinking": "Відв'язування...",
+    "preview": "Попередній перегляд",
+    "download": "Завантажити",
+    "exitFocusMode": "Вийти з режиму фокусування",
+    "searchTimezones": "Шукати часові пояси...",
+    "dismiss": "Відхилити"
   },
   "sidebar": {
     "dashboard": "Дашборд",
@@ -58,7 +63,10 @@
     "unpinView": "Відкріпити перегляд",
     "pinView": "Закріпити перегляд",
     "eisenhower": "Матриця Айзенхауера",
-    "kanban": "Дошка Канбан"
+    "kanban": "Дошка Канбан",
+    "addHabitAriaLabel": "Додати звичку",
+    "addHabitTitle": "Додати звичку",
+    "toggleDarkMode": "Переключити темний режим"
   },
   "navigation": {
     "home": "Головна",
@@ -68,7 +76,11 @@
     "settings": "Налаштування",
     "about": "Про програму",
     "logout": "Вийти",
-    "backupRestore": "Резервне копіювання та відновлення"
+    "backupRestore": "Резервне копіювання та відновлення",
+    "toggleSearch": "Переключити пошук",
+    "quickInboxCapture": "Швидке захоплення вхідних повідомлень",
+    "userMenu": "Меню користувача",
+    "search": "Пошук"
   },
   "settings": {
     "todayPageSettings": "Налаштування сторінки Сьогодні",
@@ -181,7 +193,9 @@
       "waiting": "Очікування",
       "done": "Завершено",
       "dropHere": "Перетягніть сюди"
-    }
+    },
+    "chaseUp": "Нагадати",
+    "habit": "Звичка"
   },
   "timeline": {
     "activityTimeline": "Хронологія Активності",
@@ -287,7 +301,9 @@
     "nextUp": "Наступна найкраща дія",
     "focusTask": "Найвпливовіше завдання",
     "focusHint": "Переміщує це завдання до „Виконується\" та „Сьогодні\"",
-    "noNextAction": "Все готово - немає невиконаних завдань."
+    "noNextAction": "Все готово - немає невиконаних завдань.",
+    "selectDueDatePlaceholder": "Виберіть термін виконання",
+    "goalTitle": "Мета"
   },
   "projectItem": {
     "edit": "Редагувати",
@@ -452,7 +468,11 @@
     "failedToSaveTag": "Не вдалося зберегти тег.",
     "projectImageTooLarge": "Зображення занадто велике. Будь ласка, виберіть файл розміром до 10 МБ.",
     "projectImageUpload": "Не вдалося завантажити зображення. Будь ласка, спробуйте менший файл або інший формат.",
-    "bannerSaveFailed": "Не вдалося зберегти банер"
+    "bannerSaveFailed": "Не вдалося зберегти банер",
+    "loginFailed": "Не вдалося увійти. Будь ласка, спробуйте ще раз.",
+    "generalError": "Сталася помилка. Будь ласка, спробуйте ще раз.",
+    "viewNameRequired": "Назва перегляду є обов'язковою",
+    "viewSaveFailed": "Не вдалося зберегти перегляд. Будь ласка, спробуйте ще раз."
   },
   "success": {
     "noteUpdated": "Нотатку успішно оновлено!",
@@ -479,7 +499,14 @@
     "deleteNoteAriaLabel": "Видалити нотатку {{noteTitle}}",
     "deleteNoteTitle": "Видалити нотатку {{noteTitle}}",
     "editNoteAriaLabel": "Редагувати нотатку {{noteTitle}}",
-    "editNoteTitle": "Редагувати нотатку {{noteTitle}}"
+    "editNoteTitle": "Редагувати нотатку {{noteTitle}}",
+    "titlePlaceholder": "Назва нотатки...",
+    "contentPlaceholder": "Напишіть вміст вашої нотатки тут... (підтримується Markdown)",
+    "focusMode": "Режим фокусу",
+    "noteOptions": "Опції нотатки",
+    "clickToEdit": "Натисніть, щоб редагувати",
+    "contentPlaceholderFocus": "Напишіть вашу нотатку... (підтримується Markdown)",
+    "contentPlaceholderMarkdown": "Напишіть ваш вміст, використовуючи форматування Markdown...\n\nПриклади:\n# Заголовок\n**Жирний текст**\n*Курсивний текст*\n- Пункт списку\n```код```"
   },
   "recurrence": {
     "none": "Немає",
@@ -541,7 +568,9 @@
     "loadMoreError": "Не вдалося завантажити більше елементів",
     "loading": "Завантаження...",
     "loadMore": "Завантажити більше елементів вхідних повідомлень",
-    "showingItems": "Показано {{current}} з {{total}} елементів"
+    "showingItems": "Показано {{current}} з {{total}} елементів",
+    "removeTag": "Видалити тег",
+    "removeProject": "Видалити проект"
   },
   "project": {
     "projectImage": "Зображення проекту",
@@ -836,7 +865,9 @@
       "serverSettings": "Налаштування сервера",
       "syncSettings": "Налаштування синхронізації",
       "setupSuccess": "Календар успішно налаштовано!",
-      "setupFailed": "Не вдалося створити календар"
+      "setupFailed": "Не вдалося створити календар",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "Вирішення конфліктів синхронізації",
@@ -871,7 +902,9 @@
       "intervalError": "Інтервал синхронізації має бути між 1 і 1440 хвилинами",
       "updateSuccess": "Календар успішно оновлено",
       "updateError": "Не вдалося оновити календар"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "task": {
     "suggestions": {
@@ -1171,7 +1204,14 @@
     "error": "Помилка при завантаженні деталей області.",
     "notFound": "Область не знайдено.",
     "details": "Деталі області",
-    "viewProjects": "Переглянути проекти в {{name}}"
+    "viewProjects": "Переглянути проекти в {{name}}",
+    "goalTitlePlaceholder": "Назва мети",
+    "goalWhyPlaceholder": "Чому це важливо (необов'язково)",
+    "editGoal": "Редагувати мету",
+    "deleteGoal": "Видалити мету",
+    "moveBackToUnlinked": "Повернутися до нев'язаної",
+    "horizonSeason": "Сезон",
+    "horizonYear": "Рік"
   },
   "tags": {
     "loading": "Завантаження тегів...",
@@ -1195,7 +1235,11 @@
     "systemTag": "Системні теги",
     "systemTagDescription": "Створені автоматично додатком. Вони забезпечують вбудовані функції і не можуть бути перейменовані або видалені.",
     "userTag": "Теги користувача",
-    "userTagDescription": "Ваші власні теги для організації завдань, нотаток та проектів."
+    "userTagDescription": "Ваші власні теги для організації завдань, нотаток та проектів.",
+    "systemTags": "Системні теги",
+    "systemTagsDescription": "Автоматично керовані · Не можуть бути видалені або перейменовані",
+    "system": "Система",
+    "customize": "Налаштувати"
   },
   "pomodoro": {
     "play": "Грати",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Пріоритет:",
     "dueLabel": "Термін:",
     "tags": "Теги",
-    "recurring": "Повторювані"
+    "recurring": "Повторювані",
+    "saveAsSmartView": "Зберегти як Розумний перегляд",
+    "viewNamePlaceholder": "Введіть назву перегляду",
+    "viewNameLabel": "Назва перегляду",
+    "viewWillSave": "Цей перегляд буде збережено:",
+    "saveView": "Зберегти перегляд",
+    "filtersLabel": "Фільтри:",
+    "searchLabel": "Пошук:"
   },
   "search": {
     "placeholder": "Шукати завдання, проекти, нотатки...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Закінчено і виконано",
     "cancelled": "Скасовано",
     "cancelled_desc": "Не буде завершено"
+  },
+  "aiAssistant": {
+    "taskNextStep": "Наступний крок",
+    "taskBreakdown": "Як до цього підійти",
+    "projectInsight": "Про цей проєкт",
+    "projectNextAction": "Наступна дія",
+    "projectHealth": "Стан проєкту",
+    "watchOut": "Обережно",
+    "suggestedLinks": "Запропоновані посилання",
+    "generate": "Генерувати бриф",
+    "regenerate": "Перегенерувати",
+    "generating": "Генерація...",
+    "errorDefault": "Не вдалося згенерувати інсайти. Будь ласка, спробуйте ще раз.",
+    "lowContextTitle": "Недостатньо контексту для гарної пропозиції",
+    "lowContextHint": "Додайте опис, нотатки, теги або призначте проєкт, щоб отримати кращі інсайти. Ви все ще можете згенерувати нижче.",
+    "generateAnyway": "Генерувати все одно",
+    "statTotal": "Всього",
+    "statDone": "Зроблено",
+    "statActive": "Активно",
+    "statOverdue": "Прострочено",
+    "title": "AI Асистент",
+    "generatedAt": "Згенеровано о {{time}}",
+    "emptyState": "Натисніть 'Згенерувати короткий огляд', щоб отримати ваш щоденний підсумок на основі AI.",
+    "focusForToday": "Фокус на сьогодні",
+    "priorityActions": "Пріоритетні дії",
+    "taskInsightsTitle": "AI Інсайти",
+    "projectInsightsTitle": "AI Інсайти",
+    "taskInsight": "Про це завдання"
+  },
+  "habits": {
+    "completeHabit": "Завершити звичку"
   }
 }

--- a/public/locales/vi/translation.json
+++ b/public/locales/vi/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "Có, bỏ qua",
     "uploading": "Đang tải lên...",
     "refresh": "Làm mới",
-    "unlinking": "Ngắt liên kết..."
+    "unlinking": "Ngắt liên kết...",
+    "preview": "Xem trước",
+    "download": "Tải xuống",
+    "exitFocusMode": "Thoát chế độ tập trung",
+    "searchTimezones": "Tìm kiếm múi giờ...",
+    "dismiss": "Bỏ qua"
   },
   "sidebar": {
     "dashboard": "Bảng điều khiển",
@@ -58,7 +63,10 @@
     "unpinView": "Bỏ ghim chế độ xem",
     "pinView": "Ghim chế độ xem",
     "eisenhower": "Ma trận Eisenhower",
-    "kanban": "Bảng Kanban"
+    "kanban": "Bảng Kanban",
+    "addHabitAriaLabel": "Thêm Thói quen",
+    "addHabitTitle": "Thêm Thói quen",
+    "toggleDarkMode": "Chuyển đổi Chế độ Tối"
   },
   "navigation": {
     "home": "Trang chủ",
@@ -68,7 +76,11 @@
     "settings": "Cài đặt",
     "about": "Giới thiệu",
     "logout": "Đăng xuất",
-    "backupRestore": "Sao lưu & Khôi phục"
+    "backupRestore": "Sao lưu & Khôi phục",
+    "toggleSearch": "Chuyển đổi Tìm kiếm",
+    "quickInboxCapture": "Chụp nhanh Hộp thư đến",
+    "userMenu": "Menu Người dùng",
+    "search": "Tìm kiếm"
   },
   "settings": {
     "todayPageSettings": "Cài đặt Trang Hôm nay",
@@ -181,7 +193,9 @@
       "waiting": "Đang chờ",
       "done": "Đã hoàn thành",
       "dropHere": "Thả ở đây"
-    }
+    },
+    "chaseUp": "Theo dõi",
+    "habit": "Thói quen"
   },
   "timeline": {
     "activityTimeline": "Dòng Thời Gian Hoạt Động",
@@ -503,7 +517,9 @@
       "serverSettings": "Cài đặt Máy chủ",
       "syncSettings": "Cài đặt Đồng bộ",
       "setupSuccess": "Lịch đã được cấu hình thành công!",
-      "setupFailed": "Tạo lịch không thành công"
+      "setupFailed": "Tạo lịch không thành công",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "Giải quyết Xung đột Đồng bộ",
@@ -538,7 +554,9 @@
       "intervalError": "Khoảng thời gian đồng bộ phải nằm giữa 1 và 1440 phút",
       "updateSuccess": "Lịch đã được cập nhật thành công",
       "updateError": "Cập nhật lịch thất bại"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "productivity": {
     "stalledProjects": "Dự án Đang Tạm Dừng",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "Không thể lưu dự án.",
     "projectImageTooLarge": "Hình ảnh quá lớn. Vui lòng chọn tệp dưới 10MB.",
     "projectImageUpload": "Tải lên hình ảnh thất bại. Vui lòng thử tệp nhỏ hơn hoặc định dạng khác.",
-    "bannerSaveFailed": "Lưu biểu ngữ thất bại"
+    "bannerSaveFailed": "Lưu biểu ngữ thất bại",
+    "loginFailed": "Đăng nhập thất bại. Vui lòng thử lại.",
+    "generalError": "Đã xảy ra lỗi. Vui lòng thử lại.",
+    "viewNameRequired": "Tên chế độ xem là bắt buộc",
+    "viewSaveFailed": "Lưu chế độ xem không thành công. Vui lòng thử lại."
   },
   "inbox": {
     "title": "Hộp thư đến",
@@ -810,7 +832,9 @@
     "loadMoreError": "Không thể tải thêm mục",
     "loading": "Đang tải...",
     "loadMore": "Tải thêm mục trong hộp thư đến",
-    "showingItems": "Đang hiển thị {{current}} trong tổng số {{total}} mục"
+    "showingItems": "Đang hiển thị {{current}} trong tổng số {{total}} mục",
+    "removeTag": "Xóa thẻ",
+    "removeProject": "Xóa dự án"
   },
   "dateFormats": {
     "long": "EEEE, d tháng MMMM, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "Hành động tốt nhất tiếp theo",
     "focusTask": "Nhiệm vụ có tác động lớn nhất",
     "focusHint": "Chuyển nhiệm vụ này sang đang thực hiện và hôm nay",
-    "noNextAction": "Tất cả rõ ràng-không có nhiệm vụ nào chưa hoàn thành."
+    "noNextAction": "Tất cả rõ ràng-không có nhiệm vụ nào chưa hoàn thành.",
+    "selectDueDatePlaceholder": "Chọn ngày hết hạn",
+    "goalTitle": "Mục tiêu"
   },
   "projectItem": {
     "edit": "Chỉnh sửa",
@@ -1088,7 +1114,14 @@
     "error": "Lỗi khi tải chi tiết khu vực.",
     "notFound": "Không tìm thấy khu vực.",
     "details": "Chi tiết khu vực",
-    "viewProjects": "Xem dự án trong {{name}}"
+    "viewProjects": "Xem dự án trong {{name}}",
+    "goalTitlePlaceholder": "Tiêu đề mục tiêu",
+    "goalWhyPlaceholder": "Tại sao điều này quan trọng (tùy chọn)",
+    "editGoal": "Chỉnh sửa mục tiêu",
+    "deleteGoal": "Xóa mục tiêu",
+    "moveBackToUnlinked": "Di chuyển trở lại không liên kết",
+    "horizonSeason": "Mùa",
+    "horizonYear": "Năm"
   },
   "notes": {
     "loading": "Đang tải ghi chú...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "Xóa ghi chú {{noteTitle}}",
     "deleteNoteTitle": "Xóa ghi chú {{noteTitle}}",
     "editNoteAriaLabel": "Chỉnh sửa ghi chú {{noteTitle}}",
-    "editNoteTitle": "Chỉnh sửa ghi chú {{noteTitle}}"
+    "editNoteTitle": "Chỉnh sửa ghi chú {{noteTitle}}",
+    "titlePlaceholder": "Tiêu đề ghi chú...",
+    "contentPlaceholder": "Viết nội dung ghi chú của bạn ở đây... (Hỗ trợ Markdown)",
+    "focusMode": "Chế độ tập trung",
+    "noteOptions": "Tùy chọn ghi chú",
+    "clickToEdit": "Nhấp để chỉnh sửa",
+    "contentPlaceholderFocus": "Viết ghi chú của bạn... (Hỗ trợ Markdown)",
+    "contentPlaceholderMarkdown": "Viết nội dung của bạn bằng định dạng Markdown...\n\nVí dụ:\n# Tiêu đề\n**Văn bản in đậm**\n*Văn bản nghiêng*\n- Mục danh sách\n```code```"
   },
   "tags": {
     "loading": "Đang tải thẻ...",
@@ -1123,7 +1163,11 @@
     "systemTag": "Thẻ hệ thống",
     "systemTagDescription": "Được tạo tự động bởi ứng dụng. Chúng cung cấp các tính năng tích hợp sẵn và không thể được đổi tên hoặc xóa.",
     "userTag": "Thẻ người dùng",
-    "userTagDescription": "Các thẻ của riêng bạn để tổ chức nhiệm vụ, ghi chú và dự án."
+    "userTagDescription": "Các thẻ của riêng bạn để tổ chức nhiệm vụ, ghi chú và dự án.",
+    "systemTags": "Thẻ Hệ Thống",
+    "systemTagsDescription": "Quản lý tự động · Không thể xóa hoặc đổi tên",
+    "system": "Hệ Thống",
+    "customize": "Tùy Chỉnh"
   },
   "recurrence": {
     "none": "Không có",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "Độ ưu tiên:",
     "dueLabel": "Đến hạn:",
     "tags": "Thẻ",
-    "recurring": "Lặp lại"
+    "recurring": "Lặp lại",
+    "saveAsSmartView": "Lưu dưới dạng Smart View",
+    "viewNamePlaceholder": "Nhập tên xem",
+    "viewNameLabel": "Tên Xem",
+    "viewWillSave": "Xem này sẽ được lưu:",
+    "saveView": "Lưu Xem",
+    "filtersLabel": "Bộ lọc:",
+    "searchLabel": "Tìm kiếm:"
   },
   "search": {
     "placeholder": "Tìm kiếm nhiệm vụ, dự án, ghi chú...",
@@ -1556,5 +1607,36 @@
     "done_desc": "Đã hoàn tất và xong",
     "cancelled": "Đã hủy",
     "cancelled_desc": "Sẽ không được hoàn thành"
+  },
+  "habits": {
+    "completeHabit": "Hoàn thành thói quen"
+  },
+  "aiAssistant": {
+    "title": "Trợ Lý AI",
+    "generatedAt": "Tạo lúc {{time}}",
+    "emptyState": "Nhấn 'Tạo Tóm Tắt' để nhận tóm tắt hàng ngày được hỗ trợ bởi AI.",
+    "focusForToday": "Tập trung cho hôm nay",
+    "priorityActions": "Hành động ưu tiên",
+    "taskInsightsTitle": "Thông Tin AI",
+    "projectInsightsTitle": "Thông Tin AI",
+    "taskInsight": "Về nhiệm vụ này",
+    "taskNextStep": "Bước tiếp theo",
+    "taskBreakdown": "Cách tiếp cận",
+    "projectInsight": "Về dự án này",
+    "projectNextAction": "Hành động tiếp theo",
+    "projectHealth": "Tình trạng dự án",
+    "watchOut": "Cẩn thận",
+    "suggestedLinks": "Liên kết gợi ý",
+    "generate": "Tạo Tóm tắt",
+    "regenerate": "Tạo lại",
+    "generating": "Đang tạo...",
+    "errorDefault": "Không thể tạo thông tin. Vui lòng thử lại.",
+    "lowContextTitle": "Không đủ ngữ cảnh để có gợi ý tốt",
+    "lowContextHint": "Thêm mô tả, ghi chú, thẻ, hoặc gán một dự án để có thông tin tốt hơn. Bạn vẫn có thể tạo bên dưới.",
+    "generateAnyway": "Tạo bất chấp",
+    "statTotal": "Tổng cộng",
+    "statDone": "Đã hoàn thành",
+    "statActive": "Đang hoạt động",
+    "statOverdue": "Quá hạn"
   }
 }

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -25,7 +25,12 @@
     "yesDiscard": "是的，放弃",
     "uploading": "上传中...",
     "refresh": "刷新",
-    "unlinking": "正在解除链接..."
+    "unlinking": "正在解除链接...",
+    "preview": "预览",
+    "download": "下载",
+    "exitFocusMode": "退出专注模式",
+    "searchTimezones": "搜索时区...",
+    "dismiss": "关闭"
   },
   "sidebar": {
     "dashboard": "仪表板",
@@ -58,7 +63,10 @@
     "unpinView": "取消固定视图",
     "pinView": "固定视图",
     "eisenhower": "艾森豪威尔矩阵",
-    "kanban": "看板"
+    "kanban": "看板",
+    "addHabitAriaLabel": "添加习惯",
+    "addHabitTitle": "添加习惯",
+    "toggleDarkMode": "切换暗黑模式"
   },
   "navigation": {
     "home": "首页",
@@ -68,7 +76,11 @@
     "settings": "设置",
     "about": "关于",
     "logout": "注销",
-    "backupRestore": "备份与恢复"
+    "backupRestore": "备份与恢复",
+    "toggleSearch": "切换搜索",
+    "quickInboxCapture": "快速收件箱捕获",
+    "userMenu": "用户菜单",
+    "search": "搜索"
   },
   "settings": {
     "todayPageSettings": "今日页面设置",
@@ -181,7 +193,9 @@
       "waiting": "等待",
       "done": "完成",
       "dropHere": "拖放到这里"
-    }
+    },
+    "chaseUp": "催促",
+    "habit": "习惯"
   },
   "timeline": {
     "activityTimeline": "活动时间线",
@@ -503,7 +517,9 @@
       "serverSettings": "服务器设置",
       "syncSettings": "同步设置",
       "setupSuccess": "日历配置成功！",
-      "setupFailed": "创建日历失败"
+      "setupFailed": "创建日历失败",
+      "serverUrlPlaceholder": "https://caldav.example.com",
+      "calendarPathPlaceholder": "/calendars/user/tasks"
     },
     "conflictResolver": {
       "title": "解决同步冲突",
@@ -538,7 +554,9 @@
       "intervalError": "同步间隔必须在1到1440分钟之间",
       "updateSuccess": "日历更新成功",
       "updateError": "更新日历失败"
-    }
+    },
+    "telegramTokenPlaceholder": "123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ",
+    "telegramAllowedUsersPlaceholder": "@username1, 123456789, @username2"
   },
   "productivity": {
     "stalledProjects": "停滞项目",
@@ -777,7 +795,11 @@
     "projectSaveFailed": "保存项目失败。",
     "projectImageTooLarge": "图片太大。请选取一个小于10MB的文件。",
     "projectImageUpload": "上传图片失败。请尝试一个更小的文件或不同的格式。",
-    "bannerSaveFailed": "保存横幅失败"
+    "bannerSaveFailed": "保存横幅失败",
+    "loginFailed": "登录失败。请再试一次。",
+    "generalError": "发生错误。请再试一次。",
+    "viewNameRequired": "视图名称是必需的",
+    "viewSaveFailed": "保存视图失败。请再试一次。"
   },
   "inbox": {
     "title": "收件箱",
@@ -810,7 +832,9 @@
     "loadMoreError": "加载更多项目失败",
     "loading": "加载中...",
     "loadMore": "加载更多收件箱项目",
-    "showingItems": "显示 {{current}} / {{total}} 项"
+    "showingItems": "显示 {{current}} / {{total}} 项",
+    "removeTag": "移除标签",
+    "removeProject": "移除项目"
   },
   "dateFormats": {
     "long": "EEEE, MMMM d, yyyy",
@@ -1056,7 +1080,9 @@
     "nextUp": "下一个最佳行动",
     "focusTask": "最具影响力的任务",
     "focusHint": "将此任务移至进行中和今天",
-    "noNextAction": "一切正常--没有未完成的任务。"
+    "noNextAction": "一切正常--没有未完成的任务。",
+    "selectDueDatePlaceholder": "选择截止日期",
+    "goalTitle": "目标"
   },
   "projectItem": {
     "edit": "编辑",
@@ -1088,7 +1114,14 @@
     "error": "加载区域详情时出错。",
     "notFound": "未找到区域。",
     "details": "区域详情",
-    "viewProjects": "查看 {{name}} 中的项目"
+    "viewProjects": "查看 {{name}} 中的项目",
+    "goalTitlePlaceholder": "目标标题",
+    "goalWhyPlaceholder": "为什么这很重要（可选）",
+    "editGoal": "编辑目标",
+    "deleteGoal": "删除目标",
+    "moveBackToUnlinked": "移回未链接",
+    "horizonSeason": "季节",
+    "horizonYear": "年份"
   },
   "notes": {
     "loading": "加载笔记...",
@@ -1099,7 +1132,14 @@
     "deleteNoteAriaLabel": "删除笔记 {{noteTitle}}",
     "deleteNoteTitle": "删除笔记 {{noteTitle}}",
     "editNoteAriaLabel": "编辑笔记 {{noteTitle}}",
-    "editNoteTitle": "编辑笔记 {{noteTitle}}"
+    "editNoteTitle": "编辑笔记 {{noteTitle}}",
+    "titlePlaceholder": "笔记标题...",
+    "contentPlaceholder": "在这里写下你的笔记内容...（支持Markdown）",
+    "focusMode": "专注模式",
+    "noteOptions": "笔记选项",
+    "clickToEdit": "点击编辑",
+    "contentPlaceholderFocus": "写下你的笔记...（支持Markdown）",
+    "contentPlaceholderMarkdown": "使用Markdown格式编写内容...\n\n示例：\n# 标题\n**粗体文本**\n*斜体文本*\n- 列表项\n```代码```"
   },
   "tags": {
     "loading": "加载标签...",
@@ -1123,7 +1163,11 @@
     "systemTag": "系统标签",
     "systemTagDescription": "由应用程序自动创建。它们支持内置功能，无法重命名或删除。",
     "userTag": "用户标签",
-    "userTagDescription": "您自己用于组织任务、笔记和项目的标签。"
+    "userTagDescription": "您自己用于组织任务、笔记和项目的标签。",
+    "systemTags": "系统标签",
+    "systemTagsDescription": "自动管理 · 不能被删除或重命名",
+    "system": "系统",
+    "customize": "自定义"
   },
   "recurrence": {
     "none": "无",
@@ -1399,7 +1443,14 @@
     "priorityLabel": "优先级：",
     "dueLabel": "到期：",
     "tags": "标签",
-    "recurring": "循环"
+    "recurring": "循环",
+    "saveAsSmartView": "保存为智能视图",
+    "viewNamePlaceholder": "输入视图名称",
+    "viewNameLabel": "视图名称",
+    "viewWillSave": "此视图将保存：",
+    "saveView": "保存视图",
+    "filtersLabel": "过滤器：",
+    "searchLabel": "搜索："
   },
   "search": {
     "placeholder": "搜索任务、项目、笔记...",
@@ -1556,5 +1607,36 @@
     "done_desc": "已完成并结束",
     "cancelled": "已取消",
     "cancelled_desc": "将不会完成"
+  },
+  "habits": {
+    "completeHabit": "完成习惯"
+  },
+  "aiAssistant": {
+    "title": "AI 助手",
+    "generatedAt": "生成于 {{time}}",
+    "emptyState": "点击 '生成摘要' 获取您的 AI 驱动的每日总结。",
+    "focusForToday": "今天的重点",
+    "priorityActions": "优先行动",
+    "taskInsightsTitle": "AI 洞察",
+    "projectInsightsTitle": "AI 洞察",
+    "taskInsight": "关于此任务",
+    "taskNextStep": "下一步",
+    "taskBreakdown": "如何处理",
+    "projectInsight": "关于这个项目",
+    "projectNextAction": "下一步行动",
+    "projectHealth": "项目健康",
+    "watchOut": "注意",
+    "suggestedLinks": "建议的链接",
+    "generate": "生成简报",
+    "regenerate": "重新生成",
+    "generating": "正在生成...",
+    "errorDefault": "生成洞察失败。请再试一次。",
+    "lowContextTitle": "上下文不足，无法提供良好的建议",
+    "lowContextHint": "添加描述、备注、标签或分配项目以获得更好的洞察。您仍然可以在下面生成。",
+    "generateAnyway": "仍然生成",
+    "statTotal": "总计",
+    "statDone": "完成",
+    "statActive": "活跃",
+    "statOverdue": "逾期"
   }
 }


### PR DESCRIPTION
## Description

Replace hardcoded English strings with i18n translation keys across multiple frontend components, and add the corresponding new keys to all 24 language files.

## Type of Change

- [x] Bug fix (hardcoded strings break non-English locales)

## Components Updated

- `AttachmentCard` — Preview, Download, Delete button titles
- `TaskContentSection` — Edit, Preview button titles
- `TaskHeader`
- `AreaDetails` — goal form placeholders, horizon option labels, Edit/Delete/Unlink button titles
- `Areas`, `CalendarForm`, `SetupWizard`, `HabitsTodayWidget`, `NoteDetails`, `NoteModal`, `NotificationsDropdown`, `TelegramTab`, `AutoSuggestNextActionBox`, `ProjectDetails`, `ProjectModal`, `UrlPreview`, `Tags`, `LifeRadar`, `SaveViewModal`, `ViewDetail`

## New Translation Keys (all 24 languages)

- `areas.goalTitlePlaceholder`, `areas.goalWhyPlaceholder`, `areas.editGoal`, `areas.deleteGoal`, `areas.moveBackToUnlinked`, `areas.horizonSeason`, `areas.horizonYear`
- `habits.completeHabit`
- `caldav.telegramTokenPlaceholder`, `caldav.telegramAllowedUsersPlaceholder`, `caldav.serverUrlPlaceholder`, `caldav.calendarPathPlaceholder`
- `notes.contentPlaceholderMarkdown`
- `views.filtersLabel`, `views.searchLabel`
- `tasks.chaseUp`, `tasks.habit`, `tasks.selectDueDatePlaceholder`, `tasks.goalTitle`

## Testing

- Switch the app language to any non-English locale and verify previously hardcoded strings now display translated text
- Verify no visual regressions in English

## Checklist

- [x] Lint passes (`npm run lint`)
- [x] All 24 language files updated with new keys