### PR TITLE
fix(caldav): align frontend sync direction values with backend model

### DIFF
--- a/frontend/components/CalDAV/CalendarCard.tsx
+++ b/frontend/components/CalDAV/CalendarCard.tsx
@@ -50,9 +50,9 @@ const CalendarCard: React.FC<CalendarCardProps> = ({
         switch (calendar.sync_direction) {
             case 'bidirectional':
                 return t('profile.caldav.bidirectional', 'Bidirectional');
-            case 'pull':
+            case 'pull_only':
                 return t('profile.caldav.pullOnly', 'Pull only');
-            case 'push':
+            case 'push_only':
                 return t('profile.caldav.pushOnly', 'Push only');
             default:
                 return calendar.sync_direction;

--- a/frontend/components/CalDAV/CalendarForm.tsx
+++ b/frontend/components/CalDAV/CalendarForm.tsx
@@ -36,7 +36,7 @@ const CalendarForm: React.FC<CalendarFormProps> = ({ onComplete, onCancel }) => 
         username: '',
         password: '',
         authType: 'basic' as 'basic' | 'bearer',
-        syncDirection: 'bidirectional' as 'bidirectional' | 'pull' | 'push',
+        syncDirection: 'bidirectional' as 'bidirectional' | 'pull_only' | 'push_only',
         syncInterval: 15,
         conflictResolution: 'manual' as 'last_write_wins' | 'local_wins' | 'remote_wins' | 'manual',
         enabled: true,
@@ -463,7 +463,7 @@ const CalendarForm: React.FC<CalendarFormProps> = ({ onComplete, onCancel }) => 
                         onChange={(e) =>
                             setFormData({
                                 ...formData,
-                                syncDirection: e.target.value as 'bidirectional' | 'pull' | 'push',
+                                syncDirection: e.target.value as 'bidirectional' | 'pull_only' | 'push_only',
                             })
                         }
                         className="block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-900 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500"
@@ -471,10 +471,10 @@ const CalendarForm: React.FC<CalendarFormProps> = ({ onComplete, onCancel }) => 
                         <option value="bidirectional">
                             {t('profile.caldavWizard.bidirectional', 'Bidirectional (sync both ways)')}
                         </option>
-                        <option value="pull">
+                        <option value="pull_only">
                             {t('profile.caldavWizard.pullOnly', 'Pull only (from server to Tududi)')}
                         </option>
-                        <option value="push">
+                        <option value="push_only">
                             {t('profile.caldavWizard.pushOnly', 'Push only (from Tududi to server)')}
                         </option>
                     </select>

--- a/frontend/components/CalDAV/EditCalendarModal.tsx
+++ b/frontend/components/CalDAV/EditCalendarModal.tsx
@@ -226,8 +226,8 @@ const EditCalendarModal: React.FC<EditCalendarModalProps> = ({
                                     ...formData,
                                     sync_direction: e.target.value as
                                         | 'bidirectional'
-                                        | 'pull'
-                                        | 'push',
+                                        | 'pull_only'
+                                        | 'push_only',
                                 })
                             }
                             disabled={isSubmitting}
@@ -239,13 +239,13 @@ const EditCalendarModal: React.FC<EditCalendarModalProps> = ({
                                     'Bidirectional (sync both ways)'
                                 )}
                             </option>
-                            <option value="pull">
+                            <option value="pull_only">
                                 {t(
                                     'profile.caldavWizard.pullOnly',
                                     'Pull only (from server to Tududi)'
                                 )}
                             </option>
-                            <option value="push">
+                            <option value="push_only">
                                 {t(
                                     'profile.caldavWizard.pushOnly',
                                     'Push only (from Tududi to server)'

--- a/frontend/components/CalDAV/SetupWizard.tsx
+++ b/frontend/components/CalDAV/SetupWizard.tsx
@@ -29,7 +29,7 @@ interface WizardData {
     username: string;
     password: string;
     authType: 'basic' | 'bearer';
-    syncDirection: 'bidirectional' | 'pull' | 'push';
+    syncDirection: 'bidirectional' | 'pull_only' | 'push_only';
     syncInterval: number;
     conflictResolution: 'last_write_wins' | 'local_wins' | 'remote_wins' | 'manual';
     enabled: boolean;
@@ -586,8 +586,8 @@ const SetupWizard: React.FC<SetupWizardProps> = ({
                                         ...wizardData,
                                         syncDirection: e.target.value as
                                             | 'bidirectional'
-                                            | 'pull'
-                                            | 'push',
+                                            | 'pull_only'
+                                            | 'push_only',
                                     })
                                 }
                                 className="block w-full border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500"
@@ -598,13 +598,13 @@ const SetupWizard: React.FC<SetupWizardProps> = ({
                                         'Bidirectional (sync both ways)'
                                     )}
                                 </option>
-                                <option value="pull">
+                                <option value="pull_only">
                                     {t(
                                         'profile.caldavWizard.pullOnly',
                                         'Pull only (from server to Tududi)'
                                     )}
                                 </option>
-                                <option value="push">
+                                <option value="push_only">
                                     {t(
                                         'profile.caldavWizard.pushOnly',
                                         'Push only (from Tududi to server)'

--- a/frontend/utils/caldavService.ts
+++ b/frontend/utils/caldavService.ts
@@ -11,7 +11,7 @@ export interface CalDAVCalendar {
     ctag: string | null;
     sync_token: string | null;
     enabled: boolean;
-    sync_direction: 'bidirectional' | 'pull' | 'push';
+    sync_direction: 'bidirectional' | 'pull_only' | 'push_only';
     sync_interval_minutes: number;
     last_sync_at: string | null;
     last_sync_status: string | null;
@@ -36,7 +36,7 @@ export interface RemoteCalendar {
     username: string;
     auth_type: 'basic' | 'bearer';
     enabled: boolean;
-    sync_direction: 'bidirectional' | 'pull' | 'push';
+    sync_direction: 'bidirectional' | 'pull_only' | 'push_only';
     server_ctag: string | null;
     server_sync_token: string | null;
     last_sync_at: string | null;


### PR DESCRIPTION
## Description

The frontend dropdowns for CalDAV sync direction were sending `'pull'` and `'push'` as values, but the backend Sequelize model validates against `['bidirectional', 'pull_only', 'push_only']`. This caused a `SequelizeValidationError` whenever a user tried to change direction to anything other than bidirectional.

Fixed by updating all five affected frontend files to use `'pull_only'` and `'push_only'` instead of `'pull'` and `'push'`: option values, TypeScript type unions, type casts, and the display label switch in CalendarCard.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1188

## Testing

**How did you test this?**

Traced the value mismatch through the full frontend-to-backend call path. Backend model validates `['bidirectional', 'pull_only', 'push_only']`; frontend was sending `'pull'`/`'push'`.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)