### PR TITLE
fix(calendar): show task titles instead of recurrence frequency labels

### DIFF
--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -325,7 +325,9 @@ router.get('/tasks', async (req, res) => {
         );
 
         const serializationOptions =
-            type === 'today' ? { preserveOriginalName: true } : {};
+            type === 'today' || type === 'calendar'
+                ? { preserveOriginalName: true }
+                : {};
 
         const response = {
             tasks: await serializeTasks(

--- a/frontend/components/Calendar.tsx
+++ b/frontend/components/Calendar.tsx
@@ -71,7 +71,7 @@ const Calendar: React.FC = () => {
     const loadTasks = async () => {
         setIsLoadingTasks(true);
         try {
-            const response = await fetch(getApiPath('tasks'), {
+            const response = await fetch(getApiPath('tasks?type=calendar'), {
                 credentials: 'include',
             });
             if (response.ok) {


### PR DESCRIPTION
## Description

In the calendar view, recurring parent tasks were displayed with their recurrence frequency label ("Monthly", "Weekly", etc.) instead of their actual title. This happened because the tasks API serializer transforms recurring parent task `name` fields to their recurrence type when no specific type is requested.

The fix adds a `type=calendar` parameter when the calendar fetches tasks. The backend already supports `preserveOriginalName: true` for the `type=today` case — this PR extends the same behavior to `type=calendar`, so the serializer returns the actual task names in the `name` field rather than the frequency labels.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1251

## Testing

**How did you test this?**

- Reviewed the serializer logic in `backend/modules/tasks/core/serializers.js` to confirm `preserveOriginalName: true` prevents the display name transformation
- Traced the data flow from `GET /api/tasks?type=calendar` through the serializer to the calendar event rendering
- Verified the existing `original_name || name` fallback in `convertTasksToEvents` continues to work as a safety net

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code

## Additional Notes

The `original_name || name` fallback introduced in #1249 remains in place as a safety net but the root cause is now fixed at the API level: the calendar always receives actual task names from the backend.