### PR TITLE
fix(tasks): stop infinite /api/areas requests on task detail page

### DIFF
--- a/frontend/components/Task/TaskDetails.tsx
+++ b/frontend/components/Task/TaskDetails.tsx
@@ -197,7 +197,7 @@ const TaskDetails: React.FC = () => {
     }, [tagsStore]);
 
     useEffect(() => {
-        if (!areasStore.isLoading && areasStore.areas.length === 0) {
+        if (!areasStore.hasLoaded && !areasStore.isLoading) {
             areasStore.loadAreas();
         }
     }, [areasStore]);


### PR DESCRIPTION
## Description

Fixes an infinite request loop that occurs when opening a task detail page. The page triggers continuous `GET /api/areas` requests until the browser hits its connection limit (`ERR_INSUFFICIENT_RESOURCES`), making the task detail page unresponsive.

## Root Cause

In `TaskDetails.tsx`, the areas loading guard used `areas.length === 0` as its "not yet loaded" check:

```js
if (!areasStore.isLoading && areasStore.areas.length === 0) {
    areasStore.loadAreas();
}
```

Because every `set()` in the Zustand store replaces the `areasStore` slice with a new reference, the `useEffect` re-fires on every store mutation. When a user has zero areas (or when the `/api/areas` request fails), `areas.length === 0` stays `true`, so `loadAreas()` fires again, which triggers another store mutation, which re-fires the effect — forever.

## Fix

Switch to the `hasLoaded` flag, which is already set to `true` in both the success **and** error branches of `loadAreas`. This is the same pattern used by the neighboring tags effect.

```js
if (!areasStore.hasLoaded && !areasStore.isLoading) {
    areasStore.loadAreas();
}
```

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #1241

## Testing

1. Create a fresh account with **zero Areas**
2. Create a task and click it to open the task detail page
3. Verify the page renders correctly and no repeated `/api/areas` requests appear in the browser Network tab

Also verify with an account that has areas — task detail should continue to load normally.

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have tested this change locally
- [x] Lint passes (`npm run lint`)