### PR TITLE
fix(kanban/eisenhower): prevent recurring tasks from being renamed on drag and drop

### DIFF
--- a/frontend/components/Calendar.tsx
+++ b/frontend/components/Calendar.tsx
@@ -101,7 +101,7 @@ const Calendar: React.FC = () => {
         if (!Array.isArray(tasks)) return [];
 
         tasks.forEach((task) => {
-            const name = task.name || task.title || `Task ${task.id}`;
+            const name = task.original_name || task.name || task.title || `Task ${task.id}`;
 
             if (task.defer_until) {
                 const deferDate = new Date(task.defer_until);
@@ -176,7 +176,7 @@ const Calendar: React.FC = () => {
             if (task) {
                 const taskEntity: Task = {
                     ...task,
-                    name: task.name || task.title || `Task ${task.id}`,
+                    name: task.original_name || task.name || task.title || `Task ${task.id}`,
                     priority: task.priority || 'low',
                     status: task.status || 'not_started',
                     tags: task.tags || [],

--- a/frontend/components/Eisenhower/EisenhowerMatrix.tsx
+++ b/frontend/components/Eisenhower/EisenhowerMatrix.tsx
@@ -142,7 +142,7 @@ const EisenhowerMatrix: React.FC = () => {
             ? [...otherTags, { name: URGENT_TAG }]
             : otherTags;
 
-        const updatedTask: Task = { ...task, priority: newPriority, tags: newTags };
+        const updatedTask: Task = { ...task, name: task.original_name || task.name, priority: newPriority, tags: newTags };
 
         // Optimistic update so the task moves instantly
         setTasks((prev) => prev.map((t) => (t.id === task.id ? updatedTask : t)));

--- a/frontend/components/Kanban/KanbanBoard.tsx
+++ b/frontend/components/Kanban/KanbanBoard.tsx
@@ -241,7 +241,7 @@ const KanbanBoard: React.FC = () => {
 
     const moveTaskToCol = async (task: Task, targetCol: ColKey) => {
         const newStatus = COLUMN_STATUS[targetCol];
-        const updatedTask: Task = { ...task, status: newStatus };
+        const updatedTask: Task = { ...task, name: task.original_name || task.name, status: newStatus };
         setTasks((prev) => prev.map((t) => (t.id === task.id ? updatedTask : t)));
         await handleTaskUpdate(updatedTask);
     };


### PR DESCRIPTION
## Description

Recurring tasks were being permanently renamed to their recurrence type (e.g. "Monthly", "Weekly") whenever moved via drag and drop in the Eisenhower Matrix or Kanban Board, and also displayed incorrectly in the Calendar view.

**Root cause:** The `serializeTask` function transforms recurring parent task names to the recurrence type string by default in the GET `/tasks` response. The Eisenhower, Kanban, and Calendar views fetch tasks without the `skipDisplayNameTransform` flag, so the in-memory task state holds `name: "Monthly"` (the display label) instead of the actual name. When drag-and-drop triggers a PATCH with the full task object, this transformed name is sent to the server and saved to the database, permanently overwriting the real name.

**Fix:** Before building the update payload in `moveTaskToQuadrant` (Eisenhower), `moveTaskToCol` (Kanban), and the Calendar event conversion/click handler, use `task.original_name || task.name`. The `original_name` field is always the actual stored name returned by the serializer alongside the transformed `name`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1243

## Testing

1. Create a task with a monthly recurrence set
2. Open the Kanban or Eisenhower view
3. Drag the task to a different column/quadrant
4. Verify the task title is unchanged after the move
5. Navigate away and back — title should still be the original name
6. Verify the Calendar view shows the actual task name instead of "Monthly"/"Weekly"/etc.

## Checklist

- [x] Code follows project conventions
- [x] `npm run lint` passes with no new errors
- [x] Manual testing performed