### PR TITLE
fix(tasks): fix empty due_date for shared project tasks in detail view

### DIFF
--- a/backend/tests/integration/project-sharing.test.js
+++ b/backend/tests/integration/project-sharing.test.js
@@ -616,4 +616,41 @@ describe('Project Sharing Integration Tests', () => {
             expect(deleteResponse.status).toBe(403);
         });
     });
+
+    describe('Issue 1140: Task due_date in shared project detail view', () => {
+        test('GET /api/task/:uid returns due_date for shared project task', async () => {
+            const dueDate = '2025-08-15';
+
+            const taskResponse = await ownerAgent.post('/api/task').send({
+                name: 'Task with due date in shared project',
+                project_id: project.id,
+                due_date: dueDate,
+                priority: 1,
+                status: 0,
+            });
+            expect(taskResponse.status).toBe(201);
+            const task = taskResponse.body;
+            expect(task.uid).toBeDefined();
+
+            const response = await sharedUserAgent.get(`/api/task/${task.uid}`);
+
+            expect(response.status).toBe(200);
+            expect(response.body.due_date).toBe(dueDate);
+        });
+
+        test('GET /api/task/:uid returns 200 (not 403) for shared project task', async () => {
+            const taskResponse = await ownerAgent.post('/api/task').send({
+                name: 'Task in shared project',
+                project_id: project.id,
+                priority: 1,
+                status: 0,
+            });
+            expect(taskResponse.status).toBe(201);
+            const task = taskResponse.body;
+
+            const response = await sharedUserAgent.get(`/api/task/${task.uid}`);
+
+            expect(response.status).toBe(200);
+        });
+    });
 });

--- a/frontend/components/Task/TaskDetails.tsx
+++ b/frontend/components/Task/TaskDetails.tsx
@@ -49,6 +49,7 @@ const TaskDetails: React.FC = () => {
     const isNewTask = location.state?.isNew === true;
     const isNewTaskRef = useRef(isNewTask);
     const taskModifiedRef = useRef(false);
+    const hasFetchedRef = useRef<string | null>(null);
     const { showSuccessToast, showErrorToast } = useToast();
 
     // Clear navigation state so refresh/back doesn't re-trigger edit mode
@@ -507,22 +508,39 @@ const TaskDetails: React.FC = () => {
                 return;
             }
 
-            if (!task) {
-                try {
-                    setLoading(true);
-                    const fetchedTask = await fetchTaskByUid(uid);
+            if (hasFetchedRef.current === uid) {
+                return;
+            }
+
+            hasFetchedRef.current = uid;
+
+            const alreadyInStore = tasksStore.tasks.some(
+                (t: Task) => t.uid === uid
+            );
+
+            try {
+                if (!alreadyInStore) setLoading(true);
+                const fetchedTask = await fetchTaskByUid(uid);
+                const existingIndex = tasksStore.tasks.findIndex(
+                    (t: Task) => t.uid === uid
+                );
+                if (existingIndex >= 0) {
+                    const updatedTasks = [...tasksStore.tasks];
+                    updatedTasks[existingIndex] = fetchedTask;
+                    tasksStore.setTasks(updatedTasks);
+                } else {
                     tasksStore.setTasks([...tasksStore.tasks, fetchedTask]);
-                } catch (fetchError) {
-                    setError('Task not found');
-                    console.error('Error fetching task:', fetchError);
-                } finally {
-                    setLoading(false);
                 }
+            } catch (fetchError) {
+                if (!alreadyInStore) setError('Task not found');
+                console.error('Error fetching task:', fetchError);
+            } finally {
+                setLoading(false);
             }
         };
 
         fetchTaskData();
-    }, [uid, task, tasksStore]);
+    }, [uid, tasksStore]);
 
     useEffect(() => {
         const loadAttachmentCount = async () => {


### PR DESCRIPTION
## Description

When Account 2 opens a task from a shared project in the task detail view, the due date field showed empty even though the project overview correctly displayed the due date.

**Root cause**: The `TaskDetails` component only fetched fresh task data from the API when the task was not already present in the global `tasksStore`. The `TasksToday` component (Today page) populates `tasksStore` with tasks visible in the Today view. If a shared project task appeared in the Today view while it had no due date (or a stale one), that cached version would be shown in the task detail without ever refreshing from the server, even after the task's due date was set or the project was shared.

**Fix**: Use a `hasFetchedRef` ref to ensure the task detail always performs one fresh `GET /task/:uid` fetch per page navigation. If the task is already in the store, it is shown immediately and then silently updated with server-fresh data (no loading screen flash). If the task is not in the store, the existing loading behavior applies.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1140

## Testing

**How did you test this?**

- Added two integration tests to `project-sharing.test.js` that verify `GET /api/task/:uid` returns HTTP 200 and the correct `due_date` value when Account 2 (with shared access) requests a task owned by Account 1.
- Both tests confirm the backend was already correct; the fix is in the frontend fetch logic.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser