### PR TITLE
fix(templates): prevent action menu from being clipped by card overflow

### DIFF
--- a/frontend/components/Templates/TemplateCard.tsx
+++ b/frontend/components/Templates/TemplateCard.tsx
@@ -69,9 +69,9 @@ const TemplateCard: React.FC<TemplateCardProps> = ({
     return (
         <div
             onClick={() => onPreview(template)}
-            className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden flex flex-col group hover:shadow-lg hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 cursor-pointer"
+            className="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl flex flex-col group hover:shadow-lg hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 cursor-pointer"
         >
-            <div className={`h-1.5 w-full flex-shrink-0 ${accent.bar}`} />
+            <div className={`h-1.5 w-full flex-shrink-0 rounded-t-xl ${accent.bar}`} />
 
             <div className="p-4 flex flex-col gap-2.5 flex-1 relative">
                 <div className="absolute top-2 right-2 z-10" ref={dropdownRef}>


### PR DESCRIPTION
## Description

The template card action menu (three-dot button) was being visually clipped at the bottom of each card, hiding the Delete option. The root cause was `overflow-hidden` on the card container — this clips all descendant elements, including absolutely-positioned dropdowns, regardless of their `z-index`.

**Why this change is needed:** Users could not delete templates because the Delete menu item was cut off.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1308

## Changes Made

- Removed `overflow-hidden` from the `TemplateCard` container div
- Added `rounded-t-xl` to the color bar div at the top of the card to preserve the rounded top-corner appearance (previously handled implicitly by `overflow-hidden`)

## Testing

1. Go to the Templates page (user menu → Templates)
2. Open "My Templates" tab
3. Hover over any template card — the three-dot menu button appears
4. Click the three-dot menu button
5. Verify all options are visible: Use Template, Preview, Edit, Delete

## Checklist

- [x] My changes follow the project's code conventions
- [x] I have run `npm run lint:fix` and resolved all issues
- [x] The fix has been manually verified