### PR TITLE
fix(habits): prevent habit_total_completions from inflating on same-day completions

### DIFF
--- a/backend/modules/habits/habitService.js
+++ b/backend/modules/habits/habitService.js
@@ -11,10 +11,27 @@ class HabitService {
             throw new Error('Task is not a habit');
         }
 
+        const dayStart = new Date(completedAt);
+        dayStart.setHours(0, 0, 0, 0);
+        const dayEnd = new Date(completedAt);
+        dayEnd.setHours(23, 59, 59, 999);
+
+        const existingToday = await RecurringCompletion.findOne({
+            where: {
+                task_id: task.id,
+                skipped: false,
+                completed_at: { [Op.between]: [dayStart, dayEnd] },
+            },
+        });
+
+        if (existingToday) {
+            return { completion: existingToday, task };
+        }
+
         const completion = await RecurringCompletion.create({
             task_id: task.id,
             completed_at: completedAt,
-            original_due_date: completedAt, // For habits, due date = completion date
+            original_due_date: completedAt,
             skipped: false,
         });
 
@@ -61,8 +78,16 @@ class HabitService {
             order: [['completed_at', 'DESC']],
         });
 
+        const distinctDays = new Set(
+            completions.map((c) => {
+                const d = new Date(c.completed_at);
+                d.setHours(0, 0, 0, 0);
+                return d.getTime();
+            })
+        ).size;
+
         const updates = {
-            habit_total_completions: completions.length,
+            habit_total_completions: distinctDays,
             habit_last_completion_at:
                 completions.length > 0 ? completions[0].completed_at : null,
         };


### PR DESCRIPTION
## Description

`habit_total_completions` would increment on every call to `logCompletion`, even when a habit was already completed on the same calendar day. Streak counters (`habit_current_streak`, `habit_best_streak`) correctly deduplicate by unique day, but the total count did not — causing it to drift above the real number of completion days.

Additionally, `recalculateStreaks` (called on the delete path) used `completions.length` (raw row count) rather than distinct days, so it could not heal historical duplicates created before this fix.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1316

## Changes Made

**`backend/modules/habits/habitService.js`**

- `logCompletion`: Before inserting a new `RecurringCompletion` row, query for an existing non-skipped completion on the same calendar day. If one exists, return it immediately without inserting a duplicate or updating any counters.
- `recalculateStreaks`: Compute `habit_total_completions` from the count of distinct completion days (not raw row count), so a recalculation also repairs any existing duplicates from before this fix.

## Testing

- All 1594 backend tests pass (`npm run backend:test`).
- No lint errors (`npm run lint:fix`).

**Manual verification steps:**
1. Create a habit.
2. Call `POST /api/habits/:id/complete` twice on the same day.
3. Confirm `habit_total_completions = 1`, `habit_current_streak = 1`, `habit_best_streak = 1`.
4. Delete a completion and verify `recalculateStreaks` correctly reflects distinct days.

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have tested my changes locally
- [x] All existing tests pass
- [x] No new lint errors introduced