### PR TITLE
fix(habits): prevent habit completions from being double-counted in Today overview

### DIFF
--- a/backend/modules/tasks/queries/metrics-computation.js
+++ b/backend/modules/tasks/queries/metrics-computation.js
@@ -155,6 +155,7 @@ async function computeWeeklyCompletions(userId, userTimezone) {
             where: {
                 user_id: userId,
                 status: Task.STATUS.DONE,
+                habit_mode: false,
                 completed_at: {
                     [Op.between]: [weekStart, weekEnd],
                 },

--- a/backend/modules/tasks/queries/metrics-queries.js
+++ b/backend/modules/tasks/queries/metrics-queries.js
@@ -520,13 +520,14 @@ async function fetchTasksCompletedToday(userId, userTimezone) {
     const safeTimezone = getSafeTimezone(userTimezone);
     const todayBounds = getTodayBoundsInUTC(safeTimezone);
 
-    // Fetch regular completed tasks
+    // Fetch regular completed tasks (exclude habit tasks — those are captured via RecurringCompletion)
     const regularCompletedTasks = await Task.findAll({
         where: {
             user_id: userId,
             status: Task.STATUS.DONE,
             parent_task_id: null,
             recurring_parent_id: null,
+            habit_mode: false,
             completed_at: {
                 [Op.gte]: todayBounds.start,
                 [Op.lte]: todayBounds.end,


### PR DESCRIPTION
## Description

When completing a habit on the Today page, the **Completed Today** count in the Overview was showing 2× the actual number of completed habits.

**Root Cause:** When a habit is completed, two things happen simultaneously:
1. The habit task's `status` is set to `DONE` and `completed_at` is set to now
2. A `RecurringCompletion` record is created for the habit

The `fetchTasksCompletedToday` and `computeWeeklyCompletions` queries both fetch:
- Tasks with `status = DONE` (which includes habits after completion)
- `RecurringCompletion` records (which also include habit completions)

This caused every completed habit to appear in **both** result sets, inflating the Completed Today count by 2x per habit.

**Fix:** Exclude `habit_mode = true` tasks from the regular `status = DONE` query in both affected functions. Habit completions are already fully captured via `RecurringCompletion` records, so this removes the duplicate without losing any data.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1305

## Testing

- [x] `npm test` — all 1594 tests pass
- [x] `npm run lint:fix` — no errors

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have tested this change manually
- [x] All existing tests pass

## Additional Notes

The same fix was applied to `computeWeeklyCompletions` (used by the burndown chart), which had an identical double-counting issue for habit completions in the weekly stats.