### PR TITLE
fix(tasks): prevent subtask deletion on kanban, eisenhower, and undo

### DIFF
--- a/frontend/components/Eisenhower/EisenhowerMatrix.tsx
+++ b/frontend/components/Eisenhower/EisenhowerMatrix.tsx
@@ -142,7 +142,9 @@ const EisenhowerMatrix: React.FC = () => {
             ? [...otherTags, { name: URGENT_TAG }]
             : otherTags;
 
-        const updatedTask: Task = { ...task, name: task.original_name || task.name, priority: newPriority, tags: newTags };
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { subtasks: _subtasks, ...taskWithoutSubtasks } = task;
+        const updatedTask: Task = { ...taskWithoutSubtasks, name: task.original_name || task.name, priority: newPriority, tags: newTags };
 
         // Optimistic update so the task moves instantly
         setTasks((prev) => prev.map((t) => (t.id === task.id ? updatedTask : t)));

--- a/frontend/components/Kanban/KanbanBoard.tsx
+++ b/frontend/components/Kanban/KanbanBoard.tsx
@@ -241,7 +241,9 @@ const KanbanBoard: React.FC = () => {
 
     const moveTaskToCol = async (task: Task, targetCol: ColKey) => {
         const newStatus = COLUMN_STATUS[targetCol];
-        const updatedTask: Task = { ...task, name: task.original_name || task.name, status: newStatus };
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { subtasks: _subtasks, ...taskWithoutSubtasks } = task;
+        const updatedTask: Task = { ...taskWithoutSubtasks, name: task.original_name || task.name, status: newStatus };
         setTasks((prev) => prev.map((t) => (t.id === task.id ? updatedTask : t)));
         await handleTaskUpdate(updatedTask);
     };

--- a/frontend/components/Task/TaskItem.tsx
+++ b/frontend/components/Task/TaskItem.tsx
@@ -339,15 +339,17 @@ const TaskItem: React.FC<TaskItemProps> = ({
                         <>Task <span className="font-semibold">&apos;{task.name}&apos;</span> completed.</>,
                         async () => {
                             try {
+                                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                                const { subtasks: _taskSubtasks, ...taskWithoutSubtasks } = task;
                                 const reverted = await updateTask(task.uid!, {
-                                    ...task,
+                                    ...taskWithoutSubtasks,
                                     status: previousStatus,
                                     completed_at: null,
                                 });
                                 if (onTaskCompletionToggle) {
                                     onTaskCompletionToggle(reverted);
                                 } else {
-                                    await onTaskUpdate({ ...task, ...reverted });
+                                    await onTaskUpdate({ ...taskWithoutSubtasks, ...reverted });
                                 }
                             } catch {
                                 showErrorToast('Failed to undo task completion.');


### PR DESCRIPTION
## Description

Three code paths spread the full task object (including `subtasks: []`) into PATCH payloads. When tasks are loaded from list endpoints that don't eagerly load the Subtasks association, the backend serializer returns `subtasks: []`. Sending that back in a PATCH causes `updateSubtasks` to interpret the empty array as "delete all subtasks."

The same root cause was fixed for the status dropdown in PR #1227 (`TaskStatusControl`). This PR applies the same pattern to the remaining three vulnerable paths.

**Affected paths:**
- `KanbanBoard`: `moveTaskToCol` — drag-and-drop between columns
- `EisenhowerMatrix`: `moveTaskToQuadrant` — drag-and-drop between quadrants
- `TaskItem`: undo path after completing a task (both the `updateTask` call and the `onTaskUpdate` callback)

**Fix:** Destructure `subtasks` out of the task object before building each update payload, identical to the approach already used in `TaskStatusControl.tsx`.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1194

## Testing

**How did you test this?**

- Traced all frontend code paths that spread `{...task}` into a PATCH payload
- Confirmed the three locations above were missing the subtask strip that `TaskStatusControl` already had
- Verified lint passes with `npm run lint`
- Backend tests pass (pre-existing flaky integration test failures unrelated to these changes)

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code

## Additional Notes

The backend `updateSubtasks` function already has a warning log for this scenario (lines 96-113 of `subtasks.js`) but still proceeds with deletion after logging. That warning remains useful as a last-resort signal, but the correct fix is preventing the empty array from being sent in the first place.