### PR TITLE
fix(projects): prevent scroll reset when modal is closed

### DIFF
--- a/frontend/components/Projects.tsx
+++ b/frontend/components/Projects.tsx
@@ -38,7 +38,6 @@ const Projects: React.FC = () => {
     const {
         projects,
         setProjects,
-        setLoading: setProjectsLoading,
         setError: setProjectsError,
     } = useStore((state) => state.projectsStore);
     const { isLoading, isError } = useStore((state) => state.projectsStore);
@@ -230,7 +229,6 @@ const Projects: React.FC = () => {
     };
 
     const handleSaveProject = async (project: Project) => {
-        setProjectsLoading(true);
         try {
             if (project.uid) {
                 await updateProject(project.uid, project);
@@ -244,7 +242,6 @@ const Projects: React.FC = () => {
             console.error('Error saving project:', error);
             setProjectsError(true);
         } finally {
-            setProjectsLoading(false);
             setModalState({ isOpen: false, projectToEdit: null });
         }
     };
@@ -265,7 +262,6 @@ const Projects: React.FC = () => {
 
         try {
             if (projectToDelete.uid !== undefined) {
-                setProjectsLoading(true);
                 await deleteProject(projectToDelete.uid);
 
                 // Fetch all projects without filters to keep global store complete
@@ -284,7 +280,6 @@ const Projects: React.FC = () => {
                     : t('projects.deleteError', 'Failed to delete project');
             showErrorToast(msg);
         } finally {
-            setProjectsLoading(false);
             setIsConfirmDialogOpen(false);
             setProjectToDelete(null);
         }


### PR DESCRIPTION
## Description

Scroll position in the `/projects` view was resetting to the top whenever a project was saved or deleted via the modal. This happened because `setProjectsLoading(true)` was called at the start of save/delete operations, which triggered the full-screen loading state in the component. That loading state replaces the entire project list with a spinner, effectively unmounting it and losing scroll position. When loading completed, the list remounted at scroll position 0.

The fix removes the `setProjectsLoading` calls from the save and delete handlers. The page-level loading flag should only gate the initial data fetch. Save/delete operations already show feedback through the modal's own saving state.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1247

## Testing

1. Open `/projects` and scroll down
2. Click edit on any project
3. Save the project via the modal
4. Verify scroll position is preserved after the modal closes
5. Repeat for project deletion via the confirm dialog

## Checklist

- [x] My code follows the project's code conventions
- [x] I have tested my changes locally
- [x] `npm run lint` passes with no new errors