### PR TITLE
fix(migrations): guard area_id column/index creation against duplicate on clean install

### DIFF
--- a/backend/migrations/20260623000001-add-area-id-to-tasks.js
+++ b/backend/migrations/20260623000001-add-area-id-to-tasks.js
@@ -1,19 +1,26 @@
 'use strict';
 
+const { safeAddColumns, safeAddIndex } = require('../utils/migration-utils');
+
 module.exports = {
     async up(queryInterface, Sequelize) {
-        await queryInterface.addColumn('tasks', 'area_id', {
-            type: Sequelize.INTEGER,
-            allowNull: true,
-            references: {
-                model: 'areas',
-                key: 'id',
+        await safeAddColumns(queryInterface, 'tasks', [
+            {
+                name: 'area_id',
+                definition: {
+                    type: Sequelize.INTEGER,
+                    allowNull: true,
+                    references: {
+                        model: 'areas',
+                        key: 'id',
+                    },
+                    onUpdate: 'CASCADE',
+                    onDelete: 'SET NULL',
+                },
             },
-            onUpdate: 'CASCADE',
-            onDelete: 'SET NULL',
-        });
+        ]);
 
-        await queryInterface.addIndex('tasks', ['area_id'], {
+        await safeAddIndex(queryInterface, 'tasks', ['area_id'], {
             name: 'tasks_area_id_idx',
         });
     },


### PR DESCRIPTION
## Description

On fresh Docker installations, `db-init.js` runs `sequelize.sync({ force: true })` which creates all tables from current model definitions before migrations run. The migration `20260623000001-add-area-id-to-tasks.js` then called `queryInterface.addColumn` and `queryInterface.addIndex` directly without first checking whether `area_id` already existed — causing `SQLITE_ERROR: duplicate column name: area_id`.

This failure halted the entire migration chain. All subsequent migrations (including `20260626000001-add-ai-brief-cache-to-users.js`) never ran, which led to the secondary `SQLITE_ERROR: no such column: ai_daily_brief` error during user creation.

The fix replaces the raw `addColumn`/`addIndex` calls with `safeAddColumns` and `safeAddIndex` from the project's existing `migration-utils.js`, which check for existence before attempting to add.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1240

## Testing

- Verify that on a clean install (no existing database), migrations run to completion without error
- Verify that on an existing install (upgrades), the migration correctly adds `area_id` to tasks if it doesn't already exist

## Checklist

- [x] My code follows the existing code style
- [x] I have run `npm run lint` and fixed any issues
- [x] This fix is consistent with how other migrations in the codebase handle column existence checks