### PR TITLE
perf: cache api/profile to eliminate redundant fetches on Today page

### DIFF
--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -42,6 +42,7 @@ import Templates from './components/Templates/Templates';
 import { setCurrentUser as setUserInStorage } from './utils/userUtils';
 import { getApiPath, getLocalesPath } from './config/paths';
 import { useStore } from './store/useStore';
+import { invalidateProfileCache } from './utils/profileService';
 // Lazy load Tasks component to prevent issues with tags loading
 const Tasks = lazy(() => import('./components/Tasks'));
 
@@ -65,6 +66,7 @@ const App: React.FC = () => {
 
             if (!response.ok) {
                 if (response.status === 401) {
+                    invalidateProfileCache();
                     setCurrentUser(null);
                     return;
                 }
@@ -109,6 +111,7 @@ const App: React.FC = () => {
     // Listen for login events to update user state
     useEffect(() => {
         const handleUserLoggedIn = (event: CustomEvent) => {
+            invalidateProfileCache();
             const user = event.detail;
             setCurrentUser(user);
             setUserInStorage(user);

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -21,7 +21,7 @@ import NotificationsDropdown from './Notifications/NotificationsDropdown';
 import { getApiPath, getAssetPath } from '../config/paths';
 import { getFeatureFlags, FeatureFlags } from '../utils/featureFlags';
 import { setUserTimezone } from '../utils/dateUtils';
-import { fetchProfile as fetchProfileFromService } from '../utils/profileService';
+import { fetchProfile as fetchProfileFromService, invalidateProfileCache } from '../utils/profileService';
 
 interface NavbarProps {
     isDarkMode: boolean;
@@ -143,6 +143,7 @@ const Navbar: React.FC<NavbarProps> = ({
     };
 
     const handleLogout = async () => {
+        invalidateProfileCache();
         try {
             const response = await fetch(getApiPath('logout'), {
                 method: 'GET',

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -21,6 +21,7 @@ import NotificationsDropdown from './Notifications/NotificationsDropdown';
 import { getApiPath, getAssetPath } from '../config/paths';
 import { getFeatureFlags, FeatureFlags } from '../utils/featureFlags';
 import { setUserTimezone } from '../utils/dateUtils';
+import { fetchProfile as fetchProfileFromService } from '../utils/profileService';
 
 interface NavbarProps {
     isDarkMode: boolean;
@@ -95,26 +96,19 @@ const Navbar: React.FC<NavbarProps> = ({
 
     // Fetch user's pomodoro setting and feature flags
     useEffect(() => {
-        const fetchProfile = async () => {
+        const loadProfile = async () => {
             try {
-                const response = await fetch(getApiPath('profile'), {
-                    credentials: 'include',
-                });
-                if (response.ok) {
-                    const profile = await response.json();
-                    setPomodoroEnabled(
-                        profile.features?.pomodoro_enabled !== undefined
-                            ? profile.features.pomodoro_enabled
-                            : true
-                    );
-                    // Set user timezone for date formatting
-                    if (profile.timezone) {
-                        setUserTimezone(profile.timezone);
-                    }
+                const profile = await fetchProfileFromService();
+                setPomodoroEnabled(
+                    profile.features?.pomodoro_enabled !== undefined
+                        ? profile.features.pomodoro_enabled
+                        : true
+                );
+                if (profile.timezone) {
+                    setUserTimezone(profile.timezone);
                 }
             } catch (error) {
                 console.error('Error fetching profile:', error);
-                // Keep default value (true) if fetch fails
             }
         };
 
@@ -123,7 +117,7 @@ const Navbar: React.FC<NavbarProps> = ({
             setFeatureFlags(flags);
         };
 
-        fetchProfile();
+        loadProfile();
         fetchFlags();
 
         // Listen for Pomodoro setting changes from ProfileSettings

--- a/frontend/utils/profileService.ts
+++ b/frontend/utils/profileService.ts
@@ -38,15 +38,45 @@ interface TelegramBotInfo {
     chat_url: string;
 }
 
+let profileCache: Profile | null = null;
+let profileCacheExpiry = 0;
+let profileInflightRequest: Promise<Profile> | null = null;
+const PROFILE_CACHE_TTL_MS = 60_000;
+
+export const invalidateProfileCache = (): void => {
+    profileCache = null;
+    profileCacheExpiry = 0;
+    profileInflightRequest = null;
+};
+
 export const fetchProfile = async (): Promise<Profile> => {
-    const response = await fetch(getApiPath('profile'), {
-        credentials: 'include',
-        headers: {
-            Accept: 'application/json',
-        },
-    });
-    await handleAuthResponse(response, 'Failed to fetch profile data.');
-    return await response.json();
+    if (profileCache && Date.now() < profileCacheExpiry) {
+        return profileCache;
+    }
+
+    if (profileInflightRequest) {
+        return profileInflightRequest;
+    }
+
+    profileInflightRequest = (async () => {
+        try {
+            const response = await fetch(getApiPath('profile'), {
+                credentials: 'include',
+                headers: {
+                    Accept: 'application/json',
+                },
+            });
+            await handleAuthResponse(response, 'Failed to fetch profile data.');
+            const profile = await response.json();
+            profileCache = profile;
+            profileCacheExpiry = Date.now() + PROFILE_CACHE_TTL_MS;
+            return profile;
+        } finally {
+            profileInflightRequest = null;
+        }
+    })();
+
+    return profileInflightRequest;
 };
 
 export const updateProfile = async (
@@ -60,6 +90,9 @@ export const updateProfile = async (
     });
     await handleAuthResponse(response, 'Failed to update profile.');
     const updatedProfile = await response.json();
+
+    profileCache = updatedProfile;
+    profileCacheExpiry = Date.now() + PROFILE_CACHE_TTL_MS;
 
     if (profileData.features && 'task_intelligence_enabled' in profileData.features) {
         localStorage.removeItem('taskIntelligenceEnabled');


### PR DESCRIPTION
## Description

The Today page was making 5 separate `GET /api/profile` requests on every page load, causing a 12+ second load time for some users.

**Root cause:** Multiple components mounted simultaneously each called their own variant of `fetchProfile()` independently:
- `Navbar.tsx` — inline fetch on mount
- `NewTask.tsx` — via `getTaskIntelligenceEnabled()`
- `RecurrenceDisplay.tsx` — via `getFirstDayOfWeek()` (once per recurring task rendered)
- `WeekdaySelector.tsx` — via `getFirstDayOfWeek()`

Each is a separate HTTP round-trip with no coordination between them.

**Fix:** Add a 60-second in-memory cache with in-flight request deduplication to `profileService.ts`:
- If a valid cached response exists, return it immediately
- If a request is already in-flight, all callers share the same `Promise` rather than issuing parallel requests
- `updateProfile` populates the cache with the fresh response so saves are reflected immediately
- `invalidateProfileCache` is exported for cases where stale data must be force-cleared

`Navbar.tsx` is updated to use the shared `fetchProfile` from `profileService` instead of its own inline fetch, so it participates in the same cache.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Related Issues

Fixes #1310

## Testing

1. Open the Today page with browser DevTools → Network tab
2. Filter by `profile`
3. Verify only **1** request to `/api/profile` fires on page load (was 5)
4. Edit a profile setting via `/profile` → save → return to Today page and confirm the updated value is reflected (cache is warmed from `updateProfile`)

## Checklist

- [x] Code follows project conventions
- [x] `npm run lint:fix` passes with no errors
- [x] Manual testing performed (network request deduplication verified)
- [ ] Tests added/updated (no unit tests for profileService currently exist)

## Additional Notes

The `invalidateProfileCache` export is available for any future code that needs to force a fresh fetch (e.g., after login/logout transitions).