### PR TITLE
fix(security): update npm dependencies to address Dependabot alerts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tududi",
-  "version": "v1.3.0-rc.3",
+  "version": "v1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tududi",
-      "version": "v1.3.0-rc.3",
+      "version": "v1.3.0",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.106.0",
@@ -119,7 +119,7 @@
         "typescript-eslint": "^8.36.0",
         "webpack": "^5.95.0",
         "webpack-cli": "^5.1.4",
-        "webpack-dev-server": "^5.2.5",
+        "webpack-dev-server": "^5.2.6",
         "zustand": "^5.0.3"
       }
     },
@@ -9895,9 +9895,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -10838,9 +10838,9 @@
       "peer": true
     },
     "node_modules/hono": {
-      "version": "4.12.26",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -19097,9 +19097,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20374,9 +20374,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.21",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.21.tgz",
+      "integrity": "sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -21802,9 +21802,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.5.tgz",
-      "integrity": "sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21826,7 +21826,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "typescript-eslint": "^8.36.0",
     "webpack": "^5.95.0",
     "webpack-cli": "^5.1.4",
-    "webpack-dev-server": "^5.2.5",
+    "webpack-dev-server": "^5.2.6",
     "zustand": "^5.0.3"
   },
   "dependencies": {
@@ -180,17 +180,17 @@
     "xml2js": "^0.6.0"
   },
   "overrides": {
-    "tar": "^7.5.16",
-    "hono": "^4.12.25",
+    "tar": "^7.5.19",
+    "hono": "^4.12.27",
     "http-proxy-middleware": "^3.0.6",
     "form-data": "^4.0.6",
     "launch-editor": "^2.14.1",
-    "shell-quote": "^1.8.4",
+    "shell-quote": "^1.10.0",
     "ws": "^8.21.0",
     "qs": "^6.15.2",
     "js-cookie": "^3.0.8",
     "ip-address": "^10.2.0",
-    "fast-uri": "^3.1.2"
+    "fast-uri": "^3.1.4"
   },
   "lint-staged": {
     "frontend/**/*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
## Description

Updates npm dependencies to address 8 Dependabot security alerts. Reduces open alerts from 19 to 11 (the remaining require major version upgrades or have architectural blockers).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1323
Addresses: https://github.com/chrisvel/tududi/security/dependabot

## Changes

| Package | Before | After | Severity | CVE |
|---|---|---|---|---|
| `tar` (override) | `^7.5.16` | `^7.5.19` | CRITICAL + HIGH | Decompression DoS, infinite loop, crash |
| `hono` (override) | `^4.12.25` | `^4.12.27` | MEDIUM x3 | JSX XSS bypass, header dedup, context leak |
| `shell-quote` (override) | `^1.8.4` | `^1.10.0` | HIGH | Quadratic-complexity DoS in `parse()` |
| `fast-uri` (override) | `^3.1.2` | `^3.1.4` | HIGH x2 | Host confusion via IDN/backslash |
| `webpack-dev-server` (devDep) | `^5.2.5` | `^5.2.6` | MEDIUM x2 | CSRF, DoS via malformed Host/Origin |

## Remaining Unfixed Alerts (11)

| Package | Reason Not Fixed |
|---|---|
| `@hono/node-server` | Windows-only path traversal; MCP SDK (`@modelcontextprotocol/sdk`) still requires `^1.19.x` |
| `react-router` / `react-router-dom` | Fix requires major upgrade 6→7 (breaking API changes) |
| `uuid` | Fix requires major upgrade 8→11 (breaks `sequelize@6` which expects v8 API) |
| `js-yaml` | 3.x → 4.x removes `safeLoad` API used by `@istanbuljs/load-nyc-config` in test toolchain |
| `body-parser` | LOW severity; express@4 and express@5 require incompatible 1.x/2.x ranges |
| `brace-expansion` | 5.x changed from function default export to named exports, breaking `minimatch@3.x` used by eslint |

## Testing

```
npm install
npm run lint
npm run backend:test
```

- Lint: passes (0 errors)
- Backend tests: 1604 total, pre-existing flaky integration test failures unrelated to these changes

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have tested the changes locally
- [x] No new warnings were introduced