### PR TITLE
fix(sqlite): apply busy_timeout via afterConnect to prevent SQLITE_BUSY on first install

### DIFF
--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -21,26 +21,38 @@ const sequelize = new Sequelize(dbConfig);
 
 // SQLite performance optimizations for slow I/O systems (e.g., Synology NAS with HDDs)
 if (dbConfig.dialect === 'sqlite') {
-    const pragmas = [
-        // WAL mode: sequential writes instead of random I/O, better for Btrfs COW
-        'PRAGMA journal_mode=WAL;',
-        // Relaxed sync: faster writes with minimal durability risk for single-user app
-        'PRAGMA synchronous=NORMAL;',
-        // 5 second busy timeout: prevents "database is locked" errors under load
-        'PRAGMA busy_timeout=5000;',
-        // 64MB cache: keeps more data in memory, reduces disk reads
-        'PRAGMA cache_size=-64000;',
-        // Store temp tables in memory instead of disk
-        'PRAGMA temp_store=MEMORY;',
-        // Enable memory-mapped I/O (256MB): faster reads on large databases
-        'PRAGMA mmap_size=268435456;',
-    ];
+    // Per-connection PRAGMAs via afterConnect, which runs inside _connect() before
+    // the connection is returned to the pool. This guarantees busy_timeout is set
+    // on every connection before first use, preventing SQLITE_BUSY errors when
+    // startup scripts race against an async IIFE that might not yet have run.
+    sequelize.afterConnect(async (connection) => {
+        await new Promise((resolve, reject) => {
+            connection.exec(
+                [
+                    // Relaxed sync: faster writes with minimal durability risk for single-user app
+                    'PRAGMA synchronous=NORMAL;',
+                    // 5 second busy timeout: prevents "database is locked" errors under load
+                    'PRAGMA busy_timeout=5000;',
+                    // 64MB cache: keeps more data in memory, reduces disk reads
+                    'PRAGMA cache_size=-64000;',
+                    // Store temp tables in memory instead of disk
+                    'PRAGMA temp_store=MEMORY;',
+                    // Enable memory-mapped I/O (256MB): faster reads on large databases
+                    'PRAGMA mmap_size=268435456;',
+                ].join('\n'),
+                (err) => {
+                    if (err) reject(err);
+                    else resolve();
+                }
+            );
+        });
+    });
 
+    // WAL mode persists in the DB file — set it once on startup.
+    // afterConnect ensures busy_timeout is already applied on the connection used here.
     (async () => {
         try {
-            for (const pragma of pragmas) {
-                await sequelize.query(pragma);
-            }
+            await sequelize.query('PRAGMA journal_mode=WAL;');
             if (config.environment === 'development') {
                 console.log('SQLite performance optimizations enabled');
             }


### PR DESCRIPTION
## Description

On a fresh Docker install (v1.2.3), system tags (`someday` and `today`) were never created because `seedSystemTagsForUser` hit a `SQLITE_BUSY: database is locked` error during first startup.

**Root cause:** All SQLite PRAGMAs, including `busy_timeout=5000`, were set inside a fire-and-forget async IIFE. The startup sequence is three separate Node processes:
1. `node scripts/db-init.js` — creates schema
2. `npx sequelize-cli db:migrate` — runs migrations (no `busy_timeout` set, separate process)
3. `node scripts/user-create.js` — creates initial user, triggers `afterCreate` hook

When `user-create.js` loaded `models/index.js`, the PRAGMA IIFE ran concurrently with user creation. `Tag.findOrCreate` could be reached before `busy_timeout` was applied to that connection, so SQLite immediately returned `SQLITE_BUSY` with no retry.

**Fix:** Move per-connection PRAGMAs (`synchronous`, `busy_timeout`, `cache_size`, `temp_store`, `mmap_size`) into a `sequelize.afterConnect` hook. Sequelize calls `afterConnect` inside `_connect()`, before the connection is returned to the pool, so `busy_timeout=5000` is guaranteed on every connection before any query runs.

`journal_mode=WAL` is a database-level setting that persists in the file, so it only needs to be set once and stays in the async IIFE.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1270

## Testing

- [x] Ran `npm run lint` — no new errors
- [x] Ran `npm test -- tests/integration/user-create-script.test.js` — all 15 tests pass
- [x] Ran full `npm test` suite — no new failures introduced

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings