### PR TITLE
fix(telegram): batch due/deferred notifications into one message per user

### DIFF
--- a/backend/modules/projects/dueProjectService.js
+++ b/backend/modules/projects/dueProjectService.js
@@ -5,6 +5,7 @@ const {
     shouldSendInAppNotification,
     shouldSendTelegramNotification,
 } = require('../../utils/notificationPreferences');
+const telegramPoller = require('../telegram/telegramPoller');
 
 async function checkDueProjects() {
     try {
@@ -30,6 +31,8 @@ async function checkDueProjects() {
                         'email',
                         'name',
                         'notification_preferences',
+                        'telegram_bot_token',
+                        'telegram_chat_id',
                     ],
                 },
             ],
@@ -60,95 +63,127 @@ async function checkDueProjects() {
             notificationsByUser[notif.user_id].push(notif);
         }
 
+        // Group projects by user
+        const projectsByUser = {};
+        for (const project of dueProjects) {
+            if (!projectsByUser[project.user_id]) {
+                projectsByUser[project.user_id] = {
+                    user: project.User,
+                    projects: [],
+                };
+            }
+            projectsByUser[project.user_id].projects.push(project);
+        }
+
         let notificationsCreated = 0;
 
-        for (const project of dueProjects) {
-            try {
-                const dueDate = new Date(project.due_date_at);
-                const isOverdue = dueDate < now;
-                const notificationType = isOverdue
-                    ? 'project_overdue'
-                    : 'project_due_soon';
-                const level = isOverdue ? 'error' : 'warning';
+        for (const [userId, { user, projects }] of Object.entries(
+            projectsByUser
+        )) {
+            const wantsTelegram =
+                user.telegram_bot_token &&
+                user.telegram_chat_id &&
+                (shouldSendTelegramNotification(user, 'project_due_soon') ||
+                    shouldSendTelegramNotification(user, 'project_overdue'));
 
-                // Check if user wants this notification
-                if (
-                    !shouldSendInAppNotification(project.User, notificationType)
-                ) {
-                    continue;
-                }
+            const dueSoonForTelegram = [];
+            const overdueForTelegram = [];
 
-                const recentNotifications =
-                    notificationsByUser[project.user_id] || [];
+            for (const project of projects) {
+                try {
+                    const dueDate = new Date(project.due_date_at);
+                    const isOverdue = dueDate < now;
+                    const notificationType = isOverdue
+                        ? 'project_overdue'
+                        : 'project_due_soon';
+                    const level = isOverdue ? 'error' : 'warning';
 
-                const existingNotification = recentNotifications.find(
-                    (notif) =>
-                        notif.data?.projectUid === project.uid &&
-                        notif.type === notificationType
-                );
-
-                // Preserve channel_sent_at for rate limiting when recreating notifications
-                let preservedChannelSentAt = null;
-
-                if (existingNotification) {
-                    // If notification was dismissed, don't create it again
-                    if (existingNotification.dismissed_at) {
+                    if (!shouldSendInAppNotification(user, notificationType)) {
                         continue;
                     }
 
-                    // If notification is unread, delete it before creating the new one
-                    // This prevents duplicate notifications from piling up
-                    if (!existingNotification.read_at) {
-                        // Preserve channel_sent_at to maintain rate limiting across recreations
-                        preservedChannelSentAt =
-                            existingNotification.channel_sent_at;
-                        await existingNotification.destroy();
-                    } else {
-                        // If it was already read, skip creating a new one
-                        continue;
+                    const recentNotifications =
+                        notificationsByUser[project.user_id] || [];
+
+                    const existingNotification = recentNotifications.find(
+                        (notif) =>
+                            notif.data?.projectUid === project.uid &&
+                            notif.type === notificationType
+                    );
+
+                    let preservedChannelSentAt = null;
+                    let alreadySentViaTelegram = false;
+
+                    if (existingNotification) {
+                        if (existingNotification.dismissed_at) {
+                            continue;
+                        }
+
+                        if (!existingNotification.read_at) {
+                            preservedChannelSentAt =
+                                existingNotification.channel_sent_at;
+                            alreadySentViaTelegram =
+                                existingNotification.wasChannelRecentlySent(
+                                    'telegram',
+                                    24 * 60 * 60 * 1000
+                                );
+                            await existingNotification.destroy();
+                        } else {
+                            continue;
+                        }
                     }
+
+                    const { title, message } = generateNotificationContent(
+                        project.name,
+                        dueDate,
+                        now,
+                        isOverdue
+                    );
+
+                    const notification = await Notification.createNotification({
+                        userId: project.user_id,
+                        type: notificationType,
+                        title,
+                        message,
+                        level,
+                        sources: [],
+                        data: {
+                            projectUid: project.uid,
+                            projectName: project.name,
+                            dueDate: project.due_date_at,
+                            isOverdue,
+                        },
+                        sentAt: new Date(),
+                        channel_sent_at: preservedChannelSentAt,
+                    });
+
+                    notificationsCreated++;
+
+                    if (wantsTelegram && !alreadySentViaTelegram) {
+                        if (isOverdue) {
+                            overdueForTelegram.push({
+                                project,
+                                dueDate,
+                                notification,
+                            });
+                        } else {
+                            dueSoonForTelegram.push({ project, notification });
+                        }
+                    }
+                } catch (error) {
+                    logError(
+                        `Error creating notification for project ${project.id}:`,
+                        error
+                    );
                 }
+            }
 
-                const { title, message } = generateNotificationContent(
-                    project.name,
-                    dueDate,
-                    now,
-                    isOverdue
-                );
-
-                // Build sources array based on user preferences
-                const sources = [];
-                if (
-                    shouldSendTelegramNotification(
-                        project.User,
-                        notificationType
-                    )
-                ) {
-                    sources.push('telegram');
-                }
-
-                await Notification.createNotification({
-                    userId: project.user_id,
-                    type: notificationType,
-                    title,
-                    message,
-                    level,
-                    sources,
-                    data: {
-                        projectUid: project.uid,
-                        projectName: project.name,
-                        dueDate: project.due_date_at,
-                        isOverdue,
-                    },
-                    sentAt: new Date(),
-                    channel_sent_at: preservedChannelSentAt,
-                });
-
-                notificationsCreated++;
-            } catch (error) {
-                logError(
-                    `Error creating notification for project ${project.id}:`,
-                    error
+            if (wantsTelegram) {
+                await sendBatchedProjectTelegramMessage(
+                    user,
+                    dueSoonForTelegram,
+                    overdueForTelegram,
+                    now
                 );
             }
         }
@@ -161,6 +196,60 @@ async function checkDueProjects() {
     } catch (error) {
         logError('Error checking due projects:', error);
         throw error;
+    }
+}
+
+async function sendBatchedProjectTelegramMessage(
+    user,
+    dueSoonItems,
+    overdueItems,
+    now
+) {
+    try {
+        const parts = [];
+
+        if (overdueItems.length > 0) {
+            parts.push('🔴 Overdue Projects:');
+            for (const { project, dueDate } of overdueItems) {
+                const daysOverdue = Math.floor(
+                    (now - dueDate) / (1000 * 60 * 60 * 24)
+                );
+                const age =
+                    daysOverdue === 0
+                        ? 'due today'
+                        : daysOverdue === 1
+                          ? 'due yesterday'
+                          : `due ${daysOverdue} days ago`;
+                parts.push(`• ${project.name} (${age})`);
+            }
+        }
+
+        if (dueSoonItems.length > 0) {
+            if (parts.length > 0) parts.push('');
+            parts.push('⚠️ Projects Due Soon:');
+            for (const { project } of dueSoonItems) {
+                parts.push(`• ${project.name}`);
+            }
+        }
+
+        if (parts.length === 0) return;
+
+        const message = parts.join('\n');
+        await telegramPoller.sendTelegramMessage(
+            user.telegram_bot_token,
+            user.telegram_chat_id,
+            message
+        );
+
+        const allNotifications = [
+            ...overdueItems.map((i) => i.notification),
+            ...dueSoonItems.map((i) => i.notification),
+        ];
+        for (const notification of allNotifications) {
+            await notification.markChannelAsSent('telegram');
+        }
+    } catch (error) {
+        logError('Error sending batched Telegram project message:', error);
     }
 }
 

--- a/backend/modules/tasks/deferredTaskService.js
+++ b/backend/modules/tasks/deferredTaskService.js
@@ -5,6 +5,7 @@ const {
     shouldSendInAppNotification,
     shouldSendTelegramNotification,
 } = require('../../utils/notificationPreferences');
+const telegramPoller = require('../telegram/telegramPoller');
 
 async function checkDeferredTasks() {
     try {
@@ -29,6 +30,8 @@ async function checkDeferredTasks() {
                         'email',
                         'name',
                         'notification_preferences',
+                        'telegram_bot_token',
+                        'telegram_chat_id',
                     ],
                 },
             ],
@@ -62,69 +65,93 @@ async function checkDeferredTasks() {
             notificationsByUser[notif.user_id].push(notif);
         }
 
+        // Group tasks by user
+        const tasksByUser = {};
         for (const task of deferredTasks) {
-            try {
-                if (!shouldSendInAppNotification(task.User, 'deferUntil')) {
-                    continue;
-                }
+            if (!tasksByUser[task.user_id]) {
+                tasksByUser[task.user_id] = { user: task.User, tasks: [] };
+            }
+            tasksByUser[task.user_id].tasks.push(task);
+        }
 
-                const recentNotifications =
-                    notificationsByUser[task.user_id] || [];
+        for (const [userId, { user, tasks }] of Object.entries(tasksByUser)) {
+            const wantsTelegram =
+                user.telegram_bot_token &&
+                user.telegram_chat_id &&
+                shouldSendTelegramNotification(user, 'deferUntil');
 
-                const existingNotification = recentNotifications.find(
-                    (notif) =>
-                        notif.data?.taskUid === task.uid &&
-                        notif.data?.reason === 'defer_until_reached'
-                );
+            const activatedForTelegram = [];
 
-                // Preserve channel_sent_at for rate limiting when recreating notifications
-                let preservedChannelSentAt = null;
-
-                if (existingNotification) {
-                    // If notification was dismissed, don't create it again
-                    if (existingNotification.dismissed_at) {
+            for (const task of tasks) {
+                try {
+                    if (!shouldSendInAppNotification(user, 'deferUntil')) {
                         continue;
                     }
 
-                    // If notification is unread, delete it before creating the new one
-                    // This prevents duplicate notifications from piling up
-                    if (!existingNotification.read_at) {
-                        // Preserve channel_sent_at to maintain rate limiting across recreations
-                        preservedChannelSentAt =
-                            existingNotification.channel_sent_at;
-                        await existingNotification.destroy();
-                    } else {
-                        // If it was already read, skip creating a new one
-                        continue;
+                    const recentNotifications =
+                        notificationsByUser[task.user_id] || [];
+
+                    const existingNotification = recentNotifications.find(
+                        (notif) =>
+                            notif.data?.taskUid === task.uid &&
+                            notif.data?.reason === 'defer_until_reached'
+                    );
+
+                    let preservedChannelSentAt = null;
+                    let alreadySentViaTelegram = false;
+
+                    if (existingNotification) {
+                        if (existingNotification.dismissed_at) {
+                            continue;
+                        }
+
+                        if (!existingNotification.read_at) {
+                            preservedChannelSentAt =
+                                existingNotification.channel_sent_at;
+                            alreadySentViaTelegram =
+                                existingNotification.wasChannelRecentlySent(
+                                    'telegram',
+                                    24 * 60 * 60 * 1000
+                                );
+                            await existingNotification.destroy();
+                        } else {
+                            continue;
+                        }
                     }
+
+                    const notification = await Notification.createNotification({
+                        userId: task.user_id,
+                        type: 'task_due_soon',
+                        title: 'Task is now active',
+                        message: `Your task "${task.name}" is now available to work on`,
+                        sources: [],
+                        data: {
+                            taskUid: task.uid,
+                            taskName: task.name,
+                            deferUntil: task.defer_until,
+                            reason: 'defer_until_reached',
+                        },
+                        sentAt: new Date(),
+                        channel_sent_at: preservedChannelSentAt,
+                    });
+
+                    notificationsCreated++;
+
+                    if (wantsTelegram && !alreadySentViaTelegram) {
+                        activatedForTelegram.push({ task, notification });
+                    }
+                } catch (error) {
+                    logError(
+                        `Error creating notification for task ${task.id}:`,
+                        error
+                    );
                 }
+            }
 
-                const sources = [];
-                if (shouldSendTelegramNotification(task.User, 'deferUntil')) {
-                    sources.push('telegram');
-                }
-
-                await Notification.createNotification({
-                    userId: task.user_id,
-                    type: 'task_due_soon',
-                    title: 'Task is now active',
-                    message: `Your task "${task.name}" is now available to work on`,
-                    sources,
-                    data: {
-                        taskUid: task.uid,
-                        taskName: task.name,
-                        deferUntil: task.defer_until,
-                        reason: 'defer_until_reached',
-                    },
-                    sentAt: new Date(),
-                    channel_sent_at: preservedChannelSentAt,
-                });
-
-                notificationsCreated++;
-            } catch (error) {
-                logError(
-                    `Error creating notification for task ${task.id}:`,
-                    error
+            if (wantsTelegram && activatedForTelegram.length > 0) {
+                await sendBatchedDeferredTelegramMessage(
+                    user,
+                    activatedForTelegram
                 );
             }
         }
@@ -137,6 +164,31 @@ async function checkDeferredTasks() {
     } catch (error) {
         logError('Error checking deferred tasks:', error);
         throw error;
+    }
+}
+
+async function sendBatchedDeferredTelegramMessage(user, items) {
+    try {
+        const lines = ['✅ Tasks Now Active:'];
+        for (const { task } of items) {
+            lines.push(`• ${task.name}`);
+        }
+
+        const message = lines.join('\n');
+        await telegramPoller.sendTelegramMessage(
+            user.telegram_bot_token,
+            user.telegram_chat_id,
+            message
+        );
+
+        for (const { notification } of items) {
+            await notification.markChannelAsSent('telegram');
+        }
+    } catch (error) {
+        logError(
+            'Error sending batched Telegram deferred task message:',
+            error
+        );
     }
 }
 

--- a/backend/modules/tasks/dueTaskService.js
+++ b/backend/modules/tasks/dueTaskService.js
@@ -5,6 +5,7 @@ const {
     shouldSendInAppNotification,
     shouldSendTelegramNotification,
 } = require('../../utils/notificationPreferences');
+const telegramPoller = require('../telegram/telegramPoller');
 
 async function checkDueTasks() {
     try {
@@ -30,6 +31,8 @@ async function checkDueTasks() {
                         'email',
                         'name',
                         'notification_preferences',
+                        'telegram_bot_token',
+                        'telegram_chat_id',
                     ],
                 },
             ],
@@ -60,90 +63,123 @@ async function checkDueTasks() {
             notificationsByUser[notif.user_id].push(notif);
         }
 
+        // Group tasks by user
+        const tasksByUser = {};
+        for (const task of dueTasks) {
+            if (!tasksByUser[task.user_id]) {
+                tasksByUser[task.user_id] = { user: task.User, tasks: [] };
+            }
+            tasksByUser[task.user_id].tasks.push(task);
+        }
+
         let notificationsCreated = 0;
 
-        for (const task of dueTasks) {
-            try {
-                const dueDate = new Date(task.due_date);
-                const isOverdue = dueDate < now;
-                const notificationType = isOverdue
-                    ? 'task_overdue'
-                    : 'task_due_soon';
-                const level = isOverdue ? 'error' : 'warning';
+        for (const [userId, { user, tasks }] of Object.entries(tasksByUser)) {
+            const wantsTelegram =
+                user.telegram_bot_token &&
+                user.telegram_chat_id &&
+                (shouldSendTelegramNotification(user, 'task_due_soon') ||
+                    shouldSendTelegramNotification(user, 'task_overdue'));
 
-                // Check if user wants this notification
-                if (!shouldSendInAppNotification(task.User, notificationType)) {
-                    continue;
-                }
+            const dueSoonForTelegram = [];
+            const overdueForTelegram = [];
 
-                const recentNotifications =
-                    notificationsByUser[task.user_id] || [];
+            for (const task of tasks) {
+                try {
+                    const dueDate = new Date(task.due_date);
+                    const isOverdue = dueDate < now;
+                    const notificationType = isOverdue
+                        ? 'task_overdue'
+                        : 'task_due_soon';
+                    const level = isOverdue ? 'error' : 'warning';
 
-                const existingNotification = recentNotifications.find(
-                    (notif) =>
-                        notif.data?.taskUid === task.uid &&
-                        notif.type === notificationType
-                );
-
-                // Preserve channel_sent_at for rate limiting when recreating notifications
-                let preservedChannelSentAt = null;
-
-                if (existingNotification) {
-                    // If notification was dismissed, don't create it again
-                    if (existingNotification.dismissed_at) {
+                    if (!shouldSendInAppNotification(user, notificationType)) {
                         continue;
                     }
 
-                    // If notification is unread, delete it before creating the new one
-                    // This prevents duplicate notifications from piling up
-                    if (!existingNotification.read_at) {
-                        // Preserve channel_sent_at to maintain rate limiting across recreations
-                        preservedChannelSentAt =
-                            existingNotification.channel_sent_at;
-                        await existingNotification.destroy();
-                    } else {
-                        // If it was already read, skip creating a new one
-                        continue;
+                    const recentNotifications =
+                        notificationsByUser[task.user_id] || [];
+
+                    const existingNotification = recentNotifications.find(
+                        (notif) =>
+                            notif.data?.taskUid === task.uid &&
+                            notif.type === notificationType
+                    );
+
+                    let preservedChannelSentAt = null;
+                    let alreadySentViaTelegram = false;
+
+                    if (existingNotification) {
+                        if (existingNotification.dismissed_at) {
+                            continue;
+                        }
+
+                        if (!existingNotification.read_at) {
+                            preservedChannelSentAt =
+                                existingNotification.channel_sent_at;
+                            alreadySentViaTelegram =
+                                existingNotification.wasChannelRecentlySent(
+                                    'telegram',
+                                    24 * 60 * 60 * 1000
+                                );
+                            await existingNotification.destroy();
+                        } else {
+                            continue;
+                        }
                     }
+
+                    const { title, message } = generateNotificationContent(
+                        task.name,
+                        dueDate,
+                        now,
+                        isOverdue
+                    );
+
+                    const notification = await Notification.createNotification({
+                        userId: task.user_id,
+                        type: notificationType,
+                        title,
+                        message,
+                        level,
+                        sources: [],
+                        data: {
+                            taskUid: task.uid,
+                            taskName: task.name,
+                            dueDate: task.due_date,
+                            isOverdue,
+                        },
+                        sentAt: new Date(),
+                        channel_sent_at: preservedChannelSentAt,
+                    });
+
+                    notificationsCreated++;
+
+                    if (wantsTelegram && !alreadySentViaTelegram) {
+                        if (isOverdue) {
+                            overdueForTelegram.push({
+                                task,
+                                dueDate,
+                                notification,
+                            });
+                        } else {
+                            dueSoonForTelegram.push({ task, notification });
+                        }
+                    }
+                } catch (error) {
+                    logError(
+                        `Error creating notification for task ${task.id}:`,
+                        error
+                    );
                 }
+            }
 
-                const { title, message } = generateNotificationContent(
-                    task.name,
-                    dueDate,
-                    now,
-                    isOverdue
-                );
-
-                // Build sources array based on user preferences
-                const sources = [];
-                if (
-                    shouldSendTelegramNotification(task.User, notificationType)
-                ) {
-                    sources.push('telegram');
-                }
-
-                await Notification.createNotification({
-                    userId: task.user_id,
-                    type: notificationType,
-                    title,
-                    message,
-                    level,
-                    sources,
-                    data: {
-                        taskUid: task.uid,
-                        taskName: task.name,
-                        dueDate: task.due_date,
-                        isOverdue,
-                    },
-                    sentAt: new Date(),
-                    channel_sent_at: preservedChannelSentAt,
-                });
-
-                notificationsCreated++;
-            } catch (error) {
-                logError(
-                    `Error creating notification for task ${task.id}:`,
-                    error
+            // Send one batched Telegram message per type per user
+            if (wantsTelegram) {
+                await sendBatchedTaskTelegramMessage(
+                    user,
+                    dueSoonForTelegram,
+                    overdueForTelegram,
+                    now
                 );
             }
         }
@@ -156,6 +192,60 @@ async function checkDueTasks() {
     } catch (error) {
         logError('Error checking due tasks:', error);
         throw error;
+    }
+}
+
+async function sendBatchedTaskTelegramMessage(
+    user,
+    dueSoonItems,
+    overdueItems,
+    now
+) {
+    try {
+        const parts = [];
+
+        if (overdueItems.length > 0) {
+            parts.push('🔴 Overdue Tasks:');
+            for (const { task, dueDate } of overdueItems) {
+                const daysOverdue = Math.floor(
+                    (now - dueDate) / (1000 * 60 * 60 * 24)
+                );
+                const age =
+                    daysOverdue === 0
+                        ? 'due today'
+                        : daysOverdue === 1
+                          ? 'due yesterday'
+                          : `due ${daysOverdue} days ago`;
+                parts.push(`• ${task.name} (${age})`);
+            }
+        }
+
+        if (dueSoonItems.length > 0) {
+            if (parts.length > 0) parts.push('');
+            parts.push('⚠️ Tasks Due Soon:');
+            for (const { task } of dueSoonItems) {
+                parts.push(`• ${task.name}`);
+            }
+        }
+
+        if (parts.length === 0) return;
+
+        const message = parts.join('\n');
+        await telegramPoller.sendTelegramMessage(
+            user.telegram_bot_token,
+            user.telegram_chat_id,
+            message
+        );
+
+        const allNotifications = [
+            ...overdueItems.map((i) => i.notification),
+            ...dueSoonItems.map((i) => i.notification),
+        ];
+        for (const notification of allNotifications) {
+            await notification.markChannelAsSent('telegram');
+        }
+    } catch (error) {
+        logError('Error sending batched Telegram task message:', error);
     }
 }
 

--- a/backend/modules/tasks/taskSummaryService.js
+++ b/backend/modules/tasks/taskSummaryService.js
@@ -294,31 +294,17 @@ const sendSummaryToUser = async (userId) => {
         const summary = await generateSummaryForUser(userId);
         if (!summary) return false;
 
-        // Send the message via Telegram with MarkdownV2 formatting
-        // If MarkdownV2 parsing fails (e.g. unescaped characters), retry as plain text
-        try {
-            await sendTelegramMessage(
-                user.telegram_bot_token,
-                user.telegram_chat_id,
-                summary,
-                null,
-                { parseMode: 'MarkdownV2' }
-            );
-        } catch (markdownError) {
-            console.warn(
-                `MarkdownV2 send failed for user ${userId}, retrying as plain text:`,
-                markdownError.message
-            );
-            const plainSummary = summary.replace(
-                /\\([_*\[\]()~`>#+\-=|{}.!\\])/g,
-                '$1'
-            );
-            await sendTelegramMessage(
-                user.telegram_bot_token,
-                user.telegram_chat_id,
-                plainSummary
-            );
-        }
+        // Strip MarkdownV2 escape sequences and send as plain text to avoid
+        // double-send if Telegram accepts the message but the HTTP response is lost
+        const plainSummary = summary.replace(
+            /\\([_*\[\]()~`>#+\-=|{}.!\\])/g,
+            '$1'
+        );
+        await sendTelegramMessage(
+            user.telegram_bot_token,
+            user.telegram_chat_id,
+            plainSummary
+        );
 
         // Update tracking fields
         const now = new Date();

--- a/backend/tests/unit/modules/tasks/dueTaskService.test.js
+++ b/backend/tests/unit/modules/tasks/dueTaskService.test.js
@@ -303,18 +303,13 @@ describe('dueTaskService', () => {
         });
 
         describe('Telegram rate limiting', () => {
-            const telegramNotificationService = require('../../../../modules/telegram/telegramNotificationService');
+            const telegramPoller = require('../../../../modules/telegram/telegramPoller');
 
             beforeEach(() => {
-                // Mock Telegram service
                 jest.spyOn(
-                    telegramNotificationService,
-                    'isTelegramConfigured'
-                ).mockReturnValue(true);
-                jest.spyOn(
-                    telegramNotificationService,
-                    'sendTelegramNotification'
-                ).mockResolvedValue({ success: true });
+                    telegramPoller,
+                    'sendTelegramMessage'
+                ).mockResolvedValue({ ok: true });
             });
 
             afterEach(() => {
@@ -343,11 +338,11 @@ describe('dueTaskService', () => {
                 });
 
                 const sendTelegramSpy = jest.spyOn(
-                    telegramNotificationService,
-                    'sendTelegramNotification'
+                    telegramPoller,
+                    'sendTelegramMessage'
                 );
 
-                // First check - should send Telegram
+                // First check - should send one batched Telegram message
                 await checkDueTasks();
 
                 const firstCallCount = sendTelegramSpy.mock.calls.length;


### PR DESCRIPTION
## Description

Fixes a bug where Telegram notifications for due tasks, deferred tasks, and due projects sent one individual message per item. A user with 5 overdue tasks would receive 5 separate Telegram messages. This PR aggregates all items for a given user into a single Telegram message per scheduler cycle, while keeping individual in-app notification records intact.

Also fixes a secondary bug in the daily digest (`taskSummaryService`) where a MarkdownV2 formatting retry could send two messages if the first HTTP response was lost.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1327

## Changes

**`dueTaskService.js`**: Groups tasks by user before the loop. Creates individual in-app notification records without `telegram` in sources, then sends one aggregated Telegram message per user after the loop completes. Rate limiting via `wasChannelRecentlySent` is preserved — tasks already notified within 24h are excluded from the batch message.

**`deferredTaskService.js`**: Same batching pattern for deferred/activated tasks.

**`dueProjectService.js`**: Same batching pattern for due/overdue projects.

**`taskSummaryService.js`**: Removed the MarkdownV2 try/catch retry. The summary is now stripped of escape sequences and sent as plain text in a single call, eliminating the double-send risk.

**`dueTaskService.test.js`**: Updated Telegram rate-limiting test to spy on `telegramPoller.sendTelegramMessage` (the new send path) instead of the old `telegramNotificationService.sendTelegramNotification`.

## Message Format

Due/overdue batch messages look like:
```
🔴 Overdue Tasks:
• Task A (due 2 days ago)
• Task B (due yesterday)

⚠️ Tasks Due Soon:
• Task C
• Task D
```

## Testing

- `npm test -- --testPathPattern="dueTaskService|deferredTaskService|notification-telegram|telegram-duplicate"` — all pass
- `npm run lint:fix` — no errors

## Checklist

- [x] Code follows project conventions
- [x] Tests updated for changed behavior
- [x] Lint passes with no errors
- [x] No new test failures introduced

## Additional Notes

The two pre-existing test failures (`caldav-sync-engine`, `project-sharing`) are unrelated to this change and fail identically on `main`.