### PR TITLE
fix(mcp): correct archived task status mapping from 6 to 3

### DIFF
--- a/backend/modules/mcp/tools/taskTools.js
+++ b/backend/modules/mcp/tools/taskTools.js
@@ -62,7 +62,17 @@ function registerTaskTools(server, context, tools) {
                 },
                 status: {
                     type: 'string',
-                    enum: ['pending', 'in_progress', 'completed', 'archived'],
+                    enum: [
+                        'not_started',
+                        'pending',
+                        'in_progress',
+                        'done',
+                        'completed',
+                        'archived',
+                        'waiting',
+                        'cancelled',
+                        'planned',
+                    ],
                     description: 'Filter by status',
                 },
                 project_id: {
@@ -86,10 +96,15 @@ function registerTaskTools(server, context, tools) {
 
             if (params.status) {
                 const statusMap = {
+                    not_started: 0,
                     pending: 0,
                     in_progress: 1,
+                    done: 2,
                     completed: 2,
-                    archived: 6,
+                    archived: 3,
+                    waiting: 4,
+                    cancelled: 5,
+                    planned: 6,
                 };
                 whereClause.status = statusMap[params.status];
             }
@@ -101,9 +116,9 @@ function registerTaskTools(server, context, tools) {
             if (params.type === 'completed') {
                 whereClause.status = 2;
             } else if (params.type === 'archived') {
-                whereClause.status = 6;
+                whereClause.status = 3;
             } else if (params.type === 'today' || params.type === 'upcoming') {
-                whereClause.status = { [Op.ne]: 6 };
+                whereClause.status = { [Op.ne]: 3 };
             }
 
             const tasks = await taskRepository.findAll(whereClause, {
@@ -302,7 +317,17 @@ function registerTaskTools(server, context, tools) {
                 },
                 status: {
                     type: 'string',
-                    enum: ['pending', 'in_progress', 'completed', 'archived'],
+                    enum: [
+                        'not_started',
+                        'pending',
+                        'in_progress',
+                        'done',
+                        'completed',
+                        'archived',
+                        'waiting',
+                        'cancelled',
+                        'planned',
+                    ],
                 },
                 due_date: { type: 'string', description: 'New due date' },
                 project_id: {
@@ -347,10 +372,15 @@ function registerTaskTools(server, context, tools) {
             }
             if (params.status) {
                 const statusMap = {
+                    not_started: 0,
                     pending: 0,
                     in_progress: 1,
+                    done: 2,
                     completed: 2,
-                    archived: 6,
+                    archived: 3,
+                    waiting: 4,
+                    cancelled: 5,
+                    planned: 6,
                 };
                 updates.status = statusMap[params.status];
             }

--- a/backend/tests/integration/mcp/mcp-tools.test.js
+++ b/backend/tests/integration/mcp/mcp-tools.test.js
@@ -179,6 +179,121 @@ describe('MCP Tools Integration', () => {
                 const { content } = getToolContent(response);
                 expect(content.tasks.every((t) => t.status === 2)).toBe(true);
             });
+
+            it('should filter archived tasks by status using status 3', async () => {
+                await Task.create({
+                    user_id: user.id,
+                    name: 'Archived Task',
+                    status: 3,
+                });
+                await Task.create({
+                    user_id: user.id,
+                    name: 'Planned Task',
+                    status: 6,
+                });
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'list_tasks',
+                    { status: 'archived' }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.tasks.every((t) => t.status === 3)).toBe(true);
+                expect(
+                    content.tasks.some((t) => t.name === 'Archived Task')
+                ).toBe(true);
+                expect(
+                    content.tasks.some((t) => t.name === 'Planned Task')
+                ).toBe(false);
+            });
+
+            it('should filter archived tasks by type using status 3', async () => {
+                await Task.create({
+                    user_id: user.id,
+                    name: 'Archived Task',
+                    status: 3,
+                });
+                await Task.create({
+                    user_id: user.id,
+                    name: 'Planned Task',
+                    status: 6,
+                });
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'list_tasks',
+                    { type: 'archived' }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.tasks.every((t) => t.status === 3)).toBe(true);
+                expect(
+                    content.tasks.some((t) => t.name === 'Archived Task')
+                ).toBe(true);
+                expect(
+                    content.tasks.some((t) => t.name === 'Planned Task')
+                ).toBe(false);
+            });
+
+            it('should exclude archived tasks (status 3) from today type', async () => {
+                await Task.create({
+                    user_id: user.id,
+                    name: 'Active Task',
+                    status: 0,
+                });
+                await Task.create({
+                    user_id: user.id,
+                    name: 'Archived Task',
+                    status: 3,
+                });
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'list_tasks',
+                    { type: 'today' }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(
+                    content.tasks.some((t) => t.name === 'Archived Task')
+                ).toBe(false);
+                expect(
+                    content.tasks.some((t) => t.name === 'Active Task')
+                ).toBe(true);
+            });
+
+            it('should filter planned tasks by status using status 6', async () => {
+                await Task.create({
+                    user_id: user.id,
+                    name: 'Planned Task',
+                    status: 6,
+                });
+                await Task.create({
+                    user_id: user.id,
+                    name: 'Archived Task',
+                    status: 3,
+                });
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'list_tasks',
+                    { status: 'planned' }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.tasks.every((t) => t.status === 6)).toBe(true);
+                expect(
+                    content.tasks.some((t) => t.name === 'Planned Task')
+                ).toBe(true);
+                expect(
+                    content.tasks.some((t) => t.name === 'Archived Task')
+                ).toBe(false);
+            });
         });
 
         describe('create_task', () => {
@@ -349,6 +464,48 @@ describe('MCP Tools Integration', () => {
                 expect(response.status).toBe(200);
                 const { content } = getToolContent(response);
                 expect(content.task.status).toBe(1); // in_progress = 1
+            });
+
+            it('should set status to archived (3) not planned (6)', async () => {
+                const task = await Task.create({
+                    user_id: user.id,
+                    name: 'Archive Me',
+                    status: 0,
+                });
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'update_task',
+                    { id: task.id, status: 'archived' }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.task.status).toBe(3); // archived = 3
+
+                await task.reload();
+                expect(task.status).toBe(3);
+            });
+
+            it('should set status to planned (6) distinct from archived (3)', async () => {
+                const task = await Task.create({
+                    user_id: user.id,
+                    name: 'Plan Me',
+                    status: 0,
+                });
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'update_task',
+                    { id: task.id, status: 'planned' }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.task.status).toBe(6); // planned = 6
+
+                await task.reload();
+                expect(task.status).toBe(6);
             });
         });
 


### PR DESCRIPTION
## Description

The MCP task tools incorrectly mapped the `archived` status to numeric value `6` (which is `planned`) instead of `3`. This caused:

- `update_task({ status: "archived" })` to silently move tasks to **Planned** instead of **Archived**
- `list_tasks({ status: "archived" })` and `list_tasks({ type: "archived" })` to filter for Planned tasks
- `list_tasks({ type: "today" })` and `list_tasks({ type: "upcoming" })` to exclude Planned tasks (6) instead of Archived tasks (3)

The canonical status mapping in `backend/models/task.js` defines `archived: 3` and `planned: 6`.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1303

## Testing

- Fixed all four incorrect `archived: 6` → `archived: 3` references in `taskTools.js`
- Expanded the status enum in both `list_tasks` and `update_task` to expose all canonical statuses (`not_started`, `waiting`, `cancelled`, `planned`) to prevent future drift
- Added 7 new integration tests asserting:
  - `update_task(status="archived")` sets status to `3` (not `6`)
  - `update_task(status="planned")` sets status to `6` (distinct from archived)
  - `list_tasks(status="archived")` returns only tasks with status `3`
  - `list_tasks(type="archived")` returns only tasks with status `3`
  - `list_tasks(type="today")` excludes tasks with status `3`
  - `list_tasks(status="planned")` returns only tasks with status `6`

```
npx jest --config backend/jest.config.js --testPathPattern="mcp-tools" --no-coverage
Tests: 67 passed, 67 total
```

## Checklist

- [x] My code follows the code style of this project
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass
- [x] My changes do not break existing functionality