### PR TITLE
fix(deps): replace uuid with Node.js built-in crypto.randomUUID()

### DIFF
--- a/backend/migrations/20250623000001-add-uuid-to-tasks.js
+++ b/backend/migrations/20250623000001-add-uuid-to-tasks.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { v4: uuidv4 } = require('uuid');
+const { randomUUID } = require('crypto');
 const { safeAddColumns, safeAddIndex } = require('../utils/migration-utils');
 
 module.exports = {
@@ -21,7 +21,7 @@ module.exports = {
         );
 
         for (const task of tasks) {
-            const uuid = uuidv4();
+            const uuid = randomUUID();
             await queryInterface.sequelize.query(
                 'UPDATE tasks SET uuid = ? WHERE id = ?',
                 { replacements: [uuid, task.id] }

--- a/backend/models/notification.js
+++ b/backend/models/notification.js
@@ -1,5 +1,5 @@
 const { DataTypes } = require('sequelize');
-const { v4: uuid } = require('uuid');
+const { randomUUID } = require('crypto');
 
 module.exports = (sequelize) => {
     const Notification = sequelize.define(
@@ -14,7 +14,7 @@ module.exports = (sequelize) => {
                 type: DataTypes.STRING,
                 unique: true,
                 allowNull: false,
-                defaultValue: () => uuid(),
+                defaultValue: () => randomUUID(),
             },
             user_id: {
                 type: DataTypes.INTEGER,

--- a/backend/scripts/add-sample-users.js
+++ b/backend/scripts/add-sample-users.js
@@ -1,5 +1,4 @@
 const bcrypt = require('bcrypt');
-const { v4: uuidv4 } = require('uuid');
 const db = require('../models');
 
 const sampleUsers = [

--- a/package.json
+++ b/package.json
@@ -176,7 +176,6 @@
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "use-debounce": "^10.0.6",
-    "uuid": "~11.1.0",
     "web-push": "^3.6.7",
     "xml2js": "^0.6.0"
   },


### PR DESCRIPTION
## Description

`uuid` v12+ dropped CommonJS support and became ESM-only. Since the backend uses `require('uuid')`, this causes Jest to fail with `SyntaxError: Unexpected token 'export'` whenever a file that imports `notification.js` is tested.

This PR fixes that by replacing all `require('uuid')` usages with Node.js's built-in `crypto.randomUUID()` (available since Node.js 14.17+) and removes the `uuid` package from `package.json` entirely.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes the CI failure in Dependabot PR #1062.

## Testing

- All 106 backend test suites pass (1591 tests) locally after this change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have run `npm run lint` and there are no errors
- [x] I have run the test suite and all tests pass
- [x] My changes do not break any existing functionality

## Additional Notes

After this PR merges, Dependabot PR #1062 can be closed as the `uuid` dependency no longer exists in the project.