### PR TITLE
fix(tasks): apply project_id/project_uid filter and status=all in API

### DIFF
--- a/backend/modules/tasks/queries/query-builders.js
+++ b/backend/modules/tasks/queries/query-builders.js
@@ -303,6 +303,8 @@ async function filterTasksByParams(
                         'cancelled',
                     ],
                 };
+            } else if (params.status === 'all') {
+                // No status filter - return tasks of all statuses
             } else if (!params.client_side_filtering) {
                 whereClause.status = { [Op.notIn]: [Task.STATUS.DONE, 'done'] };
             }
@@ -406,6 +408,17 @@ async function filterTasksByParams(
             ...(whereClause.id || {}),
             [Op.in]: tagFilteredTaskIds,
         };
+    }
+
+    if (params.project_uid) {
+        const project = await Project.findOne({
+            where: { uid: params.project_uid },
+        });
+        if (project) {
+            whereClause.project_id = project.id;
+        }
+    } else if (params.project_id) {
+        whereClause.project_id = params.project_id;
     }
 
     if (params.area_uid) {

--- a/backend/tests/integration/tasks-project-filter.test.js
+++ b/backend/tests/integration/tasks-project-filter.test.js
@@ -1,0 +1,104 @@
+const request = require('supertest');
+const app = require('../../app');
+const { Task, Project } = require('../../models');
+const { createTestUser } = require('../helpers/testUtils');
+
+describe('Tasks API project_id filter', () => {
+    let user, agent, projectA, projectB;
+
+    beforeEach(async () => {
+        user = await createTestUser({
+            email: 'project-filter-test@example.com',
+        });
+
+        agent = request.agent(app);
+        await agent.post('/api/login').send({
+            email: 'project-filter-test@example.com',
+            password: 'password123',
+        });
+
+        projectA = await Project.create({
+            name: 'Project A',
+            user_id: user.id,
+        });
+        projectB = await Project.create({
+            name: 'Project B',
+            user_id: user.id,
+        });
+
+        await Task.create({
+            user_id: user.id,
+            name: 'Task in A',
+            status: 0,
+            project_id: projectA.id,
+        });
+        await Task.create({
+            user_id: user.id,
+            name: 'Task in B',
+            status: 0,
+            project_id: projectB.id,
+        });
+        await Task.create({
+            user_id: user.id,
+            name: 'Done Task in A',
+            status: 2,
+            project_id: projectA.id,
+        });
+        await Task.create({
+            user_id: user.id,
+            name: 'No project task',
+            status: 0,
+        });
+    });
+
+    it('should filter tasks by project_id', async () => {
+        const response = await agent.get('/api/tasks').query({
+            type: 'all',
+            project_id: projectA.id,
+        });
+
+        expect(response.status).toBe(200);
+        const names = response.body.tasks.map((t) => t.name);
+        expect(names).toContain('Task in A');
+        expect(names).not.toContain('Task in B');
+        expect(names).not.toContain('No project task');
+    });
+
+    it('should filter tasks by project_uid', async () => {
+        const response = await agent.get('/api/tasks').query({
+            type: 'all',
+            project_uid: projectB.uid,
+        });
+
+        expect(response.status).toBe(200);
+        const names = response.body.tasks.map((t) => t.name);
+        expect(names).toContain('Task in B');
+        expect(names).not.toContain('Task in A');
+        expect(names).not.toContain('No project task');
+    });
+
+    it('should return all statuses when type=all and status=all', async () => {
+        const response = await agent.get('/api/tasks').query({
+            type: 'all',
+            project_id: projectA.id,
+            status: 'all',
+        });
+
+        expect(response.status).toBe(200);
+        const names = response.body.tasks.map((t) => t.name);
+        expect(names).toContain('Task in A');
+        expect(names).toContain('Done Task in A');
+    });
+
+    it('should only return active tasks by default with type=all and project_id', async () => {
+        const response = await agent.get('/api/tasks').query({
+            type: 'all',
+            project_id: projectA.id,
+        });
+
+        expect(response.status).toBe(200);
+        const names = response.body.tasks.map((t) => t.name);
+        expect(names).toContain('Task in A');
+        expect(names).not.toContain('Done Task in A');
+    });
+});


### PR DESCRIPTION
## Description

The `filterTasksByParams` function in the task query builder was missing `project_id` and `project_uid` as supported filter parameters. Any API request with `?project_id=XXX` or `?project_uid=XXX` was silently ignored, returning tasks from all projects instead of just the specified one.

Additionally, the `case 'all'` branch was missing `status=all` handling that already existed in the `default` case, causing `?type=all&status=all` to still exclude done tasks.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1235

## Testing

**How did you test this?**

Added 4 integration tests covering:
- Filtering by `project_id` returns only that project's tasks
- Filtering by `project_uid` returns only that project's tasks
- `type=all&status=all` returns tasks of all statuses (including done)
- `type=all&project_id` without status filter returns only active tasks (default behavior preserved)

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)

## Additional Notes

The fix adds project filtering in [query-builders.js](backend/modules/tasks/queries/query-builders.js) alongside the existing `area_uid`/`area_id` and `tag` filter blocks (lines 411-435). The pattern mirrors how `area_uid`/`area_id` filtering is already done.