### PR TITLE
fix(projects): per-user area overrides for shared projects

### DIFF
--- a/backend/migrations/20260714000001-create-user-project-areas.js
+++ b/backend/migrations/20260714000001-create-user-project-areas.js
@@ -1,0 +1,54 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await queryInterface.createTable('user_project_areas', {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+                allowNull: false,
+            },
+            user_id: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: { model: 'users', key: 'id' },
+                onDelete: 'CASCADE',
+            },
+            project_id: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: { model: 'projects', key: 'id' },
+                onDelete: 'CASCADE',
+            },
+            area_id: {
+                type: Sequelize.INTEGER,
+                allowNull: true,
+                references: { model: 'areas', key: 'id' },
+                onDelete: 'SET NULL',
+            },
+            created_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+            },
+            updated_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+            },
+        });
+
+        await queryInterface.addIndex('user_project_areas', ['user_id']);
+        await queryInterface.addIndex('user_project_areas', ['project_id']);
+        await queryInterface.addIndex(
+            'user_project_areas',
+            ['user_id', 'project_id'],
+            { unique: true, name: 'user_project_areas_user_project_unique' }
+        );
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable('user_project_areas');
+    },
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -92,6 +92,7 @@ const CalDAVRemoteCalendar = require('./caldav_remote_calendar')(sequelize);
 const CalendarToken = require('./calendar_token')(sequelize);
 const Goal = require('./goal')(sequelize);
 const Person = require('./person')(sequelize);
+const UserProjectArea = require('./user_project_area')(sequelize);
 
 User.hasMany(Area, { foreignKey: 'user_id' });
 Area.belongsTo(User, { foreignKey: 'user_id' });
@@ -284,6 +285,19 @@ User.hasMany(CalendarToken, {
 });
 CalendarToken.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
 
+// UserProjectArea associations (per-user area placement for shared projects)
+User.hasMany(UserProjectArea, {
+    foreignKey: 'user_id',
+    as: 'ProjectAreaOverrides',
+});
+UserProjectArea.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
+Project.hasMany(UserProjectArea, {
+    foreignKey: 'project_id',
+    as: 'AreaOverrides',
+});
+UserProjectArea.belongsTo(Project, { foreignKey: 'project_id', as: 'Project' });
+UserProjectArea.belongsTo(Area, { foreignKey: 'area_id', as: 'Area' });
+
 // Person associations
 User.hasMany(Person, { foreignKey: 'user_id', as: 'People' });
 Person.belongsTo(User, { foreignKey: 'user_id' });
@@ -341,4 +355,5 @@ module.exports = {
     CalDAVRemoteCalendar,
     CalendarToken,
     Person,
+    UserProjectArea,
 };

--- a/backend/models/user_project_area.js
+++ b/backend/models/user_project_area.js
@@ -1,0 +1,43 @@
+const { DataTypes } = require('sequelize');
+
+module.exports = (sequelize) => {
+    const UserProjectArea = sequelize.define(
+        'UserProjectArea',
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            user_id: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                references: { model: 'users', key: 'id' },
+            },
+            project_id: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                references: { model: 'projects', key: 'id' },
+            },
+            area_id: {
+                type: DataTypes.INTEGER,
+                allowNull: true,
+                references: { model: 'areas', key: 'id' },
+            },
+        },
+        {
+            tableName: 'user_project_areas',
+            indexes: [
+                { fields: ['user_id'] },
+                { fields: ['project_id'] },
+                {
+                    fields: ['user_id', 'project_id'],
+                    unique: true,
+                    name: 'user_project_areas_user_project_unique',
+                },
+            ],
+        }
+    );
+
+    return UserProjectArea;
+};

--- a/backend/modules/projects/repository.js
+++ b/backend/modules/projects/repository.js
@@ -11,6 +11,7 @@ const {
     User,
     Permission,
     TaskAttachment,
+    UserProjectArea,
     sequelize,
 } = require('../../models');
 const { Op } = require('sequelize');
@@ -377,6 +378,44 @@ class ProjectsRepository extends BaseRepository {
      */
     async createTag(name, userId) {
         return Tag.create({ name, user_id: userId });
+    }
+
+    /**
+     * Upsert a per-user area override for a shared project.
+     * area_id may be null to remove the project from the user's area.
+     */
+    async upsertUserProjectArea(userId, projectId, areaId) {
+        const [record] = await UserProjectArea.upsert(
+            { user_id: userId, project_id: projectId, area_id: areaId },
+            { conflictFields: ['user_id', 'project_id'] }
+        );
+        return record;
+    }
+
+    /**
+     * Get all per-user area overrides for a given user indexed by project_id.
+     */
+    async getUserProjectAreaOverrides(userId) {
+        const rows = await UserProjectArea.findAll({
+            where: { user_id: userId },
+            include: [
+                {
+                    model: Area,
+                    as: 'Area',
+                    required: false,
+                    attributes: ['id', 'uid', 'name', 'color'],
+                },
+            ],
+            raw: false,
+        });
+        const map = {};
+        rows.forEach((row) => {
+            map[row.project_id] = {
+                area_id: row.area_id,
+                Area: row.Area ? row.Area.toJSON() : null,
+            };
+        });
+        return map;
     }
 }
 

--- a/backend/modules/projects/service.js
+++ b/backend/modules/projects/service.js
@@ -91,6 +91,20 @@ class ProjectsService {
         } = query;
         const statusFilter = status || state;
 
+        // Resolve area filter target ID (used after applying per-user overrides)
+        let areaFilterId = null;
+        if (area && area !== '') {
+            const uid = extractUidFromSlug(area);
+            if (uid) {
+                const areaRecord = await projectsRepository.findAreaByUid(uid);
+                if (areaRecord) {
+                    areaFilterId = areaRecord.id;
+                }
+            }
+        } else if (area_id && area_id !== '') {
+            areaFilterId = parseInt(area_id, 10) || area_id;
+        }
+
         let whereClause = await permissionsService.ownershipOrPermissionWhere(
             'project',
             userId
@@ -118,19 +132,10 @@ class ProjectsService {
             whereClause.pin_to_sidebar = false;
         }
 
-        if (area && area !== '') {
-            const uid = extractUidFromSlug(area);
-            if (uid) {
-                const areaRecord = await projectsRepository.findAreaByUid(uid);
-                if (areaRecord) {
-                    whereClause = {
-                        [Op.and]: [whereClause, { area_id: areaRecord.id }],
-                    };
-                }
-            }
-        } else if (area_id && area_id !== '') {
-            whereClause = { [Op.and]: [whereClause, { area_id }] };
-        }
+        // When filtering by area, owned projects can be filtered at the DB level.
+        // Shared projects use per-user overrides, so we apply the area filter in-memory
+        // after resolving overrides. We omit the DB-level area filter here and handle
+        // it below to ensure shared projects' personal area placements are respected.
 
         const projects =
             await projectsRepository.findAllWithFilters(whereClause);
@@ -139,33 +144,53 @@ class ProjectsService {
         const shareCountMap =
             await projectsRepository.getShareCounts(projectUids);
 
-        const enhancedProjects = projects.map((project) => {
-            const taskStatus = calculateTaskStatus(project.Tasks);
-            const projectJson = project.toJSON();
-            const shareCount = shareCountMap[project.uid] || 0;
+        // Load per-user area overrides (covers shared projects assigned to user's areas)
+        const areaOverrides =
+            await projectsRepository.getUserProjectAreaOverrides(userId);
 
-            const isActiveStatus =
-                project.status === 'planned' ||
-                project.status === 'in_progress';
-            const activeTaskCount =
-                taskStatus.in_progress + taskStatus.not_started;
-            const isStalled = isActiveStatus && activeTaskCount === 0;
+        const enhancedProjects = projects
+            .map((project) => {
+                const taskStatus = calculateTaskStatus(project.Tasks);
+                const projectJson = project.toJSON();
+                const shareCount = shareCountMap[project.uid] || 0;
 
-            return {
-                ...projectJson,
-                tags: sortTags(projectJson.Tags),
-                due_date_at: formatDate(project.due_date_at),
-                task_status: taskStatus,
-                completion_percentage:
-                    taskStatus.total > 0
-                        ? Math.round((taskStatus.done / taskStatus.total) * 100)
-                        : 0,
-                user_uid: projectJson.User?.uid,
-                share_count: shareCount,
-                is_shared: shareCount > 0,
-                is_stalled: isStalled,
-            };
-        });
+                const isOwner = project.user_id === userId;
+
+                // Apply per-user area override for shared (non-owned) projects
+                if (!isOwner && areaOverrides[project.id] !== undefined) {
+                    const override = areaOverrides[project.id];
+                    projectJson.area_id = override.area_id;
+                    projectJson.Area = override.Area;
+                }
+
+                const isActiveStatus =
+                    project.status === 'planned' ||
+                    project.status === 'in_progress';
+                const activeTaskCount =
+                    taskStatus.in_progress + taskStatus.not_started;
+                const isStalled = isActiveStatus && activeTaskCount === 0;
+
+                return {
+                    ...projectJson,
+                    tags: sortTags(projectJson.Tags),
+                    due_date_at: formatDate(project.due_date_at),
+                    task_status: taskStatus,
+                    completion_percentage:
+                        taskStatus.total > 0
+                            ? Math.round(
+                                  (taskStatus.done / taskStatus.total) * 100
+                              )
+                            : 0,
+                    user_uid: projectJson.User?.uid,
+                    share_count: shareCount,
+                    is_shared: shareCount > 0,
+                    is_stalled: isStalled,
+                };
+            })
+            .filter((project) => {
+                if (areaFilterId === null) return true;
+                return project.area_id == areaFilterId;
+            });
 
         if (grouped === 'true') {
             const groupedProjects = {};
@@ -320,6 +345,8 @@ class ProjectsService {
             throw new NotFoundError('Project not found.');
         }
 
+        const isOwner = project.user_id === userId;
+
         const {
             name,
             description,
@@ -342,8 +369,6 @@ class ProjectsService {
 
         if (name !== undefined) updateData.name = name;
         if (description !== undefined) updateData.description = description;
-        if (area_id !== undefined)
-            updateData.area_id = area_id === '' ? null : area_id;
         if (goal_id !== undefined)
             updateData.goal_id =
                 goal_id === '' || goal_id === null ? null : goal_id;
@@ -360,6 +385,21 @@ class ProjectsService {
         if (color !== undefined) updateData.color = color === '' ? null : color;
         if (status !== undefined) updateData.status = status;
         else if (state !== undefined) updateData.status = state;
+
+        if (area_id !== undefined) {
+            const resolvedAreaId = area_id === '' ? null : area_id;
+            if (isOwner) {
+                // Owner controls the canonical area for all users
+                updateData.area_id = resolvedAreaId;
+            } else {
+                // Non-owners store their personal area placement without touching the project
+                await projectsRepository.upsertUserProjectArea(
+                    userId,
+                    project.id,
+                    resolvedAreaId
+                );
+            }
+        }
 
         await projectsRepository.update(project, updateData);
         await updateProjectTags(project, tagsData, userId);


### PR DESCRIPTION
## Description

When a project is shared with another user and that user assigns it to one of their areas, the project's `area_id` field was overwritten globally, removing it from the owner's (and all other collaborators') area. This PR fixes that by introducing per-user area placements for shared projects.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1133

## What Changed

**New table: `user_project_areas`**
- Stores a per-user `area_id` override for a given project
- Only populated for non-owner collaborators
- Unique constraint on `(user_id, project_id)`

**Project update logic (`service.js`)**
- When the **project owner** updates `area_id`, the canonical `area_id` on the project row is updated (existing behavior)
- When a **shared user** updates `area_id`, their preference is stored/updated in `user_project_areas` without touching the project row

**Project list logic (`service.js` / `repository.js`)**
- After fetching projects, per-user area overrides are loaded and applied to shared projects before returning the response
- Area filtering (by `?area=` or `?area_id=`) is now resolved in-memory after applying overrides, so a shared user's area filter correctly matches their personal placement

## Testing

```bash
npm run lint
npm test
```

- Lint: passes (0 errors)
- Tests: 1589 passed, 0 failed

**Manual scenario to verify:**
1. User A creates a project and assigns it to Area X
2. User A shares the project with User B (rw access)
3. User B assigns the project to their Area Y
4. User A's project still shows under Area X
5. User B sees the project under Area Y

## Checklist

- [x] Code follows project conventions
- [x] Tests pass (`npm test`)
- [x] Lint passes (`npm run lint`)
- [x] Database migration included
- [x] No breaking changes to existing data (new table, no modifications to existing rows)