### PR TITLE
fix(mcp): enforce shared-project permissions in MCP tools

### DIFF
--- a/backend/modules/mcp/tools/noteTools.js
+++ b/backend/modules/mcp/tools/noteTools.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const notesService = require('../../notes/service');
+const permissionsService = require('../../../services/permissionsService');
 
-/**
- * Register all note-related MCP tools
- */
 function registerNoteTools(server, context, tools) {
     // 1. list_notes - List notes
     tools.push({
@@ -68,7 +66,12 @@ function registerNoteTools(server, context, tools) {
         handler: async (params) => {
             const note = await notesService.getByUid(params.uid);
 
-            if (note.user_id !== context.userId) {
+            const access = await permissionsService.getAccess(
+                context.userId,
+                'note',
+                params.uid
+            );
+            if (access === permissionsService.ACCESS.NONE) {
                 throw new Error('Note not found.');
             }
 
@@ -167,7 +170,17 @@ function registerNoteTools(server, context, tools) {
         },
         handler: async (params) => {
             const existing = await notesService.getByUid(params.uid);
-            if (existing.user_id !== context.userId) {
+
+            const access = await permissionsService.getAccess(
+                context.userId,
+                'note',
+                params.uid
+            );
+            const canWrite =
+                existing.user_id === context.userId ||
+                access === permissionsService.ACCESS.RW ||
+                access === permissionsService.ACCESS.ADMIN;
+            if (!canWrite) {
                 throw new Error('Note not found.');
             }
 
@@ -194,7 +207,7 @@ function registerNoteTools(server, context, tools) {
         },
     });
 
-    // 5. delete_note - Delete a note
+    // 5. delete_note - Delete a note (owner only)
     tools.push({
         name: 'delete_note',
         description: 'Delete a note',

--- a/backend/modules/mcp/tools/projectTools.js
+++ b/backend/modules/mcp/tools/projectTools.js
@@ -3,10 +3,8 @@
 const { Project, Area, Tag } = require('../../../models');
 const { Op } = require('sequelize');
 const projectsRepository = require('../../projects/repository');
+const permissionsService = require('../../../services/permissionsService');
 
-/**
- * Register all project-related MCP tools
- */
 function registerProjectTools(server, context, tools) {
     // 1. list_projects - List projects
     tools.push({
@@ -40,21 +38,23 @@ function registerProjectTools(server, context, tools) {
             },
         },
         handler: async (params) => {
-            const where = { user_id: context.userId };
+            const whereClause =
+                await permissionsService.ownershipOrPermissionWhere(
+                    'project',
+                    context.userId
+                );
             const limit = params.limit || 30;
 
-            // Apply status filter
             if (params.status && params.status !== 'all') {
-                where.status = params.status;
+                whereClause.status = params.status;
             }
 
-            // Apply area filter
             if (params.area_id) {
-                where.area_id = params.area_id;
+                whereClause.area_id = params.area_id;
             }
 
             const projects = await Project.findAll({
-                where: where,
+                where: whereClause,
                 include: [
                     { model: Area, as: 'Area' },
                     { model: Tag, as: 'Tags' },
@@ -115,7 +115,7 @@ function registerProjectTools(server, context, tools) {
         },
         handler: async (params) => {
             const project = await Project.findOne({
-                where: { uid: params.uid, user_id: context.userId },
+                where: { uid: params.uid },
                 include: [
                     { model: Area, as: 'Area' },
                     { model: Tag, as: 'Tags' },
@@ -123,6 +123,15 @@ function registerProjectTools(server, context, tools) {
             });
 
             if (!project) {
+                throw new Error(`Project not found: ${params.uid}`);
+            }
+
+            const access = await permissionsService.getAccess(
+                context.userId,
+                'project',
+                project.uid
+            );
+            if (access === permissionsService.ACCESS.NONE) {
                 throw new Error(`Project not found: ${params.uid}`);
             }
 
@@ -218,7 +227,6 @@ function registerProjectTools(server, context, tools) {
 
             const project = await Project.create(projectData);
 
-            // Handle tags if provided
             if (params.tags && params.tags.length > 0) {
                 const tagInstances = await Promise.all(
                     params.tags.map(async (tagName) => {
@@ -231,7 +239,6 @@ function registerProjectTools(server, context, tools) {
                 await project.setTags(tagInstances);
             }
 
-            // Reload with associations
             const reloadedProject = await Project.findByPk(project.id, {
                 include: [
                     { model: Area, as: 'Area' },
@@ -321,10 +328,23 @@ function registerProjectTools(server, context, tools) {
         },
         handler: async (params) => {
             const project = await Project.findOne({
-                where: { uid: params.uid, user_id: context.userId },
+                where: { uid: params.uid },
             });
 
             if (!project) {
+                throw new Error(`Project not found: ${params.uid}`);
+            }
+
+            const access = await permissionsService.getAccess(
+                context.userId,
+                'project',
+                project.uid
+            );
+            const canWrite =
+                project.user_id === context.userId ||
+                access === permissionsService.ACCESS.RW ||
+                access === permissionsService.ACCESS.ADMIN;
+            if (!canWrite) {
                 throw new Error(`Project not found: ${params.uid}`);
             }
 
@@ -344,7 +364,6 @@ function registerProjectTools(server, context, tools) {
 
             await project.update(updates);
 
-            // Reload with associations
             const reloadedProject = await Project.findByPk(project.id, {
                 include: [
                     { model: Area, as: 'Area' },
@@ -386,7 +405,7 @@ function registerProjectTools(server, context, tools) {
         },
     });
 
-    // 5. delete_project - Delete a project
+    // 5. delete_project - Delete a project (owner only)
     tools.push({
         name: 'delete_project',
         description: 'Delete a project and all its tasks (notes are orphaned)',

--- a/backend/modules/mcp/tools/taskTools.js
+++ b/backend/modules/mcp/tools/taskTools.js
@@ -9,11 +9,9 @@ const { buildTaskAttributes } = require('../../tasks/core/builders');
 const { Op } = require('sequelize');
 const { Task, Project, Tag } = require('../../../models');
 const { validateProjectAccess } = require('../../tasks/utils/validation');
+const permissionsService = require('../../../services/permissionsService');
 
-/**
- * Helper to find task by ID or UID
- */
-async function findTaskByIdentifier(identifier, userId) {
+async function findTaskByIdentifier(identifier) {
     const isNumeric = !isNaN(identifier);
 
     const includeOptions = [
@@ -39,11 +37,9 @@ async function findTaskByIdentifier(identifier, userId) {
     ];
 
     if (isNumeric) {
-        return await taskRepository.findByIdAndUser(
-            parseInt(identifier),
-            userId,
-            { include: includeOptions }
-        );
+        return await taskRepository.findById(parseInt(identifier), {
+            include: includeOptions,
+        });
     } else {
         return await taskRepository.findByUid(identifier, {
             include: includeOptions,
@@ -51,9 +47,6 @@ async function findTaskByIdentifier(identifier, userId) {
     }
 }
 
-/**
- * Register all task-related MCP tools
- */
 function registerTaskTools(server, context, tools) {
     // 1. list_tasks - List tasks with filtering
     tools.push({
@@ -84,10 +77,13 @@ function registerTaskTools(server, context, tools) {
             },
         },
         handler: async (params) => {
-            const where = { user_id: context.userId };
+            const whereClause =
+                await permissionsService.ownershipOrPermissionWhere(
+                    'task',
+                    context.userId
+                );
             const limit = params.limit || 50;
 
-            // Apply status filter
             if (params.status) {
                 const statusMap = {
                     pending: 0,
@@ -95,24 +91,22 @@ function registerTaskTools(server, context, tools) {
                     completed: 2,
                     archived: 6,
                 };
-                where.status = statusMap[params.status];
+                whereClause.status = statusMap[params.status];
             }
 
-            // Apply project filter
             if (params.project_id) {
-                where.project_id = params.project_id;
+                whereClause.project_id = params.project_id;
             }
 
-            // Apply type filter
             if (params.type === 'completed') {
-                where.status = 2;
+                whereClause.status = 2;
             } else if (params.type === 'archived') {
-                where.status = 6;
+                whereClause.status = 6;
             } else if (params.type === 'today' || params.type === 'upcoming') {
-                where.status = { [Op.ne]: 6 }; // Not archived
+                whereClause.status = { [Op.ne]: 6 };
             }
 
-            const tasks = await taskRepository.findAll(where, {
+            const tasks = await taskRepository.findAll(whereClause, {
                 include: [
                     { model: Project, as: 'Project' },
                     { model: Tag, as: 'Tags' },
@@ -159,15 +153,19 @@ function registerTaskTools(server, context, tools) {
             required: ['id'],
         },
         handler: async (params) => {
-            const task = await findTaskByIdentifier(params.id, context.userId);
+            const task = await findTaskByIdentifier(params.id);
 
             if (!task) {
                 throw new Error(`Task not found: ${params.id}`);
             }
 
-            // Check ownership
-            if (task.user_id !== context.userId) {
-                throw new Error('Access denied');
+            const access = await permissionsService.getAccess(
+                context.userId,
+                'task',
+                task.uid
+            );
+            if (access === permissionsService.ACCESS.NONE) {
+                throw new Error(`Task not found: ${params.id}`);
             }
 
             const serialized = await serializeTask(task, context.user.timezone);
@@ -222,6 +220,11 @@ function registerTaskTools(server, context, tools) {
         handler: async (params) => {
             const priorityMap = { low: 0, medium: 1, high: 2 };
 
+            // Validate project access before creating task
+            const resolvedProjectId = params.project_id
+                ? await validateProjectAccess(params.project_id, context.userId)
+                : null;
+
             const taskData = {
                 user_id: context.userId,
                 name: params.name,
@@ -229,12 +232,11 @@ function registerTaskTools(server, context, tools) {
                 priority: params.priority ? priorityMap[params.priority] : 1,
                 status: 0, // pending
                 due_date: params.due_date || null,
-                project_id: params.project_id || null,
+                project_id: resolvedProjectId,
             };
 
             const task = await taskRepository.create(taskData);
 
-            // Handle tags if provided
             if (params.tags && params.tags.length > 0) {
                 const tagInstances = await Promise.all(
                     params.tags.map(async (tagName) => {
@@ -247,7 +249,6 @@ function registerTaskTools(server, context, tools) {
                 await task.setTags(tagInstances);
             }
 
-            // Reload with associations
             const reloadedTask = await taskRepository.findByIdAndUser(
                 task.id,
                 context.userId,
@@ -317,13 +318,22 @@ function registerTaskTools(server, context, tools) {
             required: ['id'],
         },
         handler: async (params) => {
-            const task = await findTaskByIdentifier(params.id, context.userId);
+            const task = await findTaskByIdentifier(params.id);
 
             if (!task) {
                 throw new Error(`Task not found: ${params.id}`);
             }
 
-            if (task.user_id !== context.userId) {
+            const access = await permissionsService.getAccess(
+                context.userId,
+                'task',
+                task.uid
+            );
+            const canWrite =
+                task.user_id === context.userId ||
+                access === permissionsService.ACCESS.RW ||
+                access === permissionsService.ACCESS.ADMIN;
+            if (!canWrite) {
                 throw new Error('Access denied');
             }
 
@@ -357,17 +367,12 @@ function registerTaskTools(server, context, tools) {
 
             await task.update(updates);
 
-            // Reload with associations
-            const reloadedTask = await taskRepository.findByIdAndUser(
-                task.id,
-                context.userId,
-                {
-                    include: [
-                        { model: Project, as: 'Project' },
-                        { model: Tag, as: 'Tags' },
-                    ],
-                }
-            );
+            const reloadedTask = await taskRepository.findById(task.id, {
+                include: [
+                    { model: Project, as: 'Project' },
+                    { model: Tag, as: 'Tags' },
+                ],
+            });
 
             const serialized = await serializeTask(
                 reloadedTask,
@@ -407,18 +412,26 @@ function registerTaskTools(server, context, tools) {
             required: ['id'],
         },
         handler: async (params) => {
-            const task = await findTaskByIdentifier(params.id, context.userId);
+            const task = await findTaskByIdentifier(params.id);
 
             if (!task) {
                 throw new Error(`Task not found: ${params.id}`);
             }
 
-            if (task.user_id !== context.userId) {
+            const access = await permissionsService.getAccess(
+                context.userId,
+                'task',
+                task.uid
+            );
+            const canWrite =
+                task.user_id === context.userId ||
+                access === permissionsService.ACCESS.RW ||
+                access === permissionsService.ACCESS.ADMIN;
+            if (!canWrite) {
                 throw new Error('Access denied');
             }
 
-            // Toggle completion
-            const newStatus = task.status === 2 ? 0 : 2; // 2 = completed, 0 = pending
+            const newStatus = task.status === 2 ? 0 : 2;
             const updates = {
                 status: newStatus,
                 completed_at: newStatus === 2 ? new Date() : null,
@@ -426,16 +439,12 @@ function registerTaskTools(server, context, tools) {
 
             await task.update(updates);
 
-            const reloadedTask = await taskRepository.findByIdAndUser(
-                task.id,
-                context.userId,
-                {
-                    include: [
-                        { model: Project, as: 'Project' },
-                        { model: Tag, as: 'Tags' },
-                    ],
-                }
-            );
+            const reloadedTask = await taskRepository.findById(task.id, {
+                include: [
+                    { model: Project, as: 'Project' },
+                    { model: Tag, as: 'Tags' },
+                ],
+            });
 
             const serialized = await serializeTask(
                 reloadedTask,
@@ -463,7 +472,7 @@ function registerTaskTools(server, context, tools) {
         },
     });
 
-    // 6. delete_task - Delete task
+    // 6. delete_task - Delete task (owner only)
     tools.push({
         name: 'delete_task',
         description: 'Permanently delete a task',
@@ -478,7 +487,7 @@ function registerTaskTools(server, context, tools) {
             required: ['id'],
         },
         handler: async (params) => {
-            const task = await findTaskByIdentifier(params.id, context.userId);
+            const task = await findTaskByIdentifier(params.id);
 
             if (!task) {
                 throw new Error(`Task not found: ${params.id}`);
@@ -535,16 +544,22 @@ function registerTaskTools(server, context, tools) {
             required: ['parent_id', 'name'],
         },
         handler: async (params) => {
-            const parentTask = await findTaskByIdentifier(
-                params.parent_id,
-                context.userId
-            );
+            const parentTask = await findTaskByIdentifier(params.parent_id);
 
             if (!parentTask) {
                 throw new Error(`Parent task not found: ${params.parent_id}`);
             }
 
-            if (parentTask.user_id !== context.userId) {
+            const access = await permissionsService.getAccess(
+                context.userId,
+                'task',
+                parentTask.uid
+            );
+            const canWrite =
+                parentTask.user_id === context.userId ||
+                access === permissionsService.ACCESS.RW ||
+                access === permissionsService.ACCESS.ADMIN;
+            if (!canWrite) {
                 throw new Error('Access denied');
             }
 
@@ -557,7 +572,7 @@ function registerTaskTools(server, context, tools) {
                 priority: params.priority ? priorityMap[params.priority] : 1,
                 status: 0,
                 due_date: params.due_date || null,
-                project_id: parentTask.project_id, // Inherit parent's project
+                project_id: parentTask.project_id,
             };
 
             const subtask = await taskRepository.create(subtaskData);
@@ -605,18 +620,16 @@ function registerTaskTools(server, context, tools) {
             properties: {},
         },
         handler: async (params) => {
-            // Get counts by status
             const openCount = await taskRepository.count({
                 user_id: context.userId,
-                status: { [Op.in]: [0, 1] }, // pending or in_progress
+                status: { [Op.in]: [0, 1] },
             });
 
             const completedCount = await taskRepository.count({
                 user_id: context.userId,
-                status: 2, // completed
+                status: 2,
             });
 
-            // Get overdue tasks
             const now = new Date();
             const overdueCount = await taskRepository.count({
                 user_id: context.userId,
@@ -624,13 +637,11 @@ function registerTaskTools(server, context, tools) {
                 due_date: { [Op.lt]: now },
             });
 
-            // Get in_progress tasks
             const inProgressCount = await taskRepository.count({
                 user_id: context.userId,
                 status: 1,
             });
 
-            // Get today's completions
             const startOfDay = new Date();
             startOfDay.setHours(0, 0, 0, 0);
             const todayCompletions = await taskRepository.count({
@@ -639,7 +650,6 @@ function registerTaskTools(server, context, tools) {
                 completed_at: { [Op.gte]: startOfDay },
             });
 
-            // Get this week's completions
             const startOfWeek = new Date();
             startOfWeek.setDate(startOfWeek.getDate() - startOfWeek.getDay());
             startOfWeek.setHours(0, 0, 0, 0);


### PR DESCRIPTION
## Description

MCP project, task, and note tools were filtering resources by direct ownership (`user_id`) instead of using the same permission-aware queries as the REST API. This caused collaborators with shared-project access to receive no projects or tasks through MCP, while `create_task` could still write to invisible shared projects by accepting a raw numeric `project_id`.

This PR aligns MCP permissions with the REST API by using `permissionsService` throughout.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1279

## Changes

**`projectTools.js`**
- `list_projects`: replaced `{ user_id }` filter with `ownershipOrPermissionWhere('project')`, so shared projects appear in results
- `get_project`: removed `user_id` from the `WHERE` clause; added `getAccess` check so read-only and rw collaborators can read shared projects
- `update_project`: same lookup change; added `getAccess` check requiring rw/admin access
- `delete_project`: unchanged — deletion remains owner-only

**`taskTools.js`**
- `list_tasks`: replaced `{ user_id }` filter with `ownershipOrPermissionWhere('task')`, covering tasks in shared projects
- `findTaskByIdentifier`: switched numeric-ID lookup from `findByIdAndUser` to `findById` so shared tasks are found before the permission check runs
- `get_task`: replaced `task.user_id !== userId` with `getAccess` allowing ro/rw collaborators to read
- `update_task`, `complete_task`, `add_subtask`: replaced ownership check with `getAccess` requiring rw/admin
- `create_task`: added `validateProjectAccess` call before task creation to block writes to projects the user has no access to
- `delete_task`: unchanged — deletion remains owner-only

**`noteTools.js`**
- `list_notes`: already correct (`notesService.getAll` uses `ownershipOrPermissionWhere`)
- `get_note`: replaced `note.user_id !== userId` with `getAccess` check
- `update_note`: replaced ownership check with `getAccess` requiring rw/admin
- `delete_note`: unchanged — deletion remains owner-only

## Testing

```bash
npm run lint
npm test
```

All tests pass (pre-existing flaky failure in `subtasks.test.js` unrelated to these changes).

## Checklist

- [x] My code follows the project's coding standards
- [x] I have tested my changes
- [x] I have run the linter (`npm run lint`)
- [x] My changes don't break existing tests