### PR TITLE
fix(ai): show stale warning when daily brief is from a previous day

### DIFF
--- a/frontend/components/AI/DailyAssistant.tsx
+++ b/frontend/components/AI/DailyAssistant.tsx
@@ -8,18 +8,31 @@ import {
     FlagIcon,
     ExclamationTriangleIcon,
     FolderIcon,
+    ClockIcon,
 } from '@heroicons/react/24/outline';
 import { fetchDailyBrief, fetchCachedBrief, DailyBrief } from '../../utils/aiAssistantService';
+
+function isBriefFromToday(generatedAt: string): boolean {
+    const briefDate = new Date(generatedAt);
+    const now = new Date();
+    return (
+        briefDate.getFullYear() === now.getFullYear() &&
+        briefDate.getMonth() === now.getMonth() &&
+        briefDate.getDate() === now.getDate()
+    );
+}
 
 const DailyAssistant: React.FC = () => {
     const { t } = useTranslation();
     const [brief, setBrief] = useState<DailyBrief | null>(null);
+    const [isStale, setIsStale] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [isLoadingCached, setIsLoadingCached] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
     const generate = useCallback(async () => {
         setIsLoading(true);
+        setIsStale(false);
         setError(null);
         try {
             setBrief(await fetchDailyBrief());
@@ -35,6 +48,7 @@ const DailyAssistant: React.FC = () => {
             .then((cached) => {
                 if (cached) {
                     setBrief(cached);
+                    setIsStale(!isBriefFromToday(cached.generated_at));
                 } else {
                     generate();
                 }
@@ -83,6 +97,22 @@ const DailyAssistant: React.FC = () => {
                     )}
                 </button>
             </div>
+
+            {/* Stale warning */}
+            {isStale && brief && !isLoading && (
+                <div className="flex items-center gap-2 px-4 py-2 bg-amber-50 dark:bg-amber-900/10 border-b border-amber-100 dark:border-amber-800/30">
+                    <ClockIcon className="h-3.5 w-3.5 flex-shrink-0 text-amber-500" />
+                    <span className="text-xs text-amber-700 dark:text-amber-400">
+                        {t('aiAssistant.pastBriefWarning', {
+                            date: new Date(brief.generated_at).toLocaleDateString([], {
+                                weekday: 'long',
+                                month: 'short',
+                                day: 'numeric',
+                            }),
+                        })}
+                    </span>
+                </div>
+            )}
 
             {/* Body */}
             <div className="p-4 space-y-3">

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1597,6 +1597,7 @@
     "regenerate": "Regenerate",
     "generating": "Generating...",
     "errorDefault": "Failed to generate insights. Please try again.",
+    "pastBriefWarning": "This brief is from {{date}} and may no longer reflect today's tasks. Click Regenerate for a fresh brief.",
     "lowContextTitle": "Not enough context for a great suggestion",
     "lowContextHint": "Add a description, notes, tags, or assign a project to get better insights. You can still generate below.",
     "generateAnyway": "Generate anyway",


### PR DESCRIPTION
## Description

When the AI Daily Brief was generated on a previous day, it would silently display outdated content with no indication it was stale. This fix detects when the cached brief is from a prior day and shows a clear amber warning banner prompting the user to regenerate.

## Type of Change

- [x] Bug fix

## Changes

- Added `isBriefFromToday()` helper in `DailyAssistant.tsx` that compares `generated_at` to today's local date
- Added `isStale` state that is set when a cached brief is from a previous day
- Added an amber warning banner (with clock icon) between the header and body when the brief is stale: "This brief is from [date] and may no longer reflect today's tasks. Click Regenerate for a fresh brief."
- Stale state clears automatically when the user regenerates
- Added `aiAssistant.pastBriefWarning` i18n key to the English locale

## Testing

1. Generate a daily brief
2. Manually set `generated_at` on the stored brief to yesterday (or wait until the next day)
3. Reload the Today page — the amber stale warning should appear below the header
4. Click Regenerate — the warning disappears and fresh content is shown

## Checklist

- [x] Code follows project conventions
- [x] `npm run lint` passes
- [x] No new API calls introduced (stale detection is client-side only)