### PR TITLE
fix(migrations): guard goals and people migrations against duplicate columns on clean install

### DIFF
--- a/backend/migrations/20260624000001-create-goals.js
+++ b/backend/migrations/20260624000001-create-goals.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const { safeCreateTable, safeAddIndex } = require('../utils/migration-utils');
+
 module.exports = {
     async up(queryInterface, Sequelize) {
-        await queryInterface.createTable('goals', {
+        await safeCreateTable(queryInterface, 'goals', {
             id: {
                 type: Sequelize.INTEGER,
                 primaryKey: true,
@@ -67,13 +69,13 @@ module.exports = {
             },
         });
 
-        await queryInterface.addIndex('goals', ['area_id'], {
+        await safeAddIndex(queryInterface, 'goals', ['area_id'], {
             name: 'goals_area_id_idx',
         });
-        await queryInterface.addIndex('goals', ['user_id'], {
+        await safeAddIndex(queryInterface, 'goals', ['user_id'], {
             name: 'goals_user_id_idx',
         });
-        await queryInterface.addIndex('goals', ['status'], {
+        await safeAddIndex(queryInterface, 'goals', ['status'], {
             name: 'goals_status_idx',
         });
     },

--- a/backend/migrations/20260624000002-add-goal-columns-to-projects.js
+++ b/backend/migrations/20260624000002-add-goal-columns-to-projects.js
@@ -1,25 +1,34 @@
 'use strict';
 
+const { safeAddColumns, safeAddIndex } = require('../utils/migration-utils');
+
 module.exports = {
     async up(queryInterface, Sequelize) {
-        await queryInterface.addColumn('projects', 'goal_id', {
-            type: Sequelize.INTEGER,
-            allowNull: true,
-            references: {
-                model: 'goals',
-                key: 'id',
+        await safeAddColumns(queryInterface, 'projects', [
+            {
+                name: 'goal_id',
+                definition: {
+                    type: Sequelize.INTEGER,
+                    allowNull: true,
+                    references: {
+                        model: 'goals',
+                        key: 'id',
+                    },
+                    onUpdate: 'CASCADE',
+                    onDelete: 'SET NULL',
+                },
             },
-            onUpdate: 'CASCADE',
-            onDelete: 'SET NULL',
-        });
+            {
+                name: 'is_maintenance',
+                definition: {
+                    type: Sequelize.BOOLEAN,
+                    allowNull: false,
+                    defaultValue: false,
+                },
+            },
+        ]);
 
-        await queryInterface.addColumn('projects', 'is_maintenance', {
-            type: Sequelize.BOOLEAN,
-            allowNull: false,
-            defaultValue: false,
-        });
-
-        await queryInterface.addIndex('projects', ['goal_id'], {
+        await safeAddIndex(queryInterface, 'projects', ['goal_id'], {
             name: 'projects_goal_id_idx',
         });
     },

--- a/backend/migrations/20260630000001-create-people.js
+++ b/backend/migrations/20260630000001-create-people.js
@@ -1,8 +1,10 @@
 'use strict';
 
+const { safeCreateTable, safeAddIndex } = require('../utils/migration-utils');
+
 module.exports = {
     async up(queryInterface, Sequelize) {
-        await queryInterface.createTable('people', {
+        await safeCreateTable(queryInterface, 'people', {
             id: {
                 type: Sequelize.INTEGER,
                 primaryKey: true,
@@ -61,10 +63,10 @@ module.exports = {
             },
         });
 
-        await queryInterface.addIndex('people', ['user_id', 'archived'], {
+        await safeAddIndex(queryInterface, 'people', ['user_id', 'archived'], {
             name: 'people_user_archived_idx',
         });
-        await queryInterface.addIndex('people', ['user_id', 'name'], {
+        await safeAddIndex(queryInterface, 'people', ['user_id', 'name'], {
             name: 'people_user_name_idx',
             unique: true,
         });

--- a/backend/migrations/20260630000002-add-people-to-tasks.js
+++ b/backend/migrations/20260630000002-add-people-to-tasks.js
@@ -1,26 +1,35 @@
 'use strict';
 
+const { safeAddColumns, safeAddIndex } = require('../utils/migration-utils');
+
 module.exports = {
     async up(queryInterface, Sequelize) {
-        await queryInterface.addColumn('tasks', 'assigned_to', {
-            type: Sequelize.STRING(15),
-            allowNull: true,
-            defaultValue: null,
-            references: {
-                model: 'people',
-                key: 'uid',
+        await safeAddColumns(queryInterface, 'tasks', [
+            {
+                name: 'assigned_to',
+                definition: {
+                    type: Sequelize.STRING(15),
+                    allowNull: true,
+                    defaultValue: null,
+                    references: {
+                        model: 'people',
+                        key: 'uid',
+                    },
+                    onUpdate: 'CASCADE',
+                    onDelete: 'SET NULL',
+                },
             },
-            onUpdate: 'CASCADE',
-            onDelete: 'SET NULL',
-        });
+            {
+                name: 'involves',
+                definition: {
+                    type: Sequelize.TEXT,
+                    allowNull: true,
+                    defaultValue: null,
+                },
+            },
+        ]);
 
-        await queryInterface.addColumn('tasks', 'involves', {
-            type: Sequelize.TEXT,
-            allowNull: true,
-            defaultValue: null,
-        });
-
-        await queryInterface.addIndex('tasks', ['assigned_to'], {
+        await safeAddIndex(queryInterface, 'tasks', ['assigned_to'], {
             name: 'tasks_assigned_to_idx',
         });
     },

--- a/backend/migrations/20260630000003-add-color-to-people.js
+++ b/backend/migrations/20260630000003-add-color-to-people.js
@@ -1,12 +1,19 @@
 'use strict';
 
+const { safeAddColumns } = require('../utils/migration-utils');
+
 module.exports = {
     async up(queryInterface, Sequelize) {
-        await queryInterface.addColumn('people', 'color', {
-            type: Sequelize.STRING(20),
-            allowNull: true,
-            defaultValue: null,
-        });
+        await safeAddColumns(queryInterface, 'people', [
+            {
+                name: 'color',
+                definition: {
+                    type: Sequelize.STRING(20),
+                    allowNull: true,
+                    defaultValue: null,
+                },
+            },
+        ]);
     },
 
     async down(queryInterface) {


### PR DESCRIPTION
## Description

On a fresh Docker install, `db-init.js` runs `sequelize.sync()` which creates all tables with **all current model columns** before migrations execute. When Sequelize CLI then runs migrations, columns like `goal_id`, `is_maintenance`, `assigned_to`, etc. already exist — causing `SQLITE_ERROR: duplicate column name` errors.

When any migration in the sequence fails, Sequelize CLI stops processing further migrations. This meant `20260626000001-add-ai-brief-cache-to-users` never ran, so the `ai_daily_brief` column was never added to the `users` table, causing user creation to fail with `SQLITE_ERROR: no such column: ai_daily_brief`.

This is the same class of bug fixed in #1245 for `add-area-id-to-tasks`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1257

## Changes

Wrap bare `queryInterface.addColumn`, `queryInterface.createTable`, and `queryInterface.addIndex` calls with the existing safe utility wrappers in 5 migrations:

- `20260624000001-create-goals.js` — `safeCreateTable` + `safeAddIndex`
- `20260624000002-add-goal-columns-to-projects.js` — `safeAddColumns` + `safeAddIndex`
- `20260630000001-create-people.js` — `safeCreateTable` + `safeAddIndex`
- `20260630000002-add-people-to-tasks.js` — `safeAddColumns` + `safeAddIndex`
- `20260630000003-add-color-to-people.js` — `safeAddColumns`

## Testing

- [x] `npm run lint` passes
- Manual verification: on a fresh install the safe wrappers check whether columns/tables already exist and skip creation if so, matching the behavior of the fixed `add-area-id-to-tasks` migration from #1245

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my changes
- [x] No new dependencies introduced