### PR TITLE
fix(people): create self-person for newly provisioned users

### DIFF
--- a/backend/migrations/20260722000002-backfill-missing-self-persons.js
+++ b/backend/migrations/20260722000002-backfill-missing-self-persons.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const { customAlphabet } = require('nanoid');
+
+module.exports = {
+    async up(queryInterface) {
+        const generate = customAlphabet(
+            '0123456789abcdefghijkmnpqrstuvwxyz',
+            15
+        );
+
+        const users = await queryInterface.sequelize.query(
+            'SELECT id, email, name, surname FROM users',
+            { type: queryInterface.sequelize.QueryTypes.SELECT }
+        );
+
+        for (const user of users) {
+            const existing = await queryInterface.sequelize.query(
+                'SELECT id FROM people WHERE user_id = :userId AND linked_user_id = :userId LIMIT 1',
+                {
+                    replacements: { userId: user.id },
+                    type: queryInterface.sequelize.QueryTypes.SELECT,
+                }
+            );
+            if (existing.length > 0) continue;
+
+            const nameParts = [user.name, user.surname].filter(Boolean);
+            let personName =
+                nameParts.length > 0
+                    ? nameParts.join(' ').trim()
+                    : user.email.split('@')[0];
+
+            const nameConflict = await queryInterface.sequelize.query(
+                'SELECT id FROM people WHERE user_id = :userId AND name = :name LIMIT 1',
+                {
+                    replacements: { userId: user.id, name: personName },
+                    type: queryInterface.sequelize.QueryTypes.SELECT,
+                }
+            );
+            if (nameConflict.length > 0) {
+                personName = personName + ' (me)';
+            }
+
+            const uid = generate();
+            await queryInterface.sequelize.query(
+                `INSERT INTO people (uid, user_id, linked_user_id, name, email, relationship_type, archived, created_at, updated_at)
+                 VALUES (:uid, :userId, :userId, :name, :email, 'other', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+                {
+                    replacements: {
+                        uid,
+                        userId: user.id,
+                        name: personName,
+                        email: user.email || null,
+                    },
+                }
+            );
+        }
+    },
+
+    async down() {
+        // Self-persons created by this migration cannot be safely removed
+        // without risking deletion of user-modified person entries
+    },
+};

--- a/backend/modules/admin/service.js
+++ b/backend/modules/admin/service.js
@@ -20,6 +20,7 @@ const { isAdmin } = require('../../services/rolesService');
 const {
     getDefaultNotificationPreferences,
 } = require('../../utils/notificationPreferences');
+const { logError } = require('../../services/logService');
 
 class AdminService {
     /**
@@ -157,6 +158,16 @@ class AdminService {
             if (person && person.linked_user_id == null) {
                 await person.update({ linked_user_id: user.id });
             }
+        }
+
+        const peopleService = require('../people/service');
+        try {
+            await peopleService.createSelfPerson(user);
+        } catch (err) {
+            logError(
+                err,
+                'Failed to create self-person for admin-created user'
+            );
         }
 
         return {

--- a/backend/modules/auth/service.js
+++ b/backend/modules/auth/service.js
@@ -11,6 +11,7 @@ const {
     sendVerificationEmail,
     verifyUserEmail,
 } = require('./registrationService');
+const peopleService = require('../people/service');
 const packageJson = require('../../../package.json');
 const {
     ValidationError,
@@ -72,6 +73,12 @@ class AuthService {
             }
 
             await transaction.commit();
+
+            try {
+                await peopleService.createSelfPerson(user);
+            } catch (err) {
+                logError(err, 'Failed to create self-person for new user');
+            }
 
             return {
                 message:

--- a/backend/modules/oidc/provisioningService.js
+++ b/backend/modules/oidc/provisioningService.js
@@ -4,6 +4,8 @@ const { sequelize } = require('../../models');
 const {
     getDefaultNotificationPreferences,
 } = require('../../utils/notificationPreferences');
+const peopleService = require('../people/service');
+const { logError } = require('../../services/logService');
 
 function shouldBeAdmin(config, email) {
     if (!config.adminEmailDomains || config.adminEmailDomains.length === 0) {
@@ -118,6 +120,14 @@ async function provisionUser(providerSlug, claims, req) {
         );
 
         await transaction.commit();
+
+        if (isNewUser) {
+            try {
+                await peopleService.createSelfPerson(user);
+            } catch (err) {
+                logError(err, 'Failed to create self-person for new OIDC user');
+            }
+        }
 
         return { user, isNewUser };
     } catch (error) {

--- a/backend/modules/people/service.js
+++ b/backend/modules/people/service.js
@@ -184,6 +184,32 @@ class PeopleService {
     async unarchive(userId, uid) {
         return this.update(userId, uid, { archived: false });
     }
+
+    async createSelfPerson(user) {
+        const existing = await peopleRepository.findByLinkedUserId(
+            user.id,
+            user.id
+        );
+        if (existing) return existing;
+
+        const nameParts = [user.name, user.surname].filter(Boolean);
+        let name =
+            nameParts.length > 0
+                ? nameParts.join(' ').trim()
+                : user.email.split('@')[0];
+
+        const nameConflict = await peopleRepository.nameExists(user.id, name);
+        if (nameConflict) name = `${name} (me)`;
+
+        return peopleRepository.create({
+            user_id: user.id,
+            linked_user_id: user.id,
+            name,
+            email: user.email || null,
+            relationship_type: 'other',
+            archived: false,
+        });
+    }
 }
 
 module.exports = new PeopleService();


### PR DESCRIPTION
## Description

When a user account is created via OIDC signup, standard registration, or the admin panel, they were missing a \"self-person\" entry in the People system. This meant OIDC-created users would not appear in the task assignment dropdown (which lists People records, not Users directly).

The root cause: migration `20260720000001-add-linked-user-to-people.js` added the `linked_user_id` field and backfilled self-persons for all existing users, but no code was added to create the self-person for users created after the migration.

**Changes:**
- `people/service.js`: Added `createSelfPerson(user)` method that creates a self-person (where `user_id = linked_user_id = user.id`), handling name conflicts gracefully
- `oidc/provisioningService.js`: Calls `createSelfPerson` after committing the transaction when a new OIDC user is provisioned
- `auth/service.js`: Calls `createSelfPerson` after registration transaction commits
- `admin/service.js`: Calls `createSelfPerson` when an admin creates a new user
- New migration `20260722000002-backfill-missing-self-persons.js`: Backfills self-persons for any users created after the initial migration who are still missing them

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1299

## Testing

- All 1600 existing tests pass
- Run `npm run lint:fix` - no errors
- Manual flow: create a new user via OIDC → user now has a self-person → user appears in task assignment dropdown

## Checklist

- [x] Code follows project conventions
- [x] Tests pass
- [x] No JSDoc comments added
- [x] Migration included for data backfill