### PR TITLE
feat(sidebar): list projects with expand/collapse, pin, and color icons

### DIFF
--- a/backend/migrations/20260721000001-add-id-to-user-project-areas.js
+++ b/backend/migrations/20260721000001-add-id-to-user-project-areas.js
@@ -1,0 +1,87 @@
+'use strict';
+
+module.exports = {
+    async up(queryInterface) {
+        const tables = await queryInterface.showAllTables();
+        if (!tables.includes('user_project_areas')) return;
+
+        const tableInfo = await queryInterface.describeTable('user_project_areas');
+        if ('id' in tableInfo) return;
+
+        await queryInterface.sequelize.query('PRAGMA foreign_keys = OFF;');
+
+        try {
+            await queryInterface.sequelize.query(
+                'DROP TABLE IF EXISTS user_project_areas_new;'
+            );
+            await queryInterface.sequelize.query(`
+                CREATE TABLE user_project_areas_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+                    area_id INTEGER REFERENCES areas(id) ON DELETE SET NULL,
+                    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+                );
+            `);
+            await queryInterface.sequelize.query(`
+                INSERT INTO user_project_areas_new (user_id, project_id, area_id, created_at, updated_at)
+                SELECT user_id, project_id, area_id, created_at, updated_at
+                FROM user_project_areas;
+            `);
+            await queryInterface.sequelize.query('DROP TABLE user_project_areas;');
+            await queryInterface.sequelize.query(
+                'ALTER TABLE user_project_areas_new RENAME TO user_project_areas;'
+            );
+        } finally {
+            await queryInterface.sequelize.query('PRAGMA foreign_keys = ON;');
+        }
+
+        await queryInterface.addIndex('user_project_areas', ['user_id']);
+        await queryInterface.addIndex('user_project_areas', ['project_id']);
+        await queryInterface.addIndex(
+            'user_project_areas',
+            ['user_id', 'project_id'],
+            { unique: true, name: 'user_project_areas_user_project_unique' }
+        );
+    },
+
+    async down(queryInterface) {
+        const tables = await queryInterface.showAllTables();
+        if (!tables.includes('user_project_areas')) return;
+
+        const tableInfo = await queryInterface.describeTable('user_project_areas');
+        if (!('id' in tableInfo)) return;
+
+        await queryInterface.sequelize.query('PRAGMA foreign_keys = OFF;');
+
+        try {
+            await queryInterface.sequelize.query(
+                'DROP TABLE IF EXISTS user_project_areas_old;'
+            );
+            await queryInterface.sequelize.query(`
+                CREATE TABLE user_project_areas_old (
+                    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+                    area_id INTEGER REFERENCES areas(id) ON DELETE SET NULL,
+                    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (user_id, project_id)
+                );
+            `);
+            await queryInterface.sequelize.query(`
+                INSERT INTO user_project_areas_old (user_id, project_id, area_id, created_at, updated_at)
+                SELECT user_id, project_id, area_id, created_at, updated_at
+                FROM user_project_areas;
+            `);
+            await queryInterface.sequelize.query(
+                'DROP TABLE user_project_areas;'
+            );
+            await queryInterface.sequelize.query(
+                'ALTER TABLE user_project_areas_old RENAME TO user_project_areas;'
+            );
+        } finally {
+            await queryInterface.sequelize.query('PRAGMA foreign_keys = ON;');
+        }
+    },
+};

--- a/backend/migrations/20260721000001-add-id-to-user-project-areas.js
+++ b/backend/migrations/20260721000001-add-id-to-user-project-areas.js
@@ -5,7 +5,8 @@ module.exports = {
         const tables = await queryInterface.showAllTables();
         if (!tables.includes('user_project_areas')) return;
 
-        const tableInfo = await queryInterface.describeTable('user_project_areas');
+        const tableInfo =
+            await queryInterface.describeTable('user_project_areas');
         if ('id' in tableInfo) return;
 
         await queryInterface.sequelize.query('PRAGMA foreign_keys = OFF;');
@@ -29,7 +30,9 @@ module.exports = {
                 SELECT user_id, project_id, area_id, created_at, updated_at
                 FROM user_project_areas;
             `);
-            await queryInterface.sequelize.query('DROP TABLE user_project_areas;');
+            await queryInterface.sequelize.query(
+                'DROP TABLE user_project_areas;'
+            );
             await queryInterface.sequelize.query(
                 'ALTER TABLE user_project_areas_new RENAME TO user_project_areas;'
             );
@@ -50,7 +53,8 @@ module.exports = {
         const tables = await queryInterface.showAllTables();
         if (!tables.includes('user_project_areas')) return;
 
-        const tableInfo = await queryInterface.describeTable('user_project_areas');
+        const tableInfo =
+            await queryInterface.describeTable('user_project_areas');
         if (!('id' in tableInfo)) return;
 
         await queryInterface.sequelize.query('PRAGMA foreign_keys = OFF;');

--- a/frontend/components/Sidebar/SidebarAreas.tsx
+++ b/frontend/components/Sidebar/SidebarAreas.tsx
@@ -29,7 +29,7 @@ const SidebarAreas: React.FC<SidebarAreasProps> = ({
             <ul className="flex flex-col space-y-1">
                 {/* "AREAS" Title with Add Button */}
                 <li
-                    className={`flex justify-between items-center px-4 py-2 rounded-md uppercase text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${isActiveArea(
+                    className={`group flex justify-between items-center px-4 py-2 rounded-md uppercase text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${isActiveArea(
                         '/areas'
                     )}`}
                     onClick={() =>
@@ -49,7 +49,7 @@ const SidebarAreas: React.FC<SidebarAreasProps> = ({
                             e.stopPropagation();
                             openAreaModal(null);
                         }}
-                        className="text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
+                        className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
                         aria-label={t('sidebar.addAreaAriaLabel')}
                         title={t('sidebar.addAreaTitle')}
                         data-testid="add-area-button"

--- a/frontend/components/Sidebar/SidebarHabits.tsx
+++ b/frontend/components/Sidebar/SidebarHabits.tsx
@@ -26,7 +26,7 @@ const SidebarHabits: React.FC<SidebarHabitsProps> = ({
         <>
             <ul className="flex flex-col space-y-1">
                 <li
-                    className={`flex justify-between items-center rounded-md px-4 py-2 uppercase text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${isActiveHabit(
+                    className={`group flex justify-between items-center rounded-md px-4 py-2 uppercase text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${isActiveHabit(
                         '/habits'
                     )}`}
                     onClick={() =>
@@ -46,7 +46,7 @@ const SidebarHabits: React.FC<SidebarHabitsProps> = ({
                             e.stopPropagation();
                             openNewHabit();
                         }}
-                        className="text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
+                        className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
                         aria-label={t('sidebar.addHabitAriaLabel')}
                         title={t('sidebar.addHabitTitle')}
                     >

--- a/frontend/components/Sidebar/SidebarNav.tsx
+++ b/frontend/components/Sidebar/SidebarNav.tsx
@@ -128,7 +128,7 @@ const SidebarNav: React.FC<SidebarNavProps> = ({
                                 handleNavClick(link.path, link.title, link.icon)
                             }
                             data-testid={`sidebar-nav-${link.path.replace(/^\//, '').replace(/\?.*$/, '')}`}
-                            className={`w-full text-left px-4 py-1 flex items-center justify-between rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200 ${isActive(
+                            className={`group w-full text-left px-4 py-1 flex items-center justify-between rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all duration-200 ${isActive(
                                 link.path,
                                 link.query
                             )}`}
@@ -164,7 +164,7 @@ const SidebarNav: React.FC<SidebarNavProps> = ({
                                                 openTaskModal();
                                             }
                                         }}
-                                        className="text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none cursor-pointer"
+                                        className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none cursor-pointer"
                                         aria-label={t(
                                             'sidebar.addTaskAriaLabel',
                                             'Add Task'

--- a/frontend/components/Sidebar/SidebarNotes.tsx
+++ b/frontend/components/Sidebar/SidebarNotes.tsx
@@ -28,7 +28,7 @@ const SidebarNotes: React.FC<SidebarNotesProps> = ({
         <>
             <ul className="flex flex-col space-y-1">
                 <li
-                    className={`flex justify-between items-center rounded-md px-4 py-2 uppercase text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${isActiveNote(
+                    className={`group flex justify-between items-center rounded-md px-4 py-2 uppercase text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${isActiveNote(
                         '/notes'
                     )}`}
                     onClick={() =>
@@ -48,7 +48,7 @@ const SidebarNotes: React.FC<SidebarNotesProps> = ({
                             e.stopPropagation();
                             openNoteModal(null);
                         }}
-                        className="text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
+                        className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
                         aria-label={t('sidebar.addNoteAriaLabel')}
                         title={t('sidebar.addNoteTitle')}
                         data-testid="add-note-button"

--- a/frontend/components/Sidebar/SidebarProjects.tsx
+++ b/frontend/components/Sidebar/SidebarProjects.tsx
@@ -1,7 +1,17 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Location } from 'react-router-dom';
-import { FolderIcon, PlusCircleIcon } from '@heroicons/react/24/outline';
+import {
+    FolderIcon,
+    PlusCircleIcon,
+    ChevronDownIcon,
+    ChevronRightIcon,
+    BookmarkIcon,
+} from '@heroicons/react/24/outline';
+import { BookmarkIcon as BookmarkIconSolid } from '@heroicons/react/24/solid';
 import { useTranslation } from 'react-i18next';
+import { useStore } from '../../store/useStore';
+import { updateProject } from '../../utils/projectsService';
+import { Project } from '../../entities/Project';
 
 interface SidebarProjectsProps {
     handleNavClick: (path: string, title: string, icon: JSX.Element) => void;
@@ -10,51 +20,186 @@ interface SidebarProjectsProps {
     openProjectModal: () => void;
 }
 
+const ProjectIcon: React.FC<{ project: Project }> = ({ project }) => (
+    <FolderIcon
+        className="h-4 w-4"
+        style={project.color ? { color: project.color } : undefined}
+    />
+);
+
+const getProjectPath = (project: Project) => {
+    const slug = project.name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+    return `/project/${project.uid}-${slug}`;
+};
+
 const SidebarProjects: React.FC<SidebarProjectsProps> = ({
     handleNavClick,
     location,
     openProjectModal,
 }) => {
     const { t } = useTranslation();
-    const isActiveProject = (path: string) => {
-        return location.pathname === path
-            ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white'
-            : 'text-gray-700 dark:text-gray-300';
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const projects = useStore((state) => state.projectsStore.projects);
+    const hasLoaded = useStore((state) => state.projectsStore.hasLoaded);
+    const loadProjects = useStore((state) => state.projectsStore.loadProjects);
+    const setProjects = useStore((state) => state.projectsStore.setProjects);
+
+    useEffect(() => {
+        if (!hasLoaded) {
+            loadProjects();
+        }
+    }, [hasLoaded, loadProjects]);
+
+    const pinnedProjects = projects.filter((p) => p.pin_to_sidebar);
+    const unpinnedActiveProjects = projects.filter(
+        (p) =>
+            !p.pin_to_sidebar &&
+            p.status !== 'done' &&
+            p.status !== 'cancelled'
+    );
+
+    const isActive = (path: string) => location.pathname === path;
+
+    const itemClass = (path: string) =>
+        `group flex justify-between items-center rounded-md px-4 py-1.5 text-sm cursor-pointer hover:text-black dark:hover:text-white ${
+            isActive(path)
+                ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white'
+                : 'text-gray-700 dark:text-gray-300'
+        }`;
+
+    const togglePin = async (project: Project, e: React.MouseEvent) => {
+        e.stopPropagation();
+        if (!project.uid) return;
+        const newValue = !project.pin_to_sidebar;
+        setProjects(
+            projects.map((p) =>
+                p.uid === project.uid ? { ...p, pin_to_sidebar: newValue } : p
+            )
+        );
+        try {
+            await updateProject(project.uid, { pin_to_sidebar: newValue });
+        } catch {
+            setProjects(
+                projects.map((p) =>
+                    p.uid === project.uid
+                        ? { ...p, pin_to_sidebar: !newValue }
+                        : p
+                )
+            );
+        }
     };
 
+    const navigate = (project: Project) =>
+        handleNavClick(
+            getProjectPath(project),
+            project.name,
+            <FolderIcon className="h-4 w-4 mr-2" />
+        );
+
     return (
-        <>
-            <ul className="flex flex-col space-y-1 mt-4">
-                <li
-                    className={`flex justify-between items-center px-4 py-2 uppercase rounded-md text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${isActiveProject(
-                        '/projects'
-                    )}`}
-                    onClick={() =>
-                        handleNavClick(
-                            '/projects',
-                            'Projects',
-                            <FolderIcon className="h-5 w-5 mr-2" />
-                        )
-                    }
-                >
-                    <span className="flex items-center">
+        <ul className="flex flex-col space-y-1 mt-4">
+            <li
+                className={`group flex justify-between items-center px-4 py-2 uppercase rounded-md text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${
+                    isActive('/projects')
+                        ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white'
+                        : 'text-gray-700 dark:text-gray-300'
+                }`}
+                onClick={() =>
+                    handleNavClick(
+                        '/projects',
+                        'Projects',
                         <FolderIcon className="h-5 w-5 mr-2" />
-                        {t('sidebar.projects')}
-                    </span>
+                    )
+                }
+            >
+                <span className="flex items-center">
+                    <FolderIcon className="h-5 w-5 mr-2" />
+                    {t('sidebar.projects')}
+                </span>
+                <div className="flex items-center gap-1">
                     <button
                         onClick={(e) => {
                             e.stopPropagation();
                             openProjectModal();
                         }}
-                        className="text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
+                        className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
                         aria-label={t('sidebar.addProjectAriaLabel')}
                         title={t('sidebar.addProjectTitle')}
                     >
                         <PlusCircleIcon className="h-5 w-5" />
                     </button>
+                    {unpinnedActiveProjects.length > 0 && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                setIsExpanded((v) => !v);
+                            }}
+                            className="text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
+                            aria-label={
+                                isExpanded
+                                    ? 'Collapse projects list'
+                                    : 'Expand projects list'
+                            }
+                        >
+                            {isExpanded ? (
+                                <ChevronDownIcon className="h-4 w-4" />
+                            ) : (
+                                <ChevronRightIcon className="h-4 w-4" />
+                            )}
+                        </button>
+                    )}
+                </div>
+            </li>
+
+            {pinnedProjects.map((project) => (
+                <li
+                    key={project.uid}
+                    className={itemClass(getProjectPath(project))}
+                    onClick={() => navigate(project)}
+                >
+                    <span className="flex items-center truncate">
+                        <span className="w-5 mr-2 flex items-center justify-center flex-shrink-0">
+                            <ProjectIcon project={project} />
+                        </span>
+                        <span className="truncate">{project.name}</span>
+                    </span>
+                    <button
+                        onClick={(e) => togglePin(project, e)}
+                        className="text-blue-500 hover:text-blue-600 dark:hover:text-blue-400 focus:outline-none flex-shrink-0"
+                        title="Unpin from sidebar"
+                    >
+                        <BookmarkIconSolid className="h-4 w-4" />
+                    </button>
                 </li>
-            </ul>
-        </>
+            ))}
+
+            {isExpanded &&
+                unpinnedActiveProjects.map((project) => (
+                    <li
+                        key={project.uid}
+                        className={itemClass(getProjectPath(project))}
+                        onClick={() => navigate(project)}
+                    >
+                        <span className="flex items-center truncate">
+                            <span className="w-5 mr-2 flex items-center justify-center flex-shrink-0">
+                                <ProjectIcon project={project} />
+                            </span>
+                            <span className="truncate">{project.name}</span>
+                        </span>
+                        <button
+                            onClick={(e) => togglePin(project, e)}
+                            className="opacity-0 group-hover:opacity-100 text-gray-400 hover:text-blue-500 dark:hover:text-blue-400 focus:outline-none flex-shrink-0 transition-opacity"
+                            title="Pin to sidebar"
+                        >
+                            <BookmarkIcon className="h-4 w-4" />
+                        </button>
+                    </li>
+                ))}
+        </ul>
     );
 };
 

--- a/frontend/components/Sidebar/SidebarTags.tsx
+++ b/frontend/components/Sidebar/SidebarTags.tsx
@@ -30,7 +30,7 @@ const SidebarTags: React.FC<SidebarTagsProps> = ({
             <ul className="flex flex-col space-y-1">
                 {/* "TAGS" Title with Add Button */}
                 <li
-                    className={`flex justify-between items-center rounded-md px-4 py-2 uppercase text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${isActiveTag(
+                    className={`group flex justify-between items-center rounded-md px-4 py-2 uppercase text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${isActiveTag(
                         '/tags'
                     )}`}
                     onClick={() =>
@@ -50,7 +50,7 @@ const SidebarTags: React.FC<SidebarTagsProps> = ({
                             e.stopPropagation();
                             openTagModal(null);
                         }}
-                        className="text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
+                        className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
                         aria-label={t('sidebar.addTagAriaLabel')}
                         title={t('sidebar.addTagTitle')}
                         data-testid="add-tag-button"


### PR DESCRIPTION
## Description

Enhances the sidebar Projects section with a full project listing, collapsible drawer, pin-to-sidebar, and visual polish across all sidebar section headers.

## Type of Change

- [x] New feature
- [x] Bug fix

## Related Issues

N/A

## Changes

### Sidebar Projects (`SidebarProjects.tsx`)
- Loads all projects from the Zustand store on mount
- Section header starts collapsed; a chevron toggle reveals the list of non-pinned active projects
- Projects can be **pinned** to the sidebar via a bookmark icon — pinned projects are always visible above the collapsible list and unaffected by collapse; state is persisted via `PATCH /project/:uid`
- Optimistic UI update on pin/unpin with rollback on error
- Project folder icons are **tinted with the project color** when set

### Sidebar add buttons (all sections)
- `+` (PlusCircleIcon) buttons in Projects, Areas, Notes, Tags, Habits, and Tasks are now **hidden at rest** and revealed on hover via `opacity-0 group-hover:opacity-100 transition-opacity`

### Migration (`20260721000001-add-id-to-user-project-areas.js`)
- Fixes a 500 error on `GET /api/projects`: the `user_project_areas` table was created without the `id AUTOINCREMENT` column (the `safeCreateTable` guard skipped creation because the table already existed from an older schema). The migration rebuilds the table using SQLite's create-copy-drop-rename approach and recreates the required indexes.

## Testing

- Start app (`npm start`) and verify:
  - Projects section shows pinned projects always, collapses/expands the rest
  - Bookmark icon pins/unpins and persists on reload
  - Folder icons pick up project colors
  - All sidebar `+` buttons are hidden until hovering the row
  - `GET /api/projects` returns 200 (no more `no such column: UserProjectArea.id` error)
- Run `npm run lint` — passes clean

## Checklist

- [x] Code follows project conventions
- [x] Linting passes (`npm run lint`)
- [x] No JSDoc comments added
- [x] No Co-authored-by trailer in commit