### PR TITLE
perf(sqlite): fix N+1 notification queries blocking API requests

### DIFF
--- a/backend/migrations/20260718000001-add-notification-type-index.js
+++ b/backend/migrations/20260718000001-add-notification-type-index.js
@@ -1,0 +1,29 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface) {
+        const indexes = await queryInterface.showIndex('notifications');
+        const indexName = 'notifications_user_type_created_at_idx';
+
+        if (!indexes.some((idx) => idx.name === indexName)) {
+            await queryInterface.addIndex(
+                'notifications',
+                ['user_id', 'type', 'created_at'],
+                { name: indexName }
+            );
+        }
+    },
+
+    async down(queryInterface) {
+        try {
+            await queryInterface.removeIndex(
+                'notifications',
+                'notifications_user_type_created_at_idx'
+            );
+        } catch (error) {
+            console.log(
+                'Index notifications_user_type_created_at_idx not found, skipping removal'
+            );
+        }
+    },
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -9,6 +9,13 @@ dbConfig = {
     dialect: 'sqlite',
     storage: config.dbFile,
     logging: config.environment === 'development' ? console.log : false,
+    // Allow concurrent reads under WAL mode; SQLite serializes writes internally
+    pool: {
+        max: 5,
+        min: 1,
+        idle: 10000,
+        acquire: 60000,
+    },
     define: {
         timestamps: true,
         underscored: true,
@@ -39,6 +46,9 @@ if (dbConfig.dialect === 'sqlite') {
                     'PRAGMA temp_store=MEMORY;',
                     // Enable memory-mapped I/O (256MB): faster reads on large databases
                     'PRAGMA mmap_size=268435456;',
+                    // Checkpoint WAL every 200 frames instead of the 1000-frame default.
+                    // Keeps the WAL file smaller so reads traverse fewer frames on slow disks.
+                    'PRAGMA wal_autocheckpoint=200;',
                 ].join('\n'),
                 (err) => {
                     if (err) reject(err);

--- a/backend/modules/projects/dueProjectService.js
+++ b/backend/modules/projects/dueProjectService.js
@@ -6,15 +6,6 @@ const {
     shouldSendTelegramNotification,
 } = require('../../utils/notificationPreferences');
 
-/**
- * Service to check for due and overdue projects
- * and create notifications for users
- */
-
-/**
- * Check for projects that are due soon or overdue
- * and create notifications for the project owners
- */
 async function checkDueProjects() {
     try {
         const now = new Date();
@@ -52,6 +43,23 @@ async function checkDueProjects() {
             };
         }
 
+        // Batch-fetch all relevant notifications in one query to avoid N+1
+        const userIds = [...new Set(dueProjects.map((p) => p.user_id))];
+        const allRecentNotifications = await Notification.findAll({
+            where: {
+                user_id: { [Op.in]: userIds },
+                type: { [Op.in]: ['project_due_soon', 'project_overdue'] },
+                created_at: { [Op.gte]: twoDaysAgo },
+            },
+        });
+        const notificationsByUser = {};
+        for (const notif of allRecentNotifications) {
+            if (!notificationsByUser[notif.user_id]) {
+                notificationsByUser[notif.user_id] = [];
+            }
+            notificationsByUser[notif.user_id].push(notif);
+        }
+
         let notificationsCreated = 0;
 
         for (const project of dueProjects) {
@@ -70,18 +78,8 @@ async function checkDueProjects() {
                     continue;
                 }
 
-                // Check for existing notifications
-                const recentNotifications = await Notification.findAll({
-                    where: {
-                        user_id: project.user_id,
-                        type: {
-                            [Op.in]: ['project_due_soon', 'project_overdue'],
-                        },
-                        created_at: {
-                            [Op.gte]: twoDaysAgo,
-                        },
-                    },
-                });
+                const recentNotifications =
+                    notificationsByUser[project.user_id] || [];
 
                 const existingNotification = recentNotifications.find(
                     (notif) =>
@@ -166,9 +164,6 @@ async function checkDueProjects() {
     }
 }
 
-/**
- * Generate notification title and message based on project due date
- */
 function generateNotificationContent(projectName, dueDate, now, isOverdue) {
     if (isOverdue) {
         const daysOverdue = Math.floor((now - dueDate) / (1000 * 60 * 60 * 24));

--- a/backend/modules/tasks/core/serializers.js
+++ b/backend/modules/tasks/core/serializers.js
@@ -8,6 +8,8 @@ const {
     getTaskTodayMoveCounts,
 } = require('../taskEventService');
 const taskRepository = require('../repository');
+const { Task } = require('../../../models');
+const { Op } = require('sequelize');
 
 // Sort tags alphabetically by name (case-insensitive)
 function sortTags(tags) {
@@ -21,7 +23,8 @@ async function serializeTask(
     task,
     userTimezone = 'UTC',
     options = {},
-    moveCountMap = null
+    moveCountMap = null,
+    parentUidMap = null
 ) {
     if (!task) {
         throw new Error('Task is null or undefined');
@@ -68,13 +71,16 @@ async function serializeTask(
 
     let recurringParentUid = null;
     if (taskJson.recurring_parent_id) {
-        const parentTask = await taskRepository.findById(
-            taskJson.recurring_parent_id,
-            {
-                attributes: ['uid'],
-            }
-        );
-        recurringParentUid = parentTask?.uid || null;
+        if (parentUidMap && taskJson.recurring_parent_id in parentUidMap) {
+            recurringParentUid =
+                parentUidMap[taskJson.recurring_parent_id] || null;
+        } else {
+            const parentTask = await taskRepository.findById(
+                taskJson.recurring_parent_id,
+                { attributes: ['uid'] }
+            );
+            recurringParentUid = parentTask?.uid || null;
+        }
     }
 
     return {
@@ -132,17 +138,54 @@ async function serializeTask(
     };
 }
 
-async function serializeTasks(tasks, userTimezone = 'UTC', options = {}) {
+async function serializeTasks(
+    tasks,
+    userTimezone = 'UTC',
+    options = {},
+    prebuiltMoveCountMap = null,
+    prebuiltParentUidMap = null
+) {
     if (!tasks || tasks.length === 0) {
         return [];
     }
 
-    const taskIds = tasks.map((task) => task.id);
-    const moveCountMap = await getTaskTodayMoveCounts(taskIds);
+    const moveCountMap =
+        prebuiltMoveCountMap !== null
+            ? prebuiltMoveCountMap
+            : await getTaskTodayMoveCounts(tasks.map((t) => t.id));
+
+    // Batch-fetch recurring parent UIDs to avoid per-task DB queries
+    let parentUidMap = prebuiltParentUidMap;
+    if (parentUidMap === null) {
+        const parentIds = [
+            ...new Set(
+                tasks
+                    .filter((t) => t.recurring_parent_id)
+                    .map((t) => t.recurring_parent_id)
+            ),
+        ];
+        parentUidMap = {};
+        if (parentIds.length > 0) {
+            const parents = await Task.findAll({
+                where: { id: { [Op.in]: parentIds } },
+                attributes: ['id', 'uid'],
+                raw: true,
+            });
+            parents.forEach((p) => {
+                parentUidMap[p.id] = p.uid;
+            });
+        }
+    }
 
     return await Promise.all(
         tasks.map((task) =>
-            serializeTask(task, userTimezone, options, moveCountMap)
+            serializeTask(
+                task,
+                userTimezone,
+                options,
+                moveCountMap,
+                parentUidMap
+            )
         )
     );
 }

--- a/backend/modules/tasks/deferredTaskService.js
+++ b/backend/modules/tasks/deferredTaskService.js
@@ -45,21 +45,31 @@ async function checkDeferredTasks() {
         let notificationsCreated = 0;
         const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
 
+        // Batch-fetch all relevant notifications in one query to avoid N+1
+        const userIds = [...new Set(deferredTasks.map((t) => t.user_id))];
+        const allRecentNotifications = await Notification.findAll({
+            where: {
+                user_id: { [Op.in]: userIds },
+                type: 'task_due_soon',
+                created_at: { [Op.gte]: oneDayAgo },
+            },
+        });
+        const notificationsByUser = {};
+        for (const notif of allRecentNotifications) {
+            if (!notificationsByUser[notif.user_id]) {
+                notificationsByUser[notif.user_id] = [];
+            }
+            notificationsByUser[notif.user_id].push(notif);
+        }
+
         for (const task of deferredTasks) {
             try {
                 if (!shouldSendInAppNotification(task.User, 'deferUntil')) {
                     continue;
                 }
 
-                const recentNotifications = await Notification.findAll({
-                    where: {
-                        user_id: task.user_id,
-                        type: 'task_due_soon',
-                        created_at: {
-                            [Op.gte]: oneDayAgo,
-                        },
-                    },
-                });
+                const recentNotifications =
+                    notificationsByUser[task.user_id] || [];
 
                 const existingNotification = recentNotifications.find(
                     (notif) =>

--- a/backend/modules/tasks/dueTaskService.js
+++ b/backend/modules/tasks/dueTaskService.js
@@ -6,15 +6,6 @@ const {
     shouldSendTelegramNotification,
 } = require('../../utils/notificationPreferences');
 
-/**
- * Service to check for due and overdue tasks
- * and create notifications for users
- */
-
-/**
- * Check for tasks that are due soon or overdue
- * and create notifications for the task owners
- */
 async function checkDueTasks() {
     try {
         const now = new Date();
@@ -52,6 +43,23 @@ async function checkDueTasks() {
             };
         }
 
+        // Batch-fetch all relevant notifications in one query to avoid N+1
+        const userIds = [...new Set(dueTasks.map((t) => t.user_id))];
+        const allRecentNotifications = await Notification.findAll({
+            where: {
+                user_id: { [Op.in]: userIds },
+                type: { [Op.in]: ['task_due_soon', 'task_overdue'] },
+                created_at: { [Op.gte]: twoDaysAgo },
+            },
+        });
+        const notificationsByUser = {};
+        for (const notif of allRecentNotifications) {
+            if (!notificationsByUser[notif.user_id]) {
+                notificationsByUser[notif.user_id] = [];
+            }
+            notificationsByUser[notif.user_id].push(notif);
+        }
+
         let notificationsCreated = 0;
 
         for (const task of dueTasks) {
@@ -68,18 +76,8 @@ async function checkDueTasks() {
                     continue;
                 }
 
-                // Check for existing notifications
-                const recentNotifications = await Notification.findAll({
-                    where: {
-                        user_id: task.user_id,
-                        type: {
-                            [Op.in]: ['task_due_soon', 'task_overdue'],
-                        },
-                        created_at: {
-                            [Op.gte]: twoDaysAgo,
-                        },
-                    },
-                });
+                const recentNotifications =
+                    notificationsByUser[task.user_id] || [];
 
                 const existingNotification = recentNotifications.find(
                     (notif) =>
@@ -161,9 +159,6 @@ async function checkDueTasks() {
     }
 }
 
-/**
- * Generate notification title and message based on task due date
- */
 function generateNotificationContent(taskName, dueDate, now, isOverdue) {
     if (isOverdue) {
         const daysOverdue = Math.floor((now - dueDate) / (1000 * 60 * 60 * 24));

--- a/backend/modules/tasks/operations/list.js
+++ b/backend/modules/tasks/operations/list.js
@@ -1,6 +1,9 @@
 const { groupTasksByDay } = require('./grouping');
 const { serializeTasks } = require('../core/serializers');
 const { computeTaskMetrics } = require('../queries/metrics-computation');
+const { getTaskTodayMoveCounts } = require('../taskEventService');
+const { Task } = require('../../../models');
+const { Op } = require('sequelize');
 
 async function handleRecurringTasks(userId, queryType) {
     return;
@@ -53,28 +56,65 @@ async function addDashboardLists(
         return;
     }
 
-    const metricsData = await computeTaskMetrics(userId, timezone);
+    const permissionCache = new Map();
+    const metricsData = await computeTaskMetrics(
+        userId,
+        timezone,
+        permissionCache
+    );
 
-    const listKeys = [
-        'tasks_in_progress',
-        'tasks_today_plan',
-        'tasks_due_today',
-        'tasks_overdue',
-        'suggested_tasks',
-        'tasks_completed_today',
+    const listKeyMap = {
+        tasks_in_progress: metricsData.tasks_in_progress,
+        tasks_today_plan: metricsData.today_plan_tasks,
+        tasks_due_today: metricsData.tasks_due_today,
+        tasks_overdue: metricsData.tasks_overdue,
+        suggested_tasks: metricsData.suggested_tasks,
+        tasks_completed_today: metricsData.tasks_completed_today,
+    };
+
+    // Single move-count query covering all lists
+    const allTasks = Object.values(listKeyMap).flat();
+    const allTaskIds = [...new Set(allTasks.map((t) => t.id))];
+    const moveCountMap = await getTaskTodayMoveCounts(allTaskIds);
+
+    // Single batch query for all recurring parent UIDs
+    const parentIds = [
+        ...new Set(
+            allTasks
+                .filter((t) => t.recurring_parent_id)
+                .map((t) => t.recurring_parent_id)
+        ),
     ];
+    const parentUidMap = {};
+    if (parentIds.length > 0) {
+        const parents = await Task.findAll({
+            where: { id: { [Op.in]: parentIds } },
+            attributes: ['id', 'uid'],
+            raw: true,
+        });
+        parents.forEach((p) => {
+            parentUidMap[p.id] = p.uid;
+        });
+    }
+
+    // Parallelize all serialization calls with shared pre-fetched maps
+    const keys = Object.keys(listKeyMap);
+    const serializedArrays = await Promise.all(
+        keys.map((key) =>
+            serializeTasks(
+                listKeyMap[key],
+                timezone,
+                serializationOptions,
+                moveCountMap,
+                parentUidMap
+            )
+        )
+    );
 
     const serializedLists = {};
-
-    for (const key of listKeys) {
-        const metricsKey =
-            key === 'tasks_today_plan' ? 'today_plan_tasks' : key;
-        serializedLists[key] = await serializeTasks(
-            metricsData[metricsKey],
-            timezone,
-            serializationOptions
-        );
-    }
+    keys.forEach((key, i) => {
+        serializedLists[key] = serializedArrays[i];
+    });
 
     Object.assign(response, serializedLists);
     response.dashboard_lists = serializedLists;

--- a/backend/modules/tasks/queries/metrics-computation.js
+++ b/backend/modules/tasks/queries/metrics-computation.js
@@ -257,13 +257,15 @@ async function computeTaskMetrics(
             visibleTasksWhere,
             userTimezone,
             userId,
-            somedayExcludedIds
+            somedayExcludedIds,
+            permissionCache
         ),
         fetchOverdueTasks(
             visibleTasksWhere,
             userTimezone,
             userId,
-            somedayExcludedIds
+            somedayExcludedIds,
+            permissionCache
         ),
         fetchTasksCompletedToday(userId, userTimezone),
         computeWeeklyCompletions(userId, userTimezone),
@@ -294,36 +296,114 @@ async function computeTaskMetrics(
 }
 
 async function getTaskMetrics(userId, timezone) {
-    const metrics = await computeTaskMetrics(userId, timezone);
+    const permissionCache = new Map();
+    const metrics = await computeTaskMetrics(userId, timezone, permissionCache);
+
     const {
         buildMetricsResponse,
         serializeTasks,
     } = require('../core/serializers');
+    const { getTaskTodayMoveCounts } = require('../taskEventService');
+    const { Task } = require('../../../models');
+    const { Op } = require('sequelize');
 
     const response = await buildMetricsResponse(metrics);
 
-    const serializedLists = {
-        tasks_in_progress: await serializeTasks(
+    // Collect all tasks across every list for single-pass pre-fetching
+    const allLists = [
+        metrics.tasks_in_progress,
+        metrics.today_plan_tasks,
+        metrics.tasks_due_today,
+        metrics.tasks_overdue,
+        metrics.suggested_tasks,
+        metrics.tasks_completed_today,
+    ];
+    const allTasks = allLists.flat();
+    const allTaskIds = [...new Set(allTasks.map((t) => t.id))];
+
+    // Single move-count query covering all lists
+    const moveCountMap = await getTaskTodayMoveCounts(allTaskIds);
+
+    // Single batch query for all recurring parent UIDs
+    const parentIds = [
+        ...new Set(
+            allTasks
+                .filter((t) => t.recurring_parent_id)
+                .map((t) => t.recurring_parent_id)
+        ),
+    ];
+    const parentUidMap = {};
+    if (parentIds.length > 0) {
+        const parents = await Task.findAll({
+            where: { id: { [Op.in]: parentIds } },
+            attributes: ['id', 'uid'],
+            raw: true,
+        });
+        parents.forEach((p) => {
+            parentUidMap[p.id] = p.uid;
+        });
+    }
+
+    // Parallelize all 6 serialization calls with shared pre-fetched maps
+    const [
+        tasks_in_progress,
+        tasks_today_plan,
+        tasks_due_today,
+        tasks_overdue,
+        suggested_tasks,
+        tasks_completed_today,
+    ] = await Promise.all([
+        serializeTasks(
             metrics.tasks_in_progress,
-            timezone
+            timezone,
+            {},
+            moveCountMap,
+            parentUidMap
         ),
-        tasks_today_plan: await serializeTasks(
+        serializeTasks(
             metrics.today_plan_tasks,
-            timezone
+            timezone,
+            {},
+            moveCountMap,
+            parentUidMap
         ),
-        tasks_due_today: await serializeTasks(
+        serializeTasks(
             metrics.tasks_due_today,
-            timezone
+            timezone,
+            {},
+            moveCountMap,
+            parentUidMap
         ),
-        tasks_overdue: await serializeTasks(metrics.tasks_overdue, timezone),
-        suggested_tasks: await serializeTasks(
+        serializeTasks(
+            metrics.tasks_overdue,
+            timezone,
+            {},
+            moveCountMap,
+            parentUidMap
+        ),
+        serializeTasks(
             metrics.suggested_tasks,
-            timezone
+            timezone,
+            {},
+            moveCountMap,
+            parentUidMap
         ),
-        tasks_completed_today: await serializeTasks(
+        serializeTasks(
             metrics.tasks_completed_today,
-            timezone
+            timezone,
+            {},
+            moveCountMap,
+            parentUidMap
         ),
+    ]);
+
+    const serializedLists = {
+        tasks_in_progress,
+        tasks_today_plan,
+        tasks_due_today,
+        tasks_overdue,
+        suggested_tasks,
+        tasks_completed_today,
     };
 
     Object.assign(response, serializedLists);

--- a/backend/modules/tasks/queries/metrics-queries.js
+++ b/backend/modules/tasks/queries/metrics-queries.js
@@ -192,7 +192,8 @@ async function fetchTasksDueToday(
     visibleTasksWhere,
     userTimezone,
     userId,
-    somedayExcludedIds = []
+    somedayExcludedIds = [],
+    permissionCache = null
 ) {
     const safeTimezone = getSafeTimezone(userTimezone);
     const todayBounds = getTodayBoundsInUTC(safeTimezone);
@@ -200,7 +201,8 @@ async function fetchTasksDueToday(
     // Get project permissions
     const projectWhere = await permissionsService.ownershipOrPermissionWhere(
         'project',
-        userId
+        userId,
+        permissionCache
     );
 
     // Build project access SQL condition
@@ -277,7 +279,8 @@ async function fetchOverdueTasks(
     visibleTasksWhere,
     userTimezone,
     userId,
-    somedayExcludedIds = []
+    somedayExcludedIds = [],
+    permissionCache = null
 ) {
     const safeTimezone = getSafeTimezone(userTimezone);
     const todayBounds = getTodayBoundsInUTC(safeTimezone);
@@ -285,7 +288,8 @@ async function fetchOverdueTasks(
     // Get project permissions
     const projectWhere = await permissionsService.ownershipOrPermissionWhere(
         'project',
-        userId
+        userId,
+        permissionCache
     );
 
     // Build project access SQL condition


### PR DESCRIPTION
## Description

Self-hosted users on slow-disk environments (Synology NAS, HDDs) were seeing intermittent 5–25 second API response times. Root-cause analysis of the HAR and codebase identified multiple query-serialization bottlenecks that monopolized SQLite's single-connection pool, causing all other requests to queue.

### Changes in this PR (two commits)

**Commit 1 — background job N+1 (cron every 5–15 min)**

`checkDueTasks`, `checkDeferredTasks`, and `checkDueProjects` each issued one `Notification.findAll()` per task/project (N+1 pattern). With pool max=1, each run blocked the DB for the full N-query duration — intermittently freezing all API requests.

- Batch all notification lookups into a single `findAll` per job run, grouped by `user_id` in memory
- Add composite index `notifications(user_id, type, created_at)` to cover the batched WHERE clause
- Increase Sequelize pool to `max: 5` for WAL-mode concurrent reads
- Add `PRAGMA wal_autocheckpoint=200` to limit WAL growth on slow disks

**Commit 2 — serialization and metrics query cascade**

`GET /api/tasks/metrics` and `GET /api/tasks?type=today&include_lists=true` had three compounding patterns:

1. `serializeTask` called `findByPk` for every recurring task instance to get parent UID (N+1 in serialization)
2. `getTaskMetrics` called `getTaskTodayMoveCounts()` 6× sequentially — one query per task list
3. `fetchTasksDueToday`/`fetchOverdueTasks` each called `ownershipOrPermissionWhere('project', userId)` without a cache, repeating User+admin+Permission roundtrips

Fixes: batch parent UID and move-count lookups once across all 6 lists; parallelize all 6 `serializeTasks` calls via `Promise.all`; thread `permissionCache` through to project permission calls; same treatment applied to `addDashboardLists`.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1292

## Testing

**How did you test this?**

Traced query patterns through call stacks; verified N+1 elimination and batching produce equivalent results; confirmed backward compatibility since all new parameters have defaults.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Database migrations included and tested (if applicable)

## Additional Notes

The pre-existing single flaky test failure (`inbox.test.js` expects 400, gets 401) is unrelated — it fails on main too.