### PR TITLE
fix(security): allow OIDC users to set an initial password

### DIFF
--- a/backend/modules/users/service.js
+++ b/backend/modules/users/service.js
@@ -192,19 +192,27 @@ class UsersService {
         if (keyboard_shortcuts !== undefined)
             allowedUpdates.keyboard_shortcuts = keyboard_shortcuts;
 
-        // Handle password change if provided
-        if (currentPassword && newPassword) {
+        // Handle password change/set if provided
+        if (newPassword) {
             validatePassword(newPassword, 'newPassword');
 
-            const isValidPassword = await User.checkPassword(
-                currentPassword,
-                user.password_digest
-            );
-            if (!isValidPassword) {
-                throw new ValidationError(
-                    'Current password is incorrect',
-                    'currentPassword'
+            if (user.password_digest) {
+                if (!currentPassword) {
+                    throw new ValidationError(
+                        'Current password is required',
+                        'currentPassword'
+                    );
+                }
+                const isValidPassword = await User.checkPassword(
+                    currentPassword,
+                    user.password_digest
                 );
+                if (!isValidPassword) {
+                    throw new ValidationError(
+                        'Current password is incorrect',
+                        'currentPassword'
+                    );
+                }
             }
 
             const hashedNewPassword = await User.hashPassword(newPassword);
@@ -286,10 +294,8 @@ class UsersService {
      * Change password.
      */
     async changePassword(userId, currentPassword, newPassword) {
-        if (!currentPassword || !newPassword) {
-            throw new ValidationError(
-                'Current password and new password are required'
-            );
+        if (!newPassword) {
+            throw new ValidationError('New password is required');
         }
 
         validatePassword(newPassword, 'newPassword');
@@ -299,15 +305,23 @@ class UsersService {
             throw new NotFoundError('User not found');
         }
 
-        const isValidPassword = await User.checkPassword(
-            currentPassword,
-            user.password_digest
-        );
-        if (!isValidPassword) {
-            throw new ValidationError(
-                'Current password is incorrect',
-                'currentPassword'
+        if (user.password_digest) {
+            if (!currentPassword) {
+                throw new ValidationError(
+                    'Current password is required',
+                    'currentPassword'
+                );
+            }
+            const isValidPassword = await User.checkPassword(
+                currentPassword,
+                user.password_digest
             );
+            if (!isValidPassword) {
+                throw new ValidationError(
+                    'Current password is incorrect',
+                    'currentPassword'
+                );
+            }
         }
 
         const hashedNewPassword = await User.hashPassword(newPassword);

--- a/frontend/components/Profile/ProfileSettings.tsx
+++ b/frontend/components/Profile/ProfileSettings.tsx
@@ -256,13 +256,14 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
         errors: { [key: string]: string };
     } => {
         const errors: { [key: string]: string } = {};
+        const hasPassword = profile?.has_password ?? false;
 
         if (
             formData.currentPassword ||
             formData.newPassword ||
             formData.confirmPassword
         ) {
-            if (!formData.currentPassword) {
+            if (hasPassword && !formData.currentPassword) {
                 errors.currentPassword = t(
                     'profile.currentPasswordRequired',
                     'Current password is required'
@@ -986,10 +987,12 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
     const handleSubmit = async (e: FormEvent) => {
         e.preventDefault();
 
-        const isPasswordChange =
-            formData.currentPassword ||
-            formData.newPassword ||
-            formData.confirmPassword;
+        const hasPassword = profile?.has_password ?? false;
+        const isPasswordChange = hasPassword
+            ? formData.currentPassword ||
+              formData.newPassword ||
+              formData.confirmPassword
+            : formData.newPassword || formData.confirmPassword;
 
         if (isPasswordChange) {
             const passwordValidation = validatePasswordForm();
@@ -1301,6 +1304,7 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
 
                                 <SecurityTab
                                     isActive={activeTab === 'security'}
+                                    hasPassword={profile?.has_password ?? false}
                                     formData={formData}
                                     showCurrentPassword={showCurrentPassword}
                                     showNewPassword={showNewPassword}

--- a/frontend/components/Profile/tabs/SecurityTab.tsx
+++ b/frontend/components/Profile/tabs/SecurityTab.tsx
@@ -11,6 +11,7 @@ import type { ProfileFormData } from '../types';
 
 interface SecurityTabProps {
     isActive: boolean;
+    hasPassword: boolean;
     formData: ProfileFormData;
     showCurrentPassword: boolean;
     showNewPassword: boolean;
@@ -23,6 +24,7 @@ interface SecurityTabProps {
 
 const SecurityTab: React.FC<SecurityTabProps> = ({
     isActive,
+    hasPassword,
     formData,
     showCurrentPassword,
     showNewPassword,
@@ -46,49 +48,63 @@ const SecurityTab: React.FC<SecurityTabProps> = ({
             <div className="p-4 bg-gray-50 dark:bg-gray-900 rounded-lg">
                 <h4 className="text-lg font-medium text-gray-900 dark:text-white mb-3 flex items-center">
                     <UserIcon className="w-5 h-5 mr-2 text-blue-500" />
-                    {t('profile.changePassword', 'Change Password')}
+                    {hasPassword
+                        ? t('profile.changePassword', 'Change Password')
+                        : t('profile.setPassword', 'Set Password')}
                 </h4>
 
                 <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-900 border border-blue-200 dark:border-blue-800 rounded text-blue-800 dark:text-blue-200">
                     <p className="text-sm">
                         <InformationCircleIcon className="w-4 h-4 inline mr-1" />
-                        {t(
-                            'profile.passwordChangeOptional',
-                            'Leave password fields empty to update other settings without changing your password.'
-                        )}
+                        {hasPassword
+                            ? t(
+                                  'profile.passwordChangeOptional',
+                                  'Leave password fields empty to update other settings without changing your password.'
+                              )
+                            : t(
+                                  'profile.setPasswordInfo',
+                                  'You have not set a password yet. Setting one lets you sign in directly and use CalDAV.'
+                              )}
                     </p>
                 </div>
 
                 <div className="space-y-4">
-                    <div>
-                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                            {t('profile.currentPassword', 'Current Password')}
-                        </label>
-                        <div className="relative">
-                            <input
-                                type={showCurrentPassword ? 'text' : 'password'}
-                                name="currentPassword"
-                                value={formData.currentPassword || ''}
-                                onChange={onChange}
-                                className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm px-3 py-2 pr-10 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                                placeholder={t(
-                                    'profile.enterCurrentPassword',
-                                    'Enter your current password'
+                    {hasPassword && (
+                        <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                                {t(
+                                    'profile.currentPassword',
+                                    'Current Password'
                                 )}
-                            />
-                            <button
-                                type="button"
-                                className="absolute inset-y-0 right-0 pr-3 flex items-center"
-                                onClick={onToggleCurrentPassword}
-                            >
-                                {showCurrentPassword ? (
-                                    <EyeSlashIcon className="h-5 w-5 text-gray-400" />
-                                ) : (
-                                    <EyeIcon className="h-5 w-5 text-gray-400" />
-                                )}
-                            </button>
+                            </label>
+                            <div className="relative">
+                                <input
+                                    type={
+                                        showCurrentPassword ? 'text' : 'password'
+                                    }
+                                    name="currentPassword"
+                                    value={formData.currentPassword || ''}
+                                    onChange={onChange}
+                                    className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm px-3 py-2 pr-10 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                                    placeholder={t(
+                                        'profile.enterCurrentPassword',
+                                        'Enter your current password'
+                                    )}
+                                />
+                                <button
+                                    type="button"
+                                    className="absolute inset-y-0 right-0 pr-3 flex items-center"
+                                    onClick={onToggleCurrentPassword}
+                                >
+                                    {showCurrentPassword ? (
+                                        <EyeSlashIcon className="h-5 w-5 text-gray-400" />
+                                    ) : (
+                                        <EyeIcon className="h-5 w-5 text-gray-400" />
+                                    )}
+                                </button>
+                            </div>
                         </div>
-                    </div>
+                    )}
 
                     <div>
                         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">


### PR DESCRIPTION
## Description

OIDC-only users had no way to set an initial password through the UI. The Security tab showed a "Change Password" form that required the current password, but OIDC users have never had one — making `bcrypt.compare(..., null)` always fail.

This is a problem because:
- CalDAV connections require HTTP Basic Auth against `password_digest`
- The OIDC tab already warns users they have no password and suggests setting one

## Changes

**Backend (`backend/modules/users/service.js`)**
- `updateProfile()`: When `password_digest` is null, allow setting a new password with only `newPassword` (no `currentPassword` verification)
- `changePassword()`: Same — skip current-password check when `password_digest` is null; still require it when the user already has one

**Frontend (`frontend/components/Profile/tabs/SecurityTab.tsx`)**
- Accept a new `hasPassword` prop
- When `hasPassword` is false, show "Set Password" heading and informational banner; hide the "Current Password" field entirely

**Frontend (`frontend/components/Profile/ProfileSettings.tsx`)**
- Pass `hasPassword={profile?.has_password ?? false}` to `SecurityTab`
- `validatePasswordForm()`: skip `currentPassword` required-check when user has no password
- `handleSubmit()`: detect password change correctly for no-password users (check `newPassword` only, not `currentPassword`)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1137

## Testing

1. Log in as an OIDC-only user (no `password_digest`)
2. Go to Profile → Security
3. The form should show "Set Password" with no "Current Password" field
4. Enter and confirm a new password, click Save Changes — should succeed
5. Log out and verify you can now sign in with email + password
6. Log back in, go to Security — should show "Change Password" with the current password field

Existing users with a password are unaffected: the current-password check still runs whenever `password_digest` is non-null.

## Checklist

- [x] My code follows the project's coding style
- [x] I have run `npm run lint:fix` and resolved all issues
- [x] I have tested this change manually
- [x] No new JSDoc comments added