### PR TITLE
fix(docker): preserve data from old mount path and harden startup error handling

### DIFF
--- a/backend/cmd/start.sh
+++ b/backend/cmd/start.sh
@@ -77,6 +77,17 @@ backup_db() {
   fi
 }
 
+# Before v1.2.0, the database was mounted at /app/backend/db. If the new path
+# does not exist but the old path does, copy it over so data is preserved.
+OLD_DB_PATH="/app/backend/db/${NODE_ENV}.sqlite3"
+if [ ! -f "$DB_FILE" ] && [ -f "$OLD_DB_PATH" ]; then
+  echo "⚠️  Database found at old location ($OLD_DB_PATH)."
+  echo "    Copying to new location ($DB_FILE) to preserve data..."
+  mkdir -p "$(dirname "$DB_FILE")"
+  cp "$OLD_DB_PATH" "$DB_FILE"
+  echo "✅ Database copied. Update your volume mount from :/app/backend/db to :/app/db."
+fi
+
 # Check if database exists and create/authenticate
 if [ ! -f "$DB_FILE" ]; then
   echo "Creating new database..."
@@ -89,16 +100,20 @@ fi
 
 # Run database migrations automatically
 echo "Running database migrations..."
-if npx sequelize-cli db:migrate --config config/database.js; then
-  echo "Migrations completed successfully"
-else
-  echo "Migration failed, but continuing startup (may be expected for new installations)"
+if ! npx sequelize-cli db:migrate --config config/database.js; then
+  echo "❌ Migration failed. Container cannot start with an incomplete schema."
+  echo "   Check the migration error above and restore from backup if needed."
+  exit 1
 fi
+echo "Migrations completed successfully"
 
 if [ -n "${TUDUDI_USER_EMAIL:-}" ] && [ -n "${TUDUDI_USER_PASSWORD:-}" ]; then
   # Trim whitespace/carriage returns that may come from docker-compose env vars
   TUDUDI_USER_EMAIL=$(printf '%s' "$TUDUDI_USER_EMAIL" | tr -d '[:space:]')
-  node scripts/user-create.js "$TUDUDI_USER_EMAIL" "$TUDUDI_USER_PASSWORD" true || exit 1
+  if ! node scripts/user-create.js "$TUDUDI_USER_EMAIL" "$TUDUDI_USER_PASSWORD" true; then
+    echo "❌ Failed to create/update user. Check migration errors above."
+    exit 1
+  fi
 fi
 
 exec node app.js

--- a/backend/migrations/20260420000005-add-caldav-indexes.js
+++ b/backend/migrations/20260420000005-add-caldav-indexes.js
@@ -1,90 +1,133 @@
-const { DataTypes } = require('sequelize');
+'use strict';
+
+async function addIndexIfMissing(queryInterface, tableName, fields, options) {
+    try {
+        const indexes = await queryInterface.showIndex(tableName);
+        const exists = indexes.some((idx) => idx.name === options.name);
+        if (!exists) {
+            await queryInterface.addIndex(tableName, fields, options);
+        }
+    } catch (err) {
+        console.log(`Skipping index ${options.name}: ${err.message}`);
+    }
+}
 
 module.exports = {
-    up: async (queryInterface, Sequelize) => {
-        await queryInterface.addIndex('caldav_calendars', ['user_id'], {
-            name: 'idx_caldav_calendars_user_id',
-        });
-
-        await queryInterface.addIndex('caldav_calendars', ['enabled'], {
-            name: 'idx_caldav_calendars_enabled',
-        });
-
-        await queryInterface.addIndex(
+    up: async (queryInterface) => {
+        await addIndexIfMissing(
+            queryInterface,
+            'caldav_calendars',
+            ['user_id'],
+            {
+                name: 'idx_caldav_calendars_user_id',
+            }
+        );
+        await addIndexIfMissing(
+            queryInterface,
+            'caldav_calendars',
+            ['enabled'],
+            {
+                name: 'idx_caldav_calendars_enabled',
+            }
+        );
+        await addIndexIfMissing(
+            queryInterface,
             'caldav_calendars',
             ['user_id', 'enabled'],
             {
                 name: 'idx_caldav_calendars_user_enabled',
             }
         );
-
-        await queryInterface.addIndex('caldav_sync_state', ['task_id'], {
-            name: 'idx_caldav_sync_state_task_id',
-        });
-
-        await queryInterface.addIndex('caldav_sync_state', ['calendar_id'], {
-            name: 'idx_caldav_sync_state_calendar_id',
-        });
-
-        await queryInterface.addIndex('caldav_sync_state', ['sync_status'], {
-            name: 'idx_caldav_sync_state_status',
-        });
-
-        await queryInterface.addIndex('caldav_sync_state', ['last_modified'], {
-            name: 'idx_caldav_sync_state_modified',
-        });
-
-        await queryInterface.addIndex(
+        await addIndexIfMissing(
+            queryInterface,
+            'caldav_sync_state',
+            ['task_id'],
+            {
+                name: 'idx_caldav_sync_state_task_id',
+            }
+        );
+        await addIndexIfMissing(
+            queryInterface,
+            'caldav_sync_state',
+            ['calendar_id'],
+            {
+                name: 'idx_caldav_sync_state_calendar_id',
+            }
+        );
+        await addIndexIfMissing(
+            queryInterface,
+            'caldav_sync_state',
+            ['sync_status'],
+            {
+                name: 'idx_caldav_sync_state_status',
+            }
+        );
+        await addIndexIfMissing(
+            queryInterface,
+            'caldav_sync_state',
+            ['last_modified'],
+            {
+                name: 'idx_caldav_sync_state_modified',
+            }
+        );
+        await addIndexIfMissing(
+            queryInterface,
             'caldav_occurrence_overrides',
             ['parent_task_id'],
             {
                 name: 'idx_caldav_overrides_parent',
             }
         );
-
-        await queryInterface.addIndex(
+        await addIndexIfMissing(
+            queryInterface,
             'caldav_occurrence_overrides',
             ['calendar_id'],
             {
                 name: 'idx_caldav_overrides_calendar',
             }
         );
-
-        await queryInterface.addIndex(
+        await addIndexIfMissing(
+            queryInterface,
             'caldav_occurrence_overrides',
             ['recurrence_id'],
             {
                 name: 'idx_caldav_overrides_recurrence',
             }
         );
-
-        await queryInterface.addIndex('caldav_remote_calendars', ['user_id'], {
-            name: 'idx_caldav_remote_user_id',
-        });
-
-        await queryInterface.addIndex('caldav_remote_calendars', ['enabled'], {
-            name: 'idx_caldav_remote_enabled',
-        });
-
-        await queryInterface.addIndex(
+        await addIndexIfMissing(
+            queryInterface,
+            'caldav_remote_calendars',
+            ['user_id'],
+            {
+                name: 'idx_caldav_remote_user_id',
+            }
+        );
+        await addIndexIfMissing(
+            queryInterface,
+            'caldav_remote_calendars',
+            ['enabled'],
+            {
+                name: 'idx_caldav_remote_enabled',
+            }
+        );
+        await addIndexIfMissing(
+            queryInterface,
             'caldav_remote_calendars',
             ['local_calendar_id'],
             {
                 name: 'idx_caldav_remote_local_cal',
             }
         );
-
-        await queryInterface.addIndex('tasks', ['uid'], {
+        await addIndexIfMissing(queryInterface, 'tasks', ['uid'], {
             name: 'idx_tasks_uid',
             unique: false,
         });
-
-        await queryInterface.addIndex('tasks', ['updated_at'], {
+        await addIndexIfMissing(queryInterface, 'tasks', ['updated_at'], {
             name: 'idx_tasks_updated_at',
         });
     },
 
-    down: async (queryInterface, Sequelize) => {
+    down: async (queryInterface) => {
         await queryInterface.removeIndex(
             'caldav_calendars',
             'idx_caldav_calendars_user_id'
@@ -97,7 +140,6 @@ module.exports = {
             'caldav_calendars',
             'idx_caldav_calendars_user_enabled'
         );
-
         await queryInterface.removeIndex(
             'caldav_sync_state',
             'idx_caldav_sync_state_task_id'
@@ -114,7 +156,6 @@ module.exports = {
             'caldav_sync_state',
             'idx_caldav_sync_state_modified'
         );
-
         await queryInterface.removeIndex(
             'caldav_occurrence_overrides',
             'idx_caldav_overrides_parent'
@@ -127,7 +168,6 @@ module.exports = {
             'caldav_occurrence_overrides',
             'idx_caldav_overrides_recurrence'
         );
-
         await queryInterface.removeIndex(
             'caldav_remote_calendars',
             'idx_caldav_remote_user_id'
@@ -140,7 +180,6 @@ module.exports = {
             'caldav_remote_calendars',
             'idx_caldav_remote_local_cal'
         );
-
         await queryInterface.removeIndex('tasks', 'idx_tasks_uid');
         await queryInterface.removeIndex('tasks', 'idx_tasks_updated_at');
     },


### PR DESCRIPTION
## Description

Addresses the infinite Docker restart loop reported in #1263 with two improvements.

**Problem 1: Data loss on upgrade from <v1.2.0**
Users who upgraded to v1.2.0+ without updating their `docker-compose.yml` volume mount (from `:/app/backend/db` to `:/app/db`) ended up with an empty database because the container couldn't find their data at the new path. The container silently initialized a fresh database, making all tasks appear to vanish.

**Problem 2: Confusing cascade error → infinite restart loop**
When any migration failed, the startup script continued anyway. If `TUDUDI_USER_EMAIL`/`TUDUDI_USER_PASSWORD` were set, user creation would then fail with a cryptic `no such column: ai_daily_brief` error (because the schema was incomplete), triggering `exit 1` and an infinite Docker restart loop. The root migration failure was the one fixed by #1268.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #1263

## Changes

### `backend/cmd/start.sh`
- **Old-path fallback**: Before checking whether to run `db-init`, detect if the database exists at the old pre-v1.2.0 location (`/app/backend/db/${NODE_ENV}.sqlite3`) and copy it to the new location (`$DB_FILE`). Logs a clear message advising the user to update their volume mount.
- **Fail fast on migration failure**: Changed from silently continuing past a failed migration to `exit 1` with a clear error message. This avoids the confusing downstream `no such column` user-creation error. With all current migration guards in place, migrations should never fail in normal operation.
- **Clearer user-creation error**: Wrapped the `node scripts/user-create.js` call in an explicit `if !` check with a descriptive error message.

### `backend/migrations/20260420000005-add-caldav-indexes.js`
- Added an `addIndexIfMissing` helper that checks index existence by name before calling `addIndex`. Previously this migration had no guard and would fail with a duplicate-index error on fresh installs (where `db-init` creates tables via `sync({ force: true })` and model-defined indexes already exist).

## Testing

- [x] Verified linting passes (`npm run lint`)
- [x] Manual review of upgrade paths: fresh install, upgrade from v1.1.0-rc.3, upgrade with old volume mount path