### PR TITLE
feat(people): add People management system with task assignment

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -256,6 +256,7 @@ const viewsModule = require('./modules/views');
 const mcpModule = require('./modules/mcp');
 const oidcModule = require('./modules/oidc');
 const aiAssistantModule = require('./modules/ai-assistant');
+const peopleModule = require('./modules/people');
 
 // Swagger documentation - enabled by default, protected by authentication
 // Mounted on /api-docs to avoid conflicts with API routes
@@ -341,6 +342,7 @@ const registerApiRoutes = (basePath) => {
     app.use(basePath, notificationsModule.routes);
     app.use(basePath, mcpModule.routes);
     app.use(basePath, aiAssistantModule.routes);
+    app.use(basePath, peopleModule.routes);
 };
 
 // Register routes at both /api and /api/v1 (if versioned) to maintain backwards compatibility

--- a/backend/migrations/20260630000001-create-people.js
+++ b/backend/migrations/20260630000001-create-people.js
@@ -1,0 +1,78 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable('people', {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            uid: {
+                type: Sequelize.STRING(15),
+                allowNull: false,
+                unique: true,
+            },
+            user_id: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'users',
+                    key: 'id',
+                },
+                onUpdate: 'CASCADE',
+                onDelete: 'CASCADE',
+            },
+            name: {
+                type: Sequelize.STRING(255),
+                allowNull: false,
+            },
+            relationship_type: {
+                type: Sequelize.STRING(50),
+                allowNull: true,
+                defaultValue: 'other',
+            },
+            email: {
+                type: Sequelize.STRING(255),
+                allowNull: true,
+            },
+            phone: {
+                type: Sequelize.STRING(50),
+                allowNull: true,
+            },
+            notes: {
+                type: Sequelize.TEXT,
+                allowNull: true,
+            },
+            archived: {
+                type: Sequelize.BOOLEAN,
+                allowNull: false,
+                defaultValue: false,
+            },
+            created_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+            },
+            updated_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+            },
+        });
+
+        await queryInterface.addIndex('people', ['user_id', 'archived'], {
+            name: 'people_user_archived_idx',
+        });
+        await queryInterface.addIndex('people', ['user_id', 'name'], {
+            name: 'people_user_name_idx',
+            unique: true,
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeIndex('people', 'people_user_name_idx');
+        await queryInterface.removeIndex('people', 'people_user_archived_idx');
+        await queryInterface.dropTable('people');
+    },
+};

--- a/backend/migrations/20260630000002-add-people-to-tasks.js
+++ b/backend/migrations/20260630000002-add-people-to-tasks.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn('tasks', 'assigned_to', {
+            type: Sequelize.STRING(15),
+            allowNull: true,
+            defaultValue: null,
+            references: {
+                model: 'people',
+                key: 'uid',
+            },
+            onUpdate: 'CASCADE',
+            onDelete: 'SET NULL',
+        });
+
+        await queryInterface.addColumn('tasks', 'involves', {
+            type: Sequelize.TEXT,
+            allowNull: true,
+            defaultValue: null,
+        });
+
+        await queryInterface.addIndex('tasks', ['assigned_to'], {
+            name: 'tasks_assigned_to_idx',
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeIndex('tasks', 'tasks_assigned_to_idx');
+        await queryInterface.removeColumn('tasks', 'involves');
+        await queryInterface.removeColumn('tasks', 'assigned_to');
+    },
+};

--- a/backend/migrations/20260630000003-add-color-to-people.js
+++ b/backend/migrations/20260630000003-add-color-to-people.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.addColumn('people', 'color', {
+            type: Sequelize.STRING(20),
+            allowNull: true,
+            defaultValue: null,
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeColumn('people', 'color');
+    },
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -79,6 +79,7 @@ const CalDAVOccurrenceOverride = require('./caldav_occurrence_override')(
 const CalDAVRemoteCalendar = require('./caldav_remote_calendar')(sequelize);
 const CalendarToken = require('./calendar_token')(sequelize);
 const Goal = require('./goal')(sequelize);
+const Person = require('./person')(sequelize);
 
 User.hasMany(Area, { foreignKey: 'user_id' });
 Area.belongsTo(User, { foreignKey: 'user_id' });
@@ -271,6 +272,21 @@ User.hasMany(CalendarToken, {
 });
 CalendarToken.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
 
+// Person associations
+User.hasMany(Person, { foreignKey: 'user_id', as: 'People' });
+Person.belongsTo(User, { foreignKey: 'user_id' });
+Task.belongsTo(Person, {
+    foreignKey: 'assigned_to',
+    targetKey: 'uid',
+    as: 'AssignedTo',
+    allowNull: true,
+});
+Person.hasMany(Task, {
+    foreignKey: 'assigned_to',
+    sourceKey: 'uid',
+    as: 'AssignedTasks',
+});
+
 // Seed system tags for every new user
 User.addHook('afterCreate', async (user) => {
     try {
@@ -312,4 +328,5 @@ module.exports = {
     CalDAVOccurrenceOverride,
     CalDAVRemoteCalendar,
     CalendarToken,
+    Person,
 };

--- a/backend/models/person.js
+++ b/backend/models/person.js
@@ -1,0 +1,68 @@
+const { DataTypes } = require('sequelize');
+const { uid } = require('../utils/uid');
+
+module.exports = (sequelize) => {
+    const Person = sequelize.define(
+        'Person',
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            uid: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                unique: true,
+                defaultValue: uid,
+            },
+            user_id: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'users',
+                    key: 'id',
+                },
+            },
+            name: {
+                type: DataTypes.STRING,
+                allowNull: false,
+            },
+            relationship_type: {
+                type: DataTypes.STRING,
+                allowNull: true,
+                defaultValue: 'other',
+            },
+            email: {
+                type: DataTypes.STRING,
+                allowNull: true,
+            },
+            phone: {
+                type: DataTypes.STRING,
+                allowNull: true,
+            },
+            notes: {
+                type: DataTypes.TEXT,
+                allowNull: true,
+            },
+            archived: {
+                type: DataTypes.BOOLEAN,
+                allowNull: false,
+                defaultValue: false,
+            },
+            color: {
+                type: DataTypes.STRING(20),
+                allowNull: true,
+            },
+        },
+        {
+            tableName: 'people',
+            indexes: [
+                { fields: ['user_id', 'archived'] },
+                { fields: ['user_id', 'name'], unique: true },
+            ],
+        }
+    );
+
+    return Person;
+};

--- a/backend/models/task.js
+++ b/backend/models/task.js
@@ -206,6 +206,30 @@ module.exports = (sequelize) => {
                 allowNull: true,
                 defaultValue: null,
             },
+            assigned_to: {
+                type: DataTypes.STRING,
+                allowNull: true,
+                defaultValue: null,
+                references: {
+                    model: 'people',
+                    key: 'uid',
+                },
+            },
+            involves: {
+                type: DataTypes.TEXT,
+                allowNull: true,
+                defaultValue: null,
+                get() {
+                    const raw = this.getDataValue('involves');
+                    return raw ? JSON.parse(raw) : [];
+                },
+                set(value) {
+                    this.setDataValue(
+                        'involves',
+                        value && value.length > 0 ? JSON.stringify(value) : null
+                    );
+                },
+            },
         },
         {
             tableName: 'tasks',

--- a/backend/modules/people/controller.js
+++ b/backend/modules/people/controller.js
@@ -1,0 +1,74 @@
+'use strict';
+
+const peopleService = require('./service');
+const { getAuthenticatedUserId } = require('../../utils/request-utils');
+const { UnauthorizedError } = require('../../shared/errors');
+
+function requireUserId(req) {
+    const userId = getAuthenticatedUserId(req);
+    if (!userId) throw new UnauthorizedError('Authentication required');
+    return userId;
+}
+
+const peopleController = {
+    async list(req, res, next) {
+        try {
+            const userId = requireUserId(req);
+            const { archived, sort, relationship_type } = req.query;
+            const people = await peopleService.getAll(userId, {
+                archived,
+                sort,
+                relationship_type,
+            });
+            res.json({ people });
+        } catch (err) {
+            next(err);
+        }
+    },
+
+    async getOne(req, res, next) {
+        try {
+            const userId = requireUserId(req);
+            const person = await peopleService.getByUid(userId, req.params.uid);
+            res.json(person);
+        } catch (err) {
+            next(err);
+        }
+    },
+
+    async create(req, res, next) {
+        try {
+            const userId = requireUserId(req);
+            const person = await peopleService.create(userId, req.body);
+            res.status(201).json({ person });
+        } catch (err) {
+            next(err);
+        }
+    },
+
+    async update(req, res, next) {
+        try {
+            const userId = requireUserId(req);
+            const person = await peopleService.update(
+                userId,
+                req.params.uid,
+                req.body
+            );
+            res.json({ person });
+        } catch (err) {
+            next(err);
+        }
+    },
+
+    async delete(req, res, next) {
+        try {
+            const userId = requireUserId(req);
+            await peopleService.delete(userId, req.params.uid);
+            res.status(204).send();
+        } catch (err) {
+            next(err);
+        }
+    },
+};
+
+module.exports = peopleController;

--- a/backend/modules/people/index.js
+++ b/backend/modules/people/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const routes = require('./routes');
+const peopleService = require('./service');
+const peopleRepository = require('./repository');
+
+module.exports = { routes, peopleService, peopleRepository };

--- a/backend/modules/people/repository.js
+++ b/backend/modules/people/repository.js
@@ -1,0 +1,57 @@
+'use strict';
+
+const { Person, Task } = require('../../models');
+const { Op } = require('sequelize');
+
+class PeopleRepository {
+    async findAllByUser(
+        userId,
+        { archived = false, sort = 'name', relationship_type } = {}
+    ) {
+        const where = { user_id: userId };
+        if (archived !== null) {
+            where.archived = archived === true || archived === 'true';
+        }
+        if (relationship_type) {
+            where.relationship_type = relationship_type;
+        }
+
+        const order =
+            sort === 'created_at'
+                ? [['created_at', 'DESC']]
+                : [['name', 'ASC']];
+
+        return Person.findAll({ where, order });
+    }
+
+    async findByUid(userId, uid) {
+        return Person.findOne({ where: { uid, user_id: userId } });
+    }
+
+    async nameExists(userId, name, excludeUid = null) {
+        const where = { user_id: userId, name };
+        if (excludeUid) {
+            where.uid = { [Op.ne]: excludeUid };
+        }
+        const count = await Person.count({ where });
+        return count > 0;
+    }
+
+    async create(data) {
+        return Person.create(data);
+    }
+
+    async update(person, data) {
+        return person.update(data);
+    }
+
+    async delete(person) {
+        return person.destroy();
+    }
+
+    async countAssignedTasks(personUid) {
+        return Task.count({ where: { assigned_to: personUid } });
+    }
+}
+
+module.exports = new PeopleRepository();

--- a/backend/modules/people/routes.js
+++ b/backend/modules/people/routes.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const peopleController = require('./controller');
+
+router.get('/people', peopleController.list);
+router.get('/people/:uid', peopleController.getOne);
+router.post('/people', peopleController.create);
+router.patch('/people/:uid', peopleController.update);
+router.delete('/people/:uid', peopleController.delete);
+
+module.exports = router;

--- a/backend/modules/people/service.js
+++ b/backend/modules/people/service.js
@@ -1,0 +1,131 @@
+'use strict';
+
+const peopleRepository = require('./repository');
+const {
+    NotFoundError,
+    ValidationError,
+    ConflictError,
+} = require('../../shared/errors');
+
+const VALID_RELATIONSHIP_TYPES = ['family', 'work', 'friend', 'other'];
+
+class PeopleService {
+    async getAll(userId, filters = {}) {
+        return peopleRepository.findAllByUser(userId, filters);
+    }
+
+    async getByUid(userId, uid) {
+        const person = await peopleRepository.findByUid(userId, uid);
+        if (!person) throw new NotFoundError('Person not found');
+        return person;
+    }
+
+    async create(userId, data) {
+        const { name, relationship_type, email, phone, notes, color } = data;
+
+        if (!name || !name.trim()) {
+            throw new ValidationError('Name is required');
+        }
+
+        if (
+            relationship_type &&
+            !VALID_RELATIONSHIP_TYPES.includes(relationship_type)
+        ) {
+            throw new ValidationError(
+                `relationship_type must be one of: ${VALID_RELATIONSHIP_TYPES.join(', ')}`
+            );
+        }
+
+        const exists = await peopleRepository.nameExists(userId, name.trim());
+        if (exists) {
+            throw new ConflictError(
+                `Person named '${name.trim()}' already exists`
+            );
+        }
+
+        return peopleRepository.create({
+            user_id: userId,
+            name: name.trim(),
+            relationship_type: relationship_type || 'other',
+            email: email || null,
+            phone: phone || null,
+            notes: notes || null,
+            color: color || null,
+            archived: false,
+        });
+    }
+
+    async update(userId, uid, data) {
+        const person = await peopleRepository.findByUid(userId, uid);
+        if (!person) throw new NotFoundError('Person not found');
+
+        const {
+            name,
+            relationship_type,
+            email,
+            phone,
+            notes,
+            color,
+            archived,
+        } = data;
+        const updates = {};
+
+        if (name !== undefined) {
+            if (!name.trim()) throw new ValidationError('Name cannot be empty');
+            const exists = await peopleRepository.nameExists(
+                userId,
+                name.trim(),
+                uid
+            );
+            if (exists)
+                throw new ConflictError(
+                    `Person named '${name.trim()}' already exists`
+                );
+            updates.name = name.trim();
+        }
+
+        if (relationship_type !== undefined) {
+            if (
+                relationship_type &&
+                !VALID_RELATIONSHIP_TYPES.includes(relationship_type)
+            ) {
+                throw new ValidationError(
+                    `relationship_type must be one of: ${VALID_RELATIONSHIP_TYPES.join(', ')}`
+                );
+            }
+            updates.relationship_type = relationship_type || 'other';
+        }
+
+        if (email !== undefined) updates.email = email || null;
+        if (phone !== undefined) updates.phone = phone || null;
+        if (notes !== undefined) updates.notes = notes || null;
+        if (color !== undefined) updates.color = color || null;
+        if (archived !== undefined) updates.archived = !!archived;
+
+        return peopleRepository.update(person, updates);
+    }
+
+    async delete(userId, uid) {
+        const person = await peopleRepository.findByUid(userId, uid);
+        if (!person) throw new NotFoundError('Person not found');
+
+        const assignedCount = await peopleRepository.countAssignedTasks(uid);
+        if (assignedCount > 0) {
+            throw new ValidationError(
+                `Cannot delete: ${assignedCount} task${assignedCount === 1 ? '' : 's'} assigned to this person. Archive or unassign first.`
+            );
+        }
+
+        await peopleRepository.delete(person);
+    }
+
+    async archive(userId, uid) {
+        return this.update(userId, uid, { archived: true });
+    }
+
+    async unarchive(userId, uid) {
+        return this.update(userId, uid, { archived: false });
+    }
+}
+
+module.exports = new PeopleService();

--- a/backend/modules/tasks/core/builders.js
+++ b/backend/modules/tasks/core/builders.js
@@ -170,6 +170,14 @@ function buildTaskAttributes(body, userId, timezone, isUpdate = false) {
         attrs.user_id = userId;
     }
 
+    if (body.assigned_to !== undefined) {
+        attrs.assigned_to = body.assigned_to || null;
+    }
+
+    if (body.involves !== undefined) {
+        attrs.involves = Array.isArray(body.involves) ? body.involves : [];
+    }
+
     return attrs;
 }
 
@@ -254,6 +262,14 @@ function buildUpdateAttributes(body, task, timezone) {
             body.defer_until,
             timezone
         );
+    }
+
+    if (body.assigned_to !== undefined) {
+        attrs.assigned_to = body.assigned_to || null;
+    }
+
+    if (body.involves !== undefined) {
+        attrs.involves = Array.isArray(body.involves) ? body.involves : [];
     }
 
     return attrs;

--- a/backend/modules/tasks/queries/query-builders.js
+++ b/backend/modules/tasks/queries/query-builders.js
@@ -417,6 +417,10 @@ async function filterTasksByParams(
         whereClause.area_id = params.area_id;
     }
 
+    if (params.assigned_to) {
+        whereClause.assigned_to = params.assigned_to;
+    }
+
     const finalWhereClause = {
         [Op.and]: [ownedOrShared, whereClause],
     };

--- a/backend/scripts/db-migrate.js
+++ b/backend/scripts/db-migrate.js
@@ -2,24 +2,51 @@
 
 /**
  * Database Migration Script
- * Migrates the database by altering existing tables to match current models
+ * Runs pending Umzug migration files to update the database schema
  */
 
 require('dotenv').config();
-const { sequelize } = require('../models');
+const path = require('path');
+const { Sequelize } = require('sequelize');
+const Umzug = require('umzug');
+const { getConfig } = require('../config/config');
+
+const config = getConfig();
+
+const sequelize = new Sequelize({
+    dialect: 'sqlite',
+    storage: config.dbFile,
+    logging: false,
+});
+
+const umzug = new Umzug({
+    migrations: {
+        path: path.join(__dirname, '../migrations'),
+        params: [sequelize.getQueryInterface(), Sequelize],
+    },
+    storage: 'sequelize',
+    storageOptions: { sequelize },
+});
 
 async function migrateDatabase() {
     try {
-        console.log('Migrating database...');
-        console.log('This will alter existing tables to match current models');
-
-        await sequelize.sync({ alter: true });
-
-        console.log('✅ Database migrated successfully');
-        console.log('All tables have been updated to match current models');
+        console.log('Running pending migrations...');
+        const pending = await umzug.pending();
+        if (pending.length === 0) {
+            console.log(
+                '✅ No pending migrations - database schema is up to date'
+            );
+        } else {
+            console.log(`Found ${pending.length} pending migration(s):`);
+            pending.forEach((m) => console.log(`  - ${m.file}`));
+            await umzug.up();
+            console.log('✅ Migrations completed successfully');
+        }
+        await sequelize.close();
         process.exit(0);
     } catch (error) {
-        console.error('❌ Error migrating database:', error.message);
+        console.error('❌ Error running migrations:', error.message);
+        await sequelize.close();
         process.exit(1);
     }
 }

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -29,6 +29,8 @@ import Habits from './components/Habits/Habits';
 import HabitDetails from './components/Habits/HabitDetails';
 import EisenhowerMatrix from './components/Eisenhower/EisenhowerMatrix';
 import KanbanBoard from './components/Kanban/KanbanBoard';
+import PeopleList from './components/People/PeopleList';
+import PersonDetails from './components/People/PersonDetails';
 import { setCurrentUser as setUserInStorage } from './utils/userUtils';
 import { getApiPath, getLocalesPath } from './config/paths';
 import { useStore } from './store/useStore';
@@ -290,6 +292,8 @@ const App: React.FC = () => {
                                 element={<About isDarkMode={isDarkMode} />}
                             />
                             <Route path="/backup" element={<BackupRestore />} />
+                            <Route path="/people" element={<PeopleList />} />
+                            <Route path="/person/:uid" element={<PersonDetails />} />
                             <Route
                                 path="/admin/users"
                                 element={

--- a/frontend/components/AI/ProjectAIInsights.tsx
+++ b/frontend/components/AI/ProjectAIInsights.tsx
@@ -52,6 +52,7 @@ const ProjectAIInsights = forwardRef<
     const [noCache, setNoCache] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [isVisible, setIsVisible] = useState(false);
 
     const buildPayload = (): ProjectInsightsRequest => ({
         projectUid: project.uid,
@@ -79,6 +80,7 @@ const ProjectAIInsights = forwardRef<
     });
 
     const dismiss = () => {
+        setIsVisible(false);
         setDismissed(true);
         if (project.uid) updateProjectInsightsDismissed(project.uid, true).catch(() => {});
     };
@@ -107,12 +109,15 @@ const ProjectAIInsights = forwardRef<
     useImperativeHandle(ref, () => ({
         activate: () => {
             if (isInitializing) return;
-            if (noCache) {
-                generate();
-            } else if (dismissed) {
-                show();
-            } else {
+            if (isVisible) {
                 dismiss();
+            } else {
+                setIsVisible(true);
+                if (noCache) {
+                    generate();
+                } else if (dismissed) {
+                    show();
+                }
             }
         },
     }));
@@ -120,12 +125,12 @@ const ProjectAIInsights = forwardRef<
     const prevActiveRef = useRef<boolean | null>(null);
     useEffect(() => {
         if (isInitializing) return;
-        const isActive = !dismissed && (!!insights || isLoading || !!error);
+        const isActive = isVisible && !dismissed && (!!insights || isLoading || !!error);
         if (prevActiveRef.current !== isActive) {
             prevActiveRef.current = isActive;
             onActiveChange?.(isActive);
         }
-    }, [dismissed, insights, isLoading, error, isInitializing]);
+    }, [isVisible, dismissed, insights, isLoading, error, isInitializing]);
 
     useEffect(() => {
         let cancelled = false;
@@ -136,6 +141,7 @@ const ProjectAIInsights = forwardRef<
         setError(null);
         setIsLoading(false);
         setIsInitializing(true);
+        setIsVisible(false);
 
         const init = async () => {
             if (project.uid) {
@@ -165,6 +171,8 @@ const ProjectAIInsights = forwardRef<
             cancelled = true;
         };
     }, [project.uid]);
+
+    if (!isVisible) return null;
 
     if (isInitializing) {
         return (

--- a/frontend/components/People/PeopleList.tsx
+++ b/frontend/components/People/PeopleList.tsx
@@ -1,0 +1,337 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { Link } from 'react-router-dom';
+import {
+    EllipsisVerticalIcon,
+    PlusIcon,
+    EnvelopeIcon,
+} from '@heroicons/react/24/outline';
+import ConfirmDialog from '../Shared/ConfirmDialog';
+import PersonModal from './PersonModal';
+import { Person } from '../../entities/Person';
+import { fetchPeople, createPerson, updatePerson, deletePerson } from '../../utils/peopleService';
+import { useToast } from '../Shared/ToastContext';
+
+const RELATIONSHIP_LABELS: Record<string, string> = {
+    family: 'Family',
+    work: 'Work',
+    friend: 'Friend',
+    other: 'Other',
+};
+
+const PeopleList: React.FC = () => {
+    const { showSuccessToast, showErrorToast } = useToast();
+    const [people, setPeople] = useState<Person[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [showArchived, setShowArchived] = useState(false);
+    const [modalOpen, setModalOpen] = useState(false);
+    const [editingPerson, setEditingPerson] = useState<Person | null>(null);
+    const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
+    const [personToDelete, setPersonToDelete] = useState<Person | null>(null);
+    const [dropdownOpen, setDropdownOpen] = useState<string | null>(null);
+    const justOpenedRef = useRef<boolean>(false);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
+    const load = async () => {
+        setIsLoading(true);
+        try {
+            const all = await fetchPeople({ archived: showArchived ? undefined : false } as any);
+            setPeople(all);
+        } catch {
+            showErrorToast('Failed to load people');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        load();
+    }, [showArchived]);
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (justOpenedRef.current) {
+                justOpenedRef.current = false;
+                return;
+            }
+            const clickedElement = event.target as Node;
+            if (dropdownRef.current && !dropdownRef.current.contains(clickedElement)) {
+                setDropdownOpen(null);
+            }
+        };
+
+        if (dropdownOpen !== null) {
+            const timeoutId = setTimeout(() => {
+                document.addEventListener('mousedown', handleClickOutside);
+            }, 100);
+            return () => {
+                clearTimeout(timeoutId);
+                document.removeEventListener('mousedown', handleClickOutside);
+            };
+        }
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [dropdownOpen]);
+
+    const handleSave = async (data: Partial<Person>) => {
+        if (editingPerson?.uid) {
+            const result = await updatePerson(editingPerson.uid, data);
+            setPeople((prev) => prev.map((p) => (p.uid === editingPerson.uid ? result.person : p)));
+            showSuccessToast('Person updated');
+        } else {
+            const result = await createPerson(data as any);
+            setPeople((prev) => [...prev, result.person].sort((a, b) => a.name.localeCompare(b.name)));
+            showSuccessToast('Person created');
+        }
+    };
+
+    const handleArchive = async (person: Person) => {
+        try {
+            const result = await updatePerson(person.uid!, { archived: !person.archived });
+            setPeople((prev) => prev.map((p) => (p.uid === person.uid ? result.person : p)));
+            showSuccessToast(person.archived ? 'Person unarchived' : 'Person archived');
+        } catch (err: unknown) {
+            showErrorToast(err instanceof Error ? err.message : 'Failed to archive person');
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!personToDelete) return;
+        try {
+            await deletePerson(personToDelete.uid!);
+            setPeople((prev) => prev.filter((p) => p.uid !== personToDelete.uid));
+            showSuccessToast('Person deleted');
+        } catch (err: unknown) {
+            showErrorToast(err instanceof Error ? err.message : 'Failed to delete person');
+        } finally {
+            setIsConfirmDialogOpen(false);
+            setPersonToDelete(null);
+        }
+    };
+
+    const openCreate = () => {
+        setEditingPerson(null);
+        setModalOpen(true);
+    };
+
+    const openEdit = (person: Person) => {
+        setEditingPerson(person);
+        setModalOpen(true);
+    };
+
+    const openDeleteConfirm = (person: Person) => {
+        setPersonToDelete(person);
+        setIsConfirmDialogOpen(true);
+    };
+
+    const displayPeople = showArchived ? people : people.filter((p) => !p.archived);
+
+    const groupedPeople = displayPeople.reduce(
+        (groups, person) => {
+            const firstLetter = person.name.charAt(0).toUpperCase();
+            if (!groups[firstLetter]) groups[firstLetter] = [];
+            groups[firstLetter].push(person);
+            return groups;
+        },
+        {} as Record<string, Person[]>
+    );
+
+    const sortedGroupKeys = Object.keys(groupedPeople).sort();
+    sortedGroupKeys.forEach((letter) => {
+        groupedPeople[letter].sort((a, b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
+    });
+
+    return (
+        <div className="w-full px-2 sm:px-4 lg:px-6 pt-4 pb-8">
+            <div className="w-full">
+                {/* Header */}
+                <div className="flex items-center justify-between mb-8">
+                    <h2 className="text-2xl font-light">People</h2>
+                    <div className="flex items-center gap-2">
+                        <button
+                            onClick={() => setShowArchived((v) => !v)}
+                            className={`text-sm px-3 py-1.5 rounded-md border transition-colors ${
+                                showArchived
+                                    ? 'bg-gray-100 dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300'
+                                    : 'border-gray-200 dark:border-gray-700 text-gray-400 dark:text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'
+                            }`}
+                        >
+                            {showArchived ? 'Hide Archived' : 'Show Archived'}
+                        </button>
+                        <button
+                            onClick={openCreate}
+                            className="flex items-center gap-1.5 px-4 py-2 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-700 transition-colors"
+                        >
+                            <PlusIcon className="w-4 h-4" />
+                            New Person
+                        </button>
+                    </div>
+                </div>
+
+                {isLoading ? (
+                    <div className="text-center py-12 text-gray-400 dark:text-gray-500">Loading...</div>
+                ) : displayPeople.length === 0 ? (
+                    <div className="text-center py-16">
+                        <p className="text-gray-500 dark:text-gray-400 text-sm">
+                            {showArchived ? 'No people found.' : 'No people yet. Add family, colleagues, or friends.'}
+                        </p>
+                        {!showArchived && (
+                            <button
+                                onClick={openCreate}
+                                className="mt-4 text-blue-600 dark:text-blue-400 text-sm hover:underline"
+                            >
+                                Add your first person
+                            </button>
+                        )}
+                    </div>
+                ) : (
+                    <div className="space-y-8">
+                        {sortedGroupKeys.map((letter) => (
+                            <div key={letter}>
+                                <h3 className="text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-widest mb-3">
+                                    {letter}
+                                </h3>
+                                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                                    {groupedPeople[letter].map((person) => (
+                                        <Link
+                                            key={person.uid}
+                                            to={`/person/${person.uid}`}
+                                            className={`rounded-xl shadow-sm relative flex flex-col group hover:shadow-md transition-shadow cursor-pointer ${
+                                                !person.color
+                                                    ? 'bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600'
+                                                    : ''
+                                            } ${dropdownOpen === person.uid ? 'z-50' : ''}`}
+                                            style={person.color ? { backgroundColor: person.color } : {}}
+                                        >
+                                            {/* Three-dot dropdown */}
+                                            <div className="absolute top-2 right-2 z-10" ref={dropdownRef}>
+                                                <button
+                                                    onClick={(e) => {
+                                                        e.preventDefault();
+                                                        e.stopPropagation();
+                                                        const next = dropdownOpen === person.uid ? null : person.uid!;
+                                                        if (next !== null) justOpenedRef.current = true;
+                                                        setDropdownOpen(next);
+                                                    }}
+                                                    className={`flex items-center justify-center w-6 h-6 rounded focus:outline-none opacity-0 group-hover:opacity-100 transition-opacity duration-200 ${
+                                                        person.color
+                                                            ? 'text-white/60 hover:text-white hover:bg-white/20'
+                                                            : 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600'
+                                                    }`}
+                                                >
+                                                    <EllipsisVerticalIcon className="h-4 w-4" />
+                                                </button>
+                                                {dropdownOpen === person.uid && (
+                                                    <div className="absolute right-0 top-full mt-1 w-32 bg-white dark:bg-gray-700 shadow-lg rounded-md z-[60]">
+                                                        <button
+                                                            onClick={(e) => {
+                                                                e.preventDefault();
+                                                                e.stopPropagation();
+                                                                openEdit(person);
+                                                                setDropdownOpen(null);
+                                                            }}
+                                                            className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left rounded-t-md"
+                                                        >
+                                                            Edit
+                                                        </button>
+                                                        <button
+                                                            onClick={(e) => {
+                                                                e.preventDefault();
+                                                                e.stopPropagation();
+                                                                handleArchive(person);
+                                                                setDropdownOpen(null);
+                                                            }}
+                                                            className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left"
+                                                        >
+                                                            {person.archived ? 'Unarchive' : 'Archive'}
+                                                        </button>
+                                                        <button
+                                                            onClick={(e) => {
+                                                                e.preventDefault();
+                                                                e.stopPropagation();
+                                                                openDeleteConfirm(person);
+                                                                setDropdownOpen(null);
+                                                            }}
+                                                            className="block px-4 py-2 text-sm text-red-500 dark:text-red-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left rounded-b-md"
+                                                        >
+                                                            Delete
+                                                        </button>
+                                                    </div>
+                                                )}
+                                            </div>
+
+                                            {/* Name */}
+                                            <div className="px-5 pt-6 pb-4 flex-1 flex items-center justify-center text-center">
+                                                <div>
+                                                    <h4 className={`text-sm font-semibold tracking-widest uppercase line-clamp-2 ${
+                                                        person.color ? 'text-white' : 'text-gray-800 dark:text-gray-100'
+                                                    }`}>
+                                                        {person.name}
+                                                    </h4>
+                                                    {person.archived && (
+                                                        <span className={`mt-1 inline-block text-[10px] uppercase tracking-wide ${
+                                                            person.color ? 'text-white/60' : 'text-gray-400 dark:text-gray-500'
+                                                        }`}>
+                                                            archived
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            </div>
+
+                                            {/* Footer */}
+                                            <div className={`rounded-b-xl flex items-stretch divide-x ${
+                                                person.color
+                                                    ? 'bg-black/20 divide-white/10'
+                                                    : 'bg-gray-50 dark:bg-gray-800 border-t border-gray-100 dark:border-gray-600 divide-gray-200 dark:divide-gray-600'
+                                            }`}>
+                                                <div className="flex-1 flex flex-col items-center py-2 gap-0.5">
+                                                    <span className={`text-[10px] leading-none uppercase tracking-wide ${
+                                                        person.color ? 'text-white/55' : 'text-gray-400 dark:text-gray-500'
+                                                    }`}>
+                                                        {RELATIONSHIP_LABELS[person.relationship_type ?? 'other']}
+                                                    </span>
+                                                </div>
+                                                {person.email && (
+                                                    <div className="flex-1 flex flex-col items-center py-2 gap-0.5 overflow-hidden">
+                                                        <span className={`flex items-center gap-1 text-[10px] leading-none truncate max-w-full px-2 ${
+                                                            person.color ? 'text-white/55' : 'text-gray-400 dark:text-gray-500'
+                                                        }`}>
+                                                            <EnvelopeIcon className="h-3 w-3 flex-shrink-0" />
+                                                            <span className="truncate">{person.email.split('@')[0]}</span>
+                                                        </span>
+                                                    </div>
+                                                )}
+                                            </div>
+                                        </Link>
+                                    ))}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {modalOpen && (
+                    <PersonModal
+                        person={editingPerson}
+                        onSave={handleSave}
+                        onClose={() => setModalOpen(false)}
+                    />
+                )}
+
+                {isConfirmDialogOpen && personToDelete && (
+                    <ConfirmDialog
+                        title="Delete Person"
+                        message={`Are you sure you want to delete "${personToDelete.name}"? This cannot be undone.`}
+                        onConfirm={handleDelete}
+                        onCancel={() => {
+                            setIsConfirmDialogOpen(false);
+                            setPersonToDelete(null);
+                        }}
+                    />
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default PeopleList;

--- a/frontend/components/People/PersonDetails.tsx
+++ b/frontend/components/People/PersonDetails.tsx
@@ -1,0 +1,269 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+    PencilSquareIcon,
+    TrashIcon,
+    ArchiveBoxIcon,
+    EnvelopeIcon,
+    PhoneIcon,
+} from '@heroicons/react/24/outline';
+import { Person } from '../../entities/Person';
+import { Task } from '../../entities/Task';
+import { fetchPersonByUid, updatePerson, deletePerson } from '../../utils/peopleService';
+import { useToast } from '../Shared/ToastContext';
+import PersonModal from './PersonModal';
+import ConfirmDialog from '../Shared/ConfirmDialog';
+
+const RELATIONSHIP_LABELS: Record<string, string> = {
+    family: 'Family',
+    work: 'Work',
+    friend: 'Friend',
+    other: 'Other',
+};
+
+const PersonDetails: React.FC = () => {
+    const { uid } = useParams<{ uid: string }>();
+    const navigate = useNavigate();
+    const { showSuccessToast, showErrorToast } = useToast();
+
+    const [person, setPerson] = useState<Person | null>(null);
+    const [assignedTasks, setAssignedTasks] = useState<Task[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [modalOpen, setModalOpen] = useState(false);
+    const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
+
+    const load = async () => {
+        if (!uid) return;
+        setLoading(true);
+        try {
+            const p = await fetchPersonByUid(uid);
+            setPerson(p);
+
+            const response = await fetch(
+                `/api/tasks?assigned_to=${encodeURIComponent(uid)}&status=active`,
+                { credentials: 'include', headers: { Accept: 'application/json' } }
+            );
+            if (response.ok) {
+                const data = await response.json();
+                setAssignedTasks(data.tasks ?? []);
+            }
+        } catch {
+            showErrorToast('Failed to load person');
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        load();
+    }, [uid]);
+
+    const handleSave = async (data: Partial<Person>) => {
+        if (!person?.uid) return;
+        const result = await updatePerson(person.uid, data);
+        setPerson(result.person);
+        showSuccessToast('Person updated');
+    };
+
+    const handleArchive = async () => {
+        if (!person?.uid) return;
+        try {
+            const result = await updatePerson(person.uid, { archived: !person.archived });
+            setPerson(result.person);
+            showSuccessToast(person.archived ? 'Person unarchived' : 'Person archived');
+        } catch (err: unknown) {
+            showErrorToast(err instanceof Error ? err.message : 'Failed to archive');
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!person?.uid) return;
+        try {
+            await deletePerson(person.uid);
+            showSuccessToast('Person deleted');
+            navigate('/people');
+        } catch (err: unknown) {
+            showErrorToast(err instanceof Error ? err.message : 'Failed to delete person');
+        } finally {
+            setIsConfirmDialogOpen(false);
+        }
+    };
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center h-64 text-gray-500 dark:text-gray-400">
+                Loading...
+            </div>
+        );
+    }
+
+    if (!person) {
+        return (
+            <div className="flex items-center justify-center h-64 text-gray-500 dark:text-gray-400">
+                Person not found.
+            </div>
+        );
+    }
+
+    const hasColor = !!person.color;
+
+    return (
+        <div className="w-full px-2 sm:px-4 lg:px-6 pt-4 pb-8">
+            {/* Person Header Banner */}
+            <div
+                className="rounded-xl mb-8 overflow-hidden"
+                style={hasColor ? { backgroundColor: person.color! } : undefined}
+            >
+                <div className={`p-6 ${hasColor ? '' : 'bg-gray-50 dark:bg-gray-900 rounded-xl'}`}>
+                    <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0">
+                            <p className={`text-xs font-medium uppercase tracking-widest mb-1 ${
+                                hasColor ? 'text-white/60' : 'text-gray-400 dark:text-gray-500'
+                            }`}>
+                                Person
+                            </p>
+                            <h1 className={`text-3xl font-light ${
+                                hasColor ? 'text-white' : 'text-gray-900 dark:text-gray-100'
+                            }`}>
+                                {person.name}
+                            </h1>
+                            <div className={`mt-3 flex flex-wrap gap-4 text-xs ${
+                                hasColor ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'
+                            }`}>
+                                <span>{RELATIONSHIP_LABELS[person.relationship_type ?? 'other']}</span>
+                                {assignedTasks.length > 0 && (
+                                    <span>{assignedTasks.length} assigned {assignedTasks.length === 1 ? 'task' : 'tasks'}</span>
+                                )}
+                                {person.archived && (
+                                    <span className={hasColor ? 'text-white/90' : 'text-amber-600 dark:text-amber-400'}>
+                                        Archived
+                                    </span>
+                                )}
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-1 flex-shrink-0">
+                            <button
+                                onClick={() => setModalOpen(true)}
+                                className={`p-2 rounded-lg transition-colors ${
+                                    hasColor
+                                        ? 'text-white/80 hover:text-white hover:bg-white/10'
+                                        : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
+                                }`}
+                                title="Edit person"
+                            >
+                                <PencilSquareIcon className="h-5 w-5" />
+                            </button>
+                            <button
+                                onClick={handleArchive}
+                                className={`p-2 rounded-lg transition-colors ${
+                                    hasColor
+                                        ? 'text-white/80 hover:text-white hover:bg-white/10'
+                                        : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
+                                }`}
+                                title={person.archived ? 'Unarchive' : 'Archive'}
+                            >
+                                <ArchiveBoxIcon className="h-5 w-5" />
+                            </button>
+                            <button
+                                onClick={() => setIsConfirmDialogOpen(true)}
+                                className={`p-2 rounded-lg transition-colors ${
+                                    hasColor
+                                        ? 'text-white/80 hover:text-white hover:bg-white/10'
+                                        : 'text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-800'
+                                }`}
+                                title="Delete person"
+                            >
+                                <TrashIcon className="h-5 w-5" />
+                            </button>
+                        </div>
+                    </div>
+
+                    {/* Contact info */}
+                    <div className="mt-4 space-y-2">
+                        {person.email && (
+                            <div className={`flex items-center gap-2 text-sm ${
+                                hasColor ? 'text-white/80' : 'text-gray-600 dark:text-gray-300'
+                            }`}>
+                                <EnvelopeIcon className={`h-4 w-4 ${hasColor ? 'text-white/60' : 'text-gray-400'}`} />
+                                <a href={`mailto:${person.email}`} className="hover:underline">
+                                    {person.email}
+                                </a>
+                            </div>
+                        )}
+                        {person.phone && (
+                            <div className={`flex items-center gap-2 text-sm ${
+                                hasColor ? 'text-white/80' : 'text-gray-600 dark:text-gray-300'
+                            }`}>
+                                <PhoneIcon className={`h-4 w-4 ${hasColor ? 'text-white/60' : 'text-gray-400'}`} />
+                                <a href={`tel:${person.phone}`} className="hover:underline">
+                                    {person.phone}
+                                </a>
+                            </div>
+                        )}
+                        {person.notes && (
+                            <p className={`text-sm mt-3 whitespace-pre-line ${
+                                hasColor ? 'text-white/80' : 'text-gray-600 dark:text-gray-300'
+                            }`}>
+                                {person.notes}
+                            </p>
+                        )}
+                    </div>
+                </div>
+            </div>
+
+            {/* Assigned Tasks */}
+            <div>
+                <h2 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-3">
+                    Assigned Tasks
+                    {assignedTasks.length > 0 && (
+                        <span className="ml-2 text-sm font-normal text-gray-400">
+                            ({assignedTasks.length})
+                        </span>
+                    )}
+                </h2>
+
+                {assignedTasks.length === 0 ? (
+                    <p className="text-sm text-gray-400 dark:text-gray-500">
+                        No tasks assigned to {person.name}.
+                    </p>
+                ) : (
+                    <ul className="divide-y divide-gray-100 dark:divide-gray-700">
+                        {assignedTasks.map((task) => (
+                            <li
+                                key={task.uid}
+                                className="py-2 text-sm text-gray-800 dark:text-gray-200 cursor-pointer hover:text-blue-600 dark:hover:text-blue-400"
+                                onClick={() => navigate(`/task/${task.uid}`)}
+                            >
+                                <span>{task.name}</span>
+                                {task.Project && (
+                                    <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">
+                                        {task.Project.name}
+                                    </span>
+                                )}
+                            </li>
+                        ))}
+                    </ul>
+                )}
+            </div>
+
+            {modalOpen && (
+                <PersonModal
+                    person={person}
+                    onSave={handleSave}
+                    onClose={() => setModalOpen(false)}
+                />
+            )}
+
+            {isConfirmDialogOpen && (
+                <ConfirmDialog
+                    title="Delete Person"
+                    message={`Are you sure you want to delete "${person.name}"? This cannot be undone.`}
+                    onConfirm={handleDelete}
+                    onCancel={() => setIsConfirmDialogOpen(false)}
+                />
+            )}
+        </div>
+    );
+};
+
+export default PersonDetails;

--- a/frontend/components/People/PersonModal.tsx
+++ b/frontend/components/People/PersonModal.tsx
@@ -1,0 +1,196 @@
+import React, { useState, useEffect } from 'react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+import { Person, RelationshipType } from '../../entities/Person';
+import ColorPicker from '../Shared/ColorPicker';
+
+interface PersonModalProps {
+    person: Person | null;
+    onSave: (data: Partial<Person>) => Promise<void>;
+    onClose: () => void;
+}
+
+const RELATIONSHIP_TYPES: { value: RelationshipType; label: string }[] = [
+    { value: 'family', label: 'Family' },
+    { value: 'work', label: 'Work' },
+    { value: 'friend', label: 'Friend' },
+    { value: 'other', label: 'Other' },
+];
+
+const PersonModal: React.FC<PersonModalProps> = ({ person, onSave, onClose }) => {
+    const [name, setName] = useState('');
+    const [relationshipType, setRelationshipType] = useState<RelationshipType>('other');
+    const [email, setEmail] = useState('');
+    const [phone, setPhone] = useState('');
+    const [notes, setNotes] = useState('');
+    const [color, setColor] = useState('');
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        if (person) {
+            setName(person.name ?? '');
+            setRelationshipType(person.relationship_type ?? 'other');
+            setEmail(person.email ?? '');
+            setPhone(person.phone ?? '');
+            setNotes(person.notes ?? '');
+            setColor(person.color ?? '');
+        } else {
+            setName('');
+            setRelationshipType('other');
+            setEmail('');
+            setPhone('');
+            setNotes('');
+            setColor('');
+        }
+        setError(null);
+    }, [person]);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        if (!name.trim()) {
+            setError('Name is required');
+            return;
+        }
+        setSaving(true);
+        setError(null);
+        try {
+            await onSave({
+                name: name.trim(),
+                relationship_type: relationshipType,
+                email: email.trim() || null,
+                phone: phone.trim() || null,
+                notes: notes.trim() || null,
+                color: color || null,
+            });
+            onClose();
+        } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : 'Failed to save person';
+            setError(msg);
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+            <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4">
+                <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                        {person ? 'Edit Person' : 'New Person'}
+                    </h2>
+                    <button
+                        onClick={onClose}
+                        className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
+                        aria-label="Close"
+                    >
+                        <XMarkIcon className="w-5 h-5" />
+                    </button>
+                </div>
+
+                <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4">
+                    {error && (
+                        <div className="text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded px-3 py-2">
+                            {error}
+                        </div>
+                    )}
+
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Name <span className="text-red-500">*</span>
+                        </label>
+                        <input
+                            type="text"
+                            value={name}
+                            onChange={(e) => setName(e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            placeholder="Dad, Partner, Alice..."
+                            autoFocus
+                        />
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Relationship
+                        </label>
+                        <select
+                            value={relationshipType}
+                            onChange={(e) => setRelationshipType(e.target.value as RelationshipType)}
+                            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        >
+                            {RELATIONSHIP_TYPES.map((rt) => (
+                                <option key={rt.value} value={rt.value}>
+                                    {rt.label}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Email
+                        </label>
+                        <input
+                            type="email"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            placeholder="optional@example.com"
+                        />
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Phone
+                        </label>
+                        <input
+                            type="tel"
+                            value={phone}
+                            onChange={(e) => setPhone(e.target.value)}
+                            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                            placeholder="+1 555 000 0000"
+                        />
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                            Notes
+                        </label>
+                        <textarea
+                            value={notes}
+                            onChange={(e) => setNotes(e.target.value)}
+                            rows={3}
+                            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                            placeholder="Any notes about this person..."
+                        />
+                    </div>
+
+                    <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                            Color
+                        </label>
+                        <ColorPicker value={color} onChange={setColor} />
+                    </div>
+
+                    <div className="flex justify-end gap-3 pt-2">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md transition-colors"
+                        >
+                            Cancel
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={saving}
+                            className="px-4 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 transition-colors"
+                        >
+                            {saving ? 'Saving...' : person ? 'Save Changes' : 'Create Person'}
+                        </button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    );
+};
+
+export default PersonModal;

--- a/frontend/components/Shared/PersonDropdown.tsx
+++ b/frontend/components/Shared/PersonDropdown.tsx
@@ -1,0 +1,168 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronDownIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Person } from '../../entities/Person';
+
+interface PersonDropdownProps {
+    personUid: string | null;
+    people: Person[];
+    onChange: (personUid: string | null) => void;
+    placeholder?: string;
+}
+
+const PersonAvatar: React.FC<{ person: Person | null; size?: 'sm' | 'md' }> = ({
+    person,
+    size = 'sm',
+}) => {
+    const dim = size === 'sm' ? 'w-3 h-3' : 'w-3.5 h-3.5';
+    return (
+        <span
+            className={`inline-block ${dim} rounded-full flex-shrink-0 border border-gray-300 dark:border-gray-600`}
+            style={
+                person?.color
+                    ? { backgroundColor: person.color, borderColor: person.color }
+                    : {}
+            }
+        />
+    );
+};
+
+const PersonDropdown: React.FC<PersonDropdownProps> = ({
+    personUid,
+    people,
+    onChange,
+    placeholder = 'Unassigned',
+}) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [position, setPosition] = useState({ top: 0, left: 0, width: 0 });
+    const dropdownRef = useRef<HTMLDivElement>(null);
+    const menuRef = useRef<HTMLDivElement>(null);
+
+    const activePeople = people.filter((p) => !p.archived);
+    const selectedPerson = people.find((p) => p.uid === personUid) ?? null;
+
+    const handleToggle = () => {
+        if (!isOpen && dropdownRef.current) {
+            const rect = dropdownRef.current.getBoundingClientRect();
+            const menuHeight = Math.min((activePeople.length + 1) * 40 + 8, 240);
+            const spaceBelow = window.innerHeight - rect.bottom;
+            const openUpward = spaceBelow < menuHeight && rect.top > spaceBelow;
+            setPosition({
+                top: openUpward ? rect.top - menuHeight - 8 : rect.bottom + 8,
+                left: rect.left,
+                width: rect.width,
+            });
+        }
+        setIsOpen((prev) => !prev);
+    };
+
+    const handleSelect = (uid: string | null) => {
+        onChange(uid);
+        setIsOpen(false);
+    };
+
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (
+                dropdownRef.current &&
+                !dropdownRef.current.contains(event.target as Node) &&
+                menuRef.current &&
+                !menuRef.current.contains(event.target as Node)
+            ) {
+                setIsOpen(false);
+            }
+        };
+        if (isOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+        }
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [isOpen]);
+
+    return (
+        <div ref={dropdownRef} className="relative inline-block text-left w-full">
+            <button
+                type="button"
+                className="inline-flex justify-between w-full px-3 py-2 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 border border-gray-300 dark:border-gray-900 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors hover:bg-gray-50 dark:hover:bg-gray-800"
+                onClick={handleToggle}
+            >
+                <span className="flex items-center space-x-2">
+                    <PersonAvatar person={selectedPerson} />
+                    <span className={selectedPerson ? '' : 'text-gray-400 dark:text-gray-500'}>
+                        {selectedPerson ? selectedPerson.name : placeholder}
+                    </span>
+                </span>
+                <div className="flex items-center gap-1">
+                    {selectedPerson && (
+                        <span
+                            role="button"
+                            tabIndex={0}
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                handleSelect(null);
+                            }}
+                            onKeyDown={(e) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                    e.stopPropagation();
+                                    handleSelect(null);
+                                }
+                            }}
+                            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 cursor-pointer"
+                            aria-label="Clear assignment"
+                        >
+                            <XMarkIcon className="w-4 h-4" />
+                        </span>
+                    )}
+                    <ChevronDownIcon className="w-5 h-5 text-gray-500 dark:text-gray-300" />
+                </div>
+            </button>
+
+            {isOpen &&
+                createPortal(
+                    <div
+                        ref={menuRef}
+                        className="fixed z-50 bg-white dark:bg-gray-700 shadow-lg rounded-md border border-gray-200 dark:border-gray-600 max-h-60 overflow-y-auto"
+                        style={{
+                            top: `${position.top}px`,
+                            left: `${position.left}px`,
+                            width: `${position.width}px`,
+                        }}
+                    >
+                        <button
+                            onClick={() => handleSelect(null)}
+                            className="flex items-center gap-2 px-4 py-2 text-sm text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-600 w-full first:rounded-t-md"
+                        >
+                            <span className="inline-block w-3 h-3 rounded-full flex-shrink-0 border border-gray-300 dark:border-gray-600" />
+                            {placeholder}
+                        </button>
+                        {activePeople.map((p) => (
+                            <button
+                                key={p.uid}
+                                onClick={() => handleSelect(p.uid ?? null)}
+                                className={`flex items-center gap-2 px-4 py-2 text-sm hover:bg-gray-100 dark:hover:bg-gray-600 w-full last:rounded-b-md ${
+                                    p.uid === personUid
+                                        ? 'text-blue-600 dark:text-blue-400 font-medium'
+                                        : 'text-gray-900 dark:text-gray-100'
+                                }`}
+                            >
+                                <PersonAvatar person={p} size="md" />
+                                <span>{p.name}</span>
+                                {p.relationship_type && p.relationship_type !== 'other' && (
+                                    <span className="ml-1 text-xs text-gray-400 dark:text-gray-500">
+                                        {p.relationship_type}
+                                    </span>
+                                )}
+                            </button>
+                        ))}
+                        {activePeople.length === 0 && (
+                            <div className="px-4 py-2 text-sm text-gray-400 dark:text-gray-500">
+                                No people yet
+                            </div>
+                        )}
+                    </div>,
+                    document.body
+                )}
+        </div>
+    );
+};
+
+export default PersonDropdown;

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -11,6 +11,7 @@ import SidebarHabits from './Sidebar/SidebarHabits';
 import SidebarProjects from './Sidebar/SidebarProjects';
 import SidebarTags from './Sidebar/SidebarTags';
 import SidebarViews from './Sidebar/SidebarViews';
+import SidebarPeople from './Sidebar/SidebarPeople';
 import { KeyboardShortcutsConfig } from '../utils/keyboardShortcutsService';
 import { useStore } from '../store/useStore';
 
@@ -118,6 +119,10 @@ const Sidebar: React.FC<SidebarProps> = ({
                             isDarkMode={isDarkMode}
                             openTagModal={openTagModal}
                             tags={tags}
+                        />
+                        <SidebarPeople
+                            handleNavClick={handleNavClick}
+                            location={location}
                         />
                         <SidebarViews
                             handleNavClick={handleNavClick}

--- a/frontend/components/Sidebar/SidebarPeople.tsx
+++ b/frontend/components/Sidebar/SidebarPeople.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Location } from 'react-router-dom';
+import { UserGroupIcon } from '@heroicons/react/24/outline';
+
+interface SidebarPeopleProps {
+    handleNavClick: (path: string, title: string, icon: JSX.Element) => void;
+    location: Location;
+}
+
+const SidebarPeople: React.FC<SidebarPeopleProps> = ({ handleNavClick, location }) => {
+    const isActive = () =>
+        location.pathname.startsWith('/people') || location.pathname.startsWith('/person/')
+            ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white'
+            : 'text-gray-700 dark:text-gray-300';
+
+    return (
+        <ul className="flex flex-col space-y-1">
+            <li
+                className={`flex items-center rounded-md px-4 py-2 uppercase text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${isActive()}`}
+                onClick={() =>
+                    handleNavClick(
+                        '/people',
+                        'People',
+                        <UserGroupIcon className="h-5 w-5 mr-2" />
+                    )
+                }
+            >
+                <UserGroupIcon className="h-5 w-5 mr-2" />
+                People
+            </li>
+        </ul>
+    );
+};
+
+export default SidebarPeople;

--- a/frontend/components/Task/TaskDetails.tsx
+++ b/frontend/components/Task/TaskDetails.tsx
@@ -32,6 +32,7 @@ import {
     TaskDueDateCard,
     TaskDeferUntilCard,
     TaskAttachmentsCard,
+    TaskAssignedToCard,
 } from './TaskDetails/';
 import TaskAIInsights, { TaskAIInsightsHandle } from '../AI/TaskAIInsights';
 import {
@@ -545,7 +546,7 @@ const TaskDetails: React.FC = () => {
 
     useEffect(() => {
         const loadSubtasks = async () => {
-            if (activePill !== 'subtasks' || !task?.uid) {
+            if (!task?.uid) {
                 return;
             }
 
@@ -581,7 +582,7 @@ const TaskDetails: React.FC = () => {
         };
 
         loadSubtasks();
-    }, [activePill, task?.uid, task?.subtasks, hasLoadedSubtasks, tasksStore]);
+    }, [task?.uid, task?.subtasks, hasLoadedSubtasks, tasksStore]);
 
     useEffect(() => {
         setPendingSubtasks(subtasks);
@@ -1104,6 +1105,21 @@ const TaskDetails: React.FC = () => {
         }
     };
 
+    const handleAssignPerson = async (personUid: string | null) => {
+        if (!task?.uid) return;
+        try {
+            taskModifiedRef.current = true;
+            await updateTask(task.uid, { assigned_to: personUid });
+            if (uid) {
+                const updatedTask = await fetchTaskByUid(uid);
+                tasksStore.updateTaskInStore(updatedTask);
+            }
+        } catch (error) {
+            console.error('Error assigning person:', error);
+            showErrorToast('Failed to update assignment');
+        }
+    };
+
     const getAreaLink = (area: Area) => {
         if (area.uid) {
             const slug = area.name
@@ -1245,7 +1261,6 @@ const TaskDetails: React.FC = () => {
                     onAiInsightsClick={aiAssistantEnabled ? handleAiInsightsClick : undefined}
                     aiInsightsActive={aiInsightsActive}
                     attachmentCount={attachmentCount}
-                    subtasksCount={subtasks.length}
                     autoEditTitle={isNewTask}
                 />
 
@@ -1270,6 +1285,26 @@ const TaskDetails: React.FC = () => {
                                     content={task.note || ''}
                                     onUpdate={handleContentUpdate}
                                 />
+                                <TaskSubtasksCard
+                                    task={task}
+                                    subtasks={pendingSubtasks}
+                                    onSubtasksChange={setPendingSubtasks}
+                                    onSave={handleSaveSubtasks}
+                                />
+                                <TaskRecurrenceCard
+                                    task={task}
+                                    parentTask={parentTask}
+                                    loadingParent={loadingParent}
+                                    isEditing={isEditingRecurrence}
+                                    recurrenceForm={recurrenceForm}
+                                    onStartEdit={handleStartRecurrenceEdit}
+                                    onChange={handleRecurrenceChange}
+                                    onSave={handleSaveRecurrence}
+                                    onCancel={handleCancelRecurrenceEdit}
+                                    loadingIterations={loadingIterations}
+                                    nextIterations={nextIterations}
+                                    canEdit={!task.recurring_parent_id}
+                                />
                             </div>
 
                             <div className="space-y-6">
@@ -1290,6 +1325,11 @@ const TaskDetails: React.FC = () => {
                                     onAreaSelect={handleAreaSelection}
                                     onAreaClear={handleClearArea}
                                     getAreaLink={getAreaLink}
+                                />
+
+                                <TaskAssignedToCard
+                                    task={task}
+                                    onAssign={handleAssignPerson}
                                 />
 
                                 <TaskTagsCard
@@ -1322,36 +1362,6 @@ const TaskDetails: React.FC = () => {
                                     onCancel={handleCancelDeferUntilEdit}
                                 />
                             </div>
-                        </div>
-                    )}
-
-                    {activePill === 'recurrence' && (
-                        <div className="grid grid-cols-1">
-                            <TaskRecurrenceCard
-                                task={task}
-                                parentTask={parentTask}
-                                loadingParent={loadingParent}
-                                isEditing={isEditingRecurrence}
-                                recurrenceForm={recurrenceForm}
-                                onStartEdit={handleStartRecurrenceEdit}
-                                onChange={handleRecurrenceChange}
-                                onSave={handleSaveRecurrence}
-                                onCancel={handleCancelRecurrenceEdit}
-                                loadingIterations={loadingIterations}
-                                nextIterations={nextIterations}
-                                canEdit={!task.recurring_parent_id}
-                            />
-                        </div>
-                    )}
-
-                    {activePill === 'subtasks' && (
-                        <div className="grid grid-cols-1">
-                            <TaskSubtasksCard
-                                task={task}
-                                subtasks={pendingSubtasks}
-                                onSubtasksChange={setPendingSubtasks}
-                                onSave={handleSaveSubtasks}
-                            />
                         </div>
                     )}
 

--- a/frontend/components/Task/TaskDetails/TaskAssignedToCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskAssignedToCard.tsx
@@ -1,0 +1,37 @@
+import React, { useEffect, useState } from 'react';
+import { UserIcon } from '@heroicons/react/24/outline';
+import { Task } from '../../../entities/Task';
+import { Person } from '../../../entities/Person';
+import { fetchPeople } from '../../../utils/peopleService';
+import PersonDropdown from '../../Shared/PersonDropdown';
+
+interface TaskAssignedToCardProps {
+    task: Task;
+    onAssign: (personUid: string | null) => Promise<void>;
+}
+
+const TaskAssignedToCard: React.FC<TaskAssignedToCardProps> = ({ task, onAssign }) => {
+    const [people, setPeople] = useState<Person[]>([]);
+
+    useEffect(() => {
+        fetchPeople().catch(console.error).then((p) => {
+            if (p) setPeople(p);
+        });
+    }, []);
+
+    return (
+        <div className="rounded-lg shadow-sm bg-white dark:bg-gray-900 border-2 border-gray-50 dark:border-gray-800 hover:border-gray-200 dark:hover:border-gray-700 transition-colors p-3">
+            <div className="flex items-center gap-2 mb-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                <UserIcon className="w-3.5 h-3.5" />
+                Assigned To
+            </div>
+            <PersonDropdown
+                personUid={task.assigned_to ?? null}
+                people={people}
+                onChange={onAssign}
+            />
+        </div>
+    );
+};
+
+export default TaskAssignedToCard;

--- a/frontend/components/Task/TaskDetails/TaskDetailsHeader.tsx
+++ b/frontend/components/Task/TaskDetails/TaskDetailsHeader.tsx
@@ -38,7 +38,6 @@ interface TaskDetailsHeaderProps {
     onAiInsightsClick?: () => void;
     aiInsightsActive?: boolean;
     attachmentCount?: number;
-    subtasksCount?: number;
     autoEditTitle?: boolean;
 }
 
@@ -61,7 +60,6 @@ const TaskDetailsHeader: React.FC<TaskDetailsHeaderProps> = ({
     onAiInsightsClick,
     aiInsightsActive = false,
     attachmentCount = 0,
-    subtasksCount = 0,
     autoEditTitle = false,
 }) => {
     const { t } = useTranslation();
@@ -604,33 +602,6 @@ const TaskDetailsHeader: React.FC<TaskDetailsHeaderProps> = ({
                             }`}
                         >
                             {t('task.overview', 'Overview')}
-                        </button>
-                        <button
-                            onClick={() => onPillChange('subtasks')}
-                            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors relative ${
-                                activePill === 'subtasks'
-                                    ? 'bg-blue-500 dark:bg-blue-600 text-white'
-                                    : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
-                            }`}
-                        >
-                            {t('task.subtasks', 'Subtasks')}
-                            {subtasksCount > 0 && (
-                                <span className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-blue-500 dark:bg-blue-400 rounded-full border border-white dark:border-gray-900"></span>
-                            )}
-                        </button>
-                        <button
-                            onClick={() => onPillChange('recurrence')}
-                            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors relative ${
-                                activePill === 'recurrence'
-                                    ? 'bg-blue-500 dark:bg-blue-600 text-white'
-                                    : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
-                            }`}
-                        >
-                            {t('task.recurrence', 'Recurrence')}
-                            {task.recurrence_type &&
-                                task.recurrence_type !== 'none' && (
-                                    <span className="absolute -top-0.5 -right-0.5 w-2 h-2 bg-blue-500 dark:bg-blue-400 rounded-full border border-white dark:border-gray-900"></span>
-                                )}
                         </button>
                         <button
                             onClick={() => onPillChange('attachments')}

--- a/frontend/components/Task/TaskDetails/index.ts
+++ b/frontend/components/Task/TaskDetails/index.ts
@@ -9,3 +9,4 @@ export { default as TaskDueDateCard } from './TaskDueDateCard';
 export { default as TaskDeferUntilCard } from './TaskDeferUntilCard';
 export { default as TaskAttachmentsCard } from './TaskAttachmentsCard';
 export { default as TaskAreaCard } from './TaskAreaCard';
+export { default as TaskAssignedToCard } from './TaskAssignedToCard';

--- a/frontend/entities/Person.ts
+++ b/frontend/entities/Person.ts
@@ -1,0 +1,16 @@
+export type RelationshipType = 'family' | 'work' | 'friend' | 'other';
+
+export interface Person {
+    id?: number;
+    uid?: string;
+    user_id?: number;
+    name: string;
+    relationship_type?: RelationshipType;
+    email?: string | null;
+    phone?: string | null;
+    notes?: string | null;
+    archived?: boolean;
+    color?: string | null;
+    created_at?: string;
+    updated_at?: string;
+}

--- a/frontend/entities/Task.ts
+++ b/frontend/entities/Task.ts
@@ -47,6 +47,8 @@ export interface Task {
     habit_best_streak?: number;
     habit_total_completions?: number;
     habit_last_completion_at?: string;
+    assigned_to?: string | null;
+    involves?: string[];
     // Transient UI field set by suggestion scoring - never persisted or sent to server
     _suggestionMeta?: {
         score: number;

--- a/frontend/utils/peopleService.ts
+++ b/frontend/utils/peopleService.ts
@@ -1,0 +1,72 @@
+import { Person } from '../entities/Person';
+import { handleAuthResponse, getPostHeadersWithCsrf } from './authUtils';
+import { getApiPath } from '../config/paths';
+import { getCsrfToken } from './csrfService';
+
+export const fetchPeople = async (params: {
+    archived?: boolean;
+    sort?: string;
+    relationship_type?: string;
+} = {}): Promise<Person[]> => {
+    const query = new URLSearchParams();
+    if (params.archived !== undefined) query.set('archived', String(params.archived));
+    if (params.sort) query.set('sort', params.sort);
+    if (params.relationship_type) query.set('relationship_type', params.relationship_type);
+
+    const url = query.toString() ? `people?${query.toString()}` : 'people';
+    const response = await fetch(getApiPath(url), {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+    });
+    await handleAuthResponse(response, 'Failed to fetch people.');
+    const data = await response.json();
+    return data.people;
+};
+
+export const fetchPersonByUid = async (uid: string): Promise<Person> => {
+    const response = await fetch(getApiPath(`people/${uid}`), {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+    });
+    await handleAuthResponse(response, 'Failed to fetch person.');
+    return response.json();
+};
+
+export const createPerson = async (
+    data: Omit<Person, 'id' | 'uid' | 'user_id' | 'created_at' | 'updated_at'>
+): Promise<{ person: Person }> => {
+    const response = await fetch(getApiPath('people'), {
+        method: 'POST',
+        credentials: 'include',
+        headers: await getPostHeadersWithCsrf(),
+        body: JSON.stringify(data),
+    });
+    await handleAuthResponse(response, 'Failed to create person.');
+    return response.json();
+};
+
+export const updatePerson = async (
+    uid: string,
+    data: Partial<Person>
+): Promise<{ person: Person }> => {
+    const response = await fetch(getApiPath(`people/${uid}`), {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: await getPostHeadersWithCsrf(),
+        body: JSON.stringify(data),
+    });
+    await handleAuthResponse(response, 'Failed to update person.');
+    return response.json();
+};
+
+export const deletePerson = async (uid: string): Promise<void> => {
+    const response = await fetch(getApiPath(`people/${uid}`), {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: {
+            Accept: 'application/json',
+            'x-csrf-token': await getCsrfToken(),
+        },
+    });
+    await handleAuthResponse(response, 'Failed to delete person.');
+};

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "backend:format:fix": "cd backend && prettier --write .",
     "db:init": "cd backend && node scripts/db-init.js",
     "db:sync": "cd backend && node scripts/db-sync.js",
-    "db:migrate": "cd backend && node scripts/db-migrate.js",
+    "db:migrate": "cd backend && NODE_ENV=development node scripts/db-migrate.js",
     "db:reset": "cd backend && node scripts/db-reset.js",
     "db:status": "cd backend && node scripts/db-status.js",
     "db:seed": "cd backend && node scripts/seed-dev-data.js",


### PR DESCRIPTION
## Description

Adds a People management system to Tududi, allowing users to track contacts and collaborators and assign them to tasks.

**What this PR does:**
- Introduces a `Person` entity (name, relationship type, email, phone, notes, color, archived flag)
- Adds `assigned_to` and `involves` fields to the `Task` model for person assignment
- Full CRUD REST API under `/api/people`
- Three database migrations: create people table, add fields to tasks, add color to people
- Sidebar navigation section for People
- People list page and person detail page with task history
- `PersonDropdown` shared component for person selection
- `TaskAssignedToCard` in task details for quick assignment
- Refactors `db-migrate.js` to use Umzug for proper migration tracking (instead of `sequelize.sync({ alter: true })`)
- Consolidates subtasks and recurrence into the task overview tab (removing separate pills)
- Fixes `ProjectAIInsights` toggle behavior with an explicit `isVisible` state

## Type of Change

- [x] New feature
- [x] Refactor (non-breaking change that improves internal structure)

## Related Issues

N/A

## Testing

```bash
npm run db:migrate       # runs the 3 new migrations
npm start                # verify People section in sidebar
# Navigate to /people, create a person, open a task and assign them
```

## Checklist

- [x] Code follows project conventions
- [x] `npm run lint` passes with no errors
- [x] Database migrations included
- [x] Frontend routes registered in App.tsx
- [x] Backend routes registered in app.js

## Additional Notes

The `db-migrate.js` refactor switches from `sequelize.sync({ alter: true })` (which modifies tables in place without tracking) to Umzug-based migration tracking, ensuring each migration runs exactly once and is recorded in the `SequelizeMeta` table.