### PR TITLE
fix(rate-limit): suppress ERR_ERL_PERMISSIVE_TRUST_PROXY when TUDUDI_TRUST_PROXY=true

### DIFF
--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -120,10 +120,12 @@ const config = {
             return false;
         }
         if (val === 'true') {
-            console.log(
-                '[Config] TUDUDI_TRUST_PROXY=true parsed as boolean true'
+            console.warn(
+                '[Config] TUDUDI_TRUST_PROXY=true is permissive — converting to 1 (single hop). ' +
+                    'Set TUDUDI_TRUST_PROXY=1 explicitly to silence this warning, ' +
+                    'or use a higher number if you have multiple proxy hops.'
             );
-            return true;
+            return 1;
         }
         if (val === 'false') {
             console.log(

--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -8,11 +8,6 @@ const rateLimitConfig = config.rateLimiting;
 // Skip rate limiting if disabled in config
 const skipInTest = (req) => !rateLimitConfig.enabled;
 
-// When trust proxy is set to boolean true, express-rate-limit raises ERR_ERL_PERMISSIVE_TRUST_PROXY
-// because anyone could spoof X-Forwarded-For. We suppress the check here since the operator
-// has explicitly opted in via TUDUDI_TRUST_PROXY.
-const validateOptions = config.trustProxy === true ? { trustProxy: false } : {};
-
 /**
  * Strict rate limiting for authentication endpoints
  * Prevents brute force attacks on login/register
@@ -25,7 +20,6 @@ const authLimiter = rateLimit({
     },
     standardHeaders: true,
     legacyHeaders: false,
-    validate: validateOptions,
     skip: skipInTest,
     handler: (req, res) => {
         res.status(429).json({
@@ -48,7 +42,6 @@ const apiLimiter = rateLimit({
     },
     standardHeaders: true,
     legacyHeaders: false,
-    validate: validateOptions,
     skip: (req) => {
         // Skip if rate limiting is disabled
         if (!rateLimitConfig.enabled) return true;
@@ -74,7 +67,6 @@ const authenticatedApiLimiter = rateLimit({
     max: rateLimitConfig.authenticatedApi.max,
     standardHeaders: true,
     legacyHeaders: false,
-    validate: validateOptions,
     keyGenerator: (req) => {
         // Prefer user ID from session or API token authentication
         const userId =
@@ -109,7 +101,6 @@ const createResourceLimiter = rateLimit({
     max: rateLimitConfig.createResource.max,
     standardHeaders: true,
     legacyHeaders: false,
-    validate: validateOptions,
     skip: skipInTest,
     keyGenerator: (req) => {
         const userId =
@@ -137,7 +128,6 @@ const apiKeyManagementLimiter = rateLimit({
     max: rateLimitConfig.apiKeyManagement.max,
     standardHeaders: true,
     legacyHeaders: false,
-    validate: validateOptions,
     skip: skipInTest,
     keyGenerator: (req) => {
         const userId =

--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -2,23 +2,16 @@ const rateLimit = require('express-rate-limit');
 const { ipKeyGenerator } = require('express-rate-limit');
 const { getConfig } = require('../config/config');
 
-/**
- * Rate limiting middleware for different endpoint types
- *
- * Rate limits are configured based on authentication state and endpoint sensitivity:
- * - Strict limits for authentication endpoints (login, register)
- * - Moderate limits for general API endpoints
- * - Higher limits for authenticated users with API tokens
- *
- * Configuration is centralized in backend/config/config.js and can be customized via environment variables.
- * Rate limiting is automatically disabled in test environment.
- */
-
 const config = getConfig();
 const rateLimitConfig = config.rateLimiting;
 
 // Skip rate limiting if disabled in config
 const skipInTest = (req) => !rateLimitConfig.enabled;
+
+// When trust proxy is set to boolean true, express-rate-limit raises ERR_ERL_PERMISSIVE_TRUST_PROXY
+// because anyone could spoof X-Forwarded-For. We suppress the check here since the operator
+// has explicitly opted in via TUDUDI_TRUST_PROXY.
+const validateOptions = config.trustProxy === true ? { trustProxy: false } : {};
 
 /**
  * Strict rate limiting for authentication endpoints
@@ -30,8 +23,9 @@ const authLimiter = rateLimit({
     message: {
         error: 'Too many authentication attempts from this IP, please try again after 15 minutes',
     },
-    standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
-    legacyHeaders: false, // Disable the `X-RateLimit-*` headers
+    standardHeaders: true,
+    legacyHeaders: false,
+    validate: validateOptions,
     skip: skipInTest,
     handler: (req, res) => {
         res.status(429).json({
@@ -54,7 +48,7 @@ const apiLimiter = rateLimit({
     },
     standardHeaders: true,
     legacyHeaders: false,
-    // Skip rate limiting for authenticated users or if disabled
+    validate: validateOptions,
     skip: (req) => {
         // Skip if rate limiting is disabled
         if (!rateLimitConfig.enabled) return true;
@@ -80,7 +74,7 @@ const authenticatedApiLimiter = rateLimit({
     max: rateLimitConfig.authenticatedApi.max,
     standardHeaders: true,
     legacyHeaders: false,
-    // Use user ID as the key instead of IP for authenticated requests
+    validate: validateOptions,
     keyGenerator: (req) => {
         // Prefer user ID from session or API token authentication
         const userId =
@@ -115,6 +109,7 @@ const createResourceLimiter = rateLimit({
     max: rateLimitConfig.createResource.max,
     standardHeaders: true,
     legacyHeaders: false,
+    validate: validateOptions,
     skip: skipInTest,
     keyGenerator: (req) => {
         const userId =
@@ -142,6 +137,7 @@ const apiKeyManagementLimiter = rateLimit({
     max: rateLimitConfig.apiKeyManagement.max,
     standardHeaders: true,
     legacyHeaders: false,
+    validate: validateOptions,
     skip: skipInTest,
     keyGenerator: (req) => {
         const userId =

--- a/backend/shared/middleware/errorHandler.js
+++ b/backend/shared/middleware/errorHandler.js
@@ -36,7 +36,7 @@ function errorHandler(err, req, res, next) {
         });
     }
 
-    // Handle express-rate-limit trust proxy validation error
+    // Handle express-rate-limit trust proxy validation errors
     if (err.code === 'ERR_ERL_UNEXPECTED_X_FORWARDED_FOR') {
         return res.status(500).json({
             error: 'Trust proxy configuration error',
@@ -44,6 +44,15 @@ function errorHandler(err, req, res, next) {
                 'X-Forwarded-For header detected but trust proxy is not configured. ' +
                 'Please set TUDUDI_TRUST_PROXY=true in your environment variables. ' +
                 'See documentation: https://github.com/chrisvel/tududi#reverse-proxy-setup',
+            code: 'TRUST_PROXY_ERROR',
+        });
+    }
+    if (err.code === 'ERR_ERL_PERMISSIVE_TRUST_PROXY') {
+        return res.status(500).json({
+            error: 'Trust proxy configuration error',
+            message:
+                'Express trust proxy is set to true, which is permissive. ' +
+                'Consider setting TUDUDI_TRUST_PROXY to a specific hop count (e.g. 1) instead of true.',
             code: 'TRUST_PROXY_ERROR',
         });
     }


### PR DESCRIPTION
## Description

When `TUDUDI_TRUST_PROXY=true` is set (required for reverse proxy setups), `express-rate-limit` v7 throws `ERR_ERL_PERMISSIVE_TRUST_PROXY` on every rate-limited request, flooding the console and causing 500 errors on OIDC auth routes.

**Root cause**: `trust proxy: true` (boolean) tells Express to trust *all* proxies, which lets any client forge `X-Forwarded-For` and bypass IP-based rate limiting. The express-rate-limit library deliberately flags this.

**Fix**: When `TUDUDI_TRUST_PROXY=true` is parsed, emit a startup warning and convert the value to `1` (trust exactly one proxy hop). This:
- fixes `ERR_ERL_PERMISSIVE_TRUST_PROXY` for the common single-proxy case
- keeps `req.ip` pointing at the address the trusted proxy inserted (not a client-supplied spoofed value), so rate limiting remains effective
- does not suppress any security validation in express-rate-limit

Also adds `ERR_ERL_PERMISSIVE_TRUST_PROXY` handling to the global error handler as a defensive fallback.

**Migration**: `TUDUDI_TRUST_PROXY=true` continues to work but prints a startup warning. Users with multiple proxy hops should set `TUDUDI_TRUST_PROXY=2` (or appropriate hop count) rather than `true`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1258

## Testing

- Reproduce: start Tududi with `TUDUDI_TRUST_PROXY=true`, make a request to any OIDC route; `ERR_ERL_PERMISSIVE_TRUST_PROXY` no longer appears.
- Startup log now shows: `[Config] TUDUDI_TRUST_PROXY=true is permissive — converting to 1 (single hop)...`
- `npm run lint` passes with no errors.

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested my changes locally
- [x] I have run linting (`npm run lint`) and fixed any issues