### PR TITLE
fix(docker): redirect DB_FILE to old path instead of copying to anonymous volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,36 @@ Connect Tududi to external CalDAV servers like Nextcloud, Baikal, or other CalDA
 
 **Documentation:** See [docs/11-caldav-sync.md](docs/11-caldav-sync.md) for client setup guides, server configuration, and troubleshooting.
 
+### Upgrading
+
+#### v1.1.x to v1.2.x: Volume path change
+
+The Docker volume mount path changed in v1.2.0 from `/app/backend/db` to `/app/db`. If you are upgrading from v1.1.x and your `docker-compose.yml` still uses the old path, **new data will be lost on container recreation** because writes go to an anonymous Docker volume that is discarded when the container is recreated.
+
+**How to check:** Look at your `docker-compose.yml` volumes section:
+
+```yaml
+# OLD (v1.1.x) - update this
+volumes:
+  - ./tududi_db:/app/backend/db
+  - ./uploads:/app/backend/uploads
+
+# NEW (v1.2.x+) - use these paths
+volumes:
+  - ./tududi_db:/app/db
+  - ./uploads:/app/uploads
+```
+
+**Migration steps:**
+
+1. Stop the container: `docker-compose down`
+2. Update `docker-compose.yml` to use the new volume paths (see above)
+3. Start the container: `docker-compose up -d`
+
+Your existing data directory (`./tududi_db`) stays the same - only the mount point inside the container changes. No data copying is needed when using bind mounts.
+
+> **Note:** While you still use the old path, Tududi will print a warning at startup and continue using the old location to prevent data loss. Once you update the volume mount, the warning disappears and writes go to the correct persistent location.
+
 ### 📚 Documentation
 
 For detailed setup instructions, configuration options, and getting started guides, visit:

--- a/backend/cmd/start.sh
+++ b/backend/cmd/start.sh
@@ -78,14 +78,28 @@ backup_db() {
 }
 
 # Before v1.2.0, the database was mounted at /app/backend/db. If the new path
-# does not exist but the old path does, copy it over so data is preserved.
+# does not exist but the old path does, redirect DB_FILE to the old path so
+# writes stay on the persistent (user-mounted) volume rather than being copied
+# to an anonymous Docker volume that is discarded on container recreation.
 OLD_DB_PATH="/app/backend/db/${NODE_ENV}.sqlite3"
 if [ ! -f "$DB_FILE" ] && [ -f "$OLD_DB_PATH" ]; then
-  echo "⚠️  Database found at old location ($OLD_DB_PATH)."
-  echo "    Copying to new location ($DB_FILE) to preserve data..."
-  mkdir -p "$(dirname "$DB_FILE")"
-  cp "$OLD_DB_PATH" "$DB_FILE"
-  echo "✅ Database copied. Update your volume mount from :/app/backend/db to :/app/db."
+  echo ""
+  echo "⚠️  =============================================================="
+  echo "⚠️  ACTION REQUIRED: Volume mount path changed in v1.2.0"
+  echo "⚠️"
+  echo "⚠️  Your database is at the old location: $OLD_DB_PATH"
+  echo "⚠️  The new canonical location is:        $DB_FILE"
+  echo "⚠️"
+  echo "⚠️  To prevent data loss, using old path until you update:"
+  echo "⚠️    docker-compose.yml volumes:"
+  echo "⚠️      - ./tududi_db:/app/backend/db  (OLD - change this)"
+  echo "⚠️      + ./tududi_db:/app/db           (NEW)"
+  echo "⚠️"
+  echo "⚠️  WARNING: New data will be LOST on container recreation until"
+  echo "⚠️  you update the volume mount. See upgrade docs for details."
+  echo "⚠️  =============================================================="
+  echo ""
+  export DB_FILE="$OLD_DB_PATH"
 fi
 
 # Check if database exists and create/authenticate


### PR DESCRIPTION
## Description

When upgrading from v1.1.x to v1.2.x without updating `docker-compose.yml`, the previous migration code in `start.sh` copied the database from the old volume path (`/app/backend/db`) to the new path (`/app/db`). However, if the user hadn't updated their compose file to mount `/app/db`, that path was backed by an **anonymous Docker volume** which is discarded on container recreation.

This caused the bug in #1277:
1. User upgrades image to v1.2.x but keeps old compose file (`./tududi_db:/app/backend/db`)
2. Container starts, copies DB from old path to anonymous `/app/db` volume
3. App writes new tasks and settings to anonymous volume
4. Container is recreated (e.g., `docker-compose up` with new image)
5. Anonymous volume is gone, old DB is copied again from the still-mounted old path
6. All new data is lost - settings and tasks "reset to before the upgrade"

## Fix

Instead of copying the database to the ephemeral new location, redirect `DB_FILE` to the old path so writes go to the user's persistent volume mount. A clear action-required warning is printed at startup with exact instructions to update the compose file.

Also adds an **Upgrading** section to README.md documenting the v1.1.x to v1.2.x volume path change.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #1277

## Testing

Simulated the scenario:
- Set `DB_FILE` to a non-existent new path
- Created the old path with a database file
- Verified the script exports `DB_FILE` to the old path and prints the warning
- Verified all node processes (migrations, app.js) inherit the redirected `DB_FILE`

## Checklist

- [x] Code follows project conventions
- [x] No new linting errors
- [x] Documentation updated (README.md Upgrading section)
- [x] Commit references the issue number