### PR TITLE
feat(ai): multi-LLM support, user profile context, and dedicated AI settings tab

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,9 @@ npm start  # Frontend on :8080, Backend on :3002
 
 22. **[AI Assistant](docs/13-ai-assistant.md)**
     - Daily Brief, Task Insights, and Project Insights features
-    - OpenAI integration (gpt-4o-mini, OPENAI_API_KEY)
+    - Provider-agnostic LLM integration (LLM_API_KEY, LLM_BASE_URL, LLM_MODEL)
+    - OpenAI, Ollama, Groq, and any OpenAI-compatible provider supported
+    - User "About You" profile context for personalised briefs
     - Caching strategy and API endpoints
     - Adding new AI features
 

--- a/backend/migrations/20260726000001-add-ai-profile-to-users.js
+++ b/backend/migrations/20260726000001-add-ai-profile-to-users.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const { safeAddColumns } = require('../utils/migration-utils');
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await safeAddColumns(queryInterface, 'users', [
+            {
+                name: 'ai_profile',
+                definition: {
+                    type: Sequelize.TEXT,
+                    allowNull: true,
+                    defaultValue: null,
+                },
+            },
+        ]);
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeColumn('users', 'ai_profile');
+    },
+};

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -226,6 +226,11 @@ module.exports = (sequelize) => {
                 allowNull: true,
                 defaultValue: null,
             },
+            ai_profile: {
+                type: DataTypes.TEXT,
+                allowNull: true,
+                defaultValue: null,
+            },
             email_verified: {
                 type: DataTypes.BOOLEAN,
                 allowNull: false,

--- a/backend/modules/ai-assistant/controller.js
+++ b/backend/modules/ai-assistant/controller.js
@@ -4,6 +4,23 @@ const { getAuthenticatedUserId } = require('../../utils/request-utils');
 const aiAssistantService = require('./service');
 
 const controller = {
+    getConfig(req, res) {
+        const userId = getAuthenticatedUserId(req);
+        if (!userId) return res.status(401).json({ error: 'Unauthorized' });
+
+        const apiKeySet = !!(
+            process.env.LLM_API_KEY || process.env.OPENAI_API_KEY
+        );
+        const baseUrl =
+            process.env.LLM_BASE_URL || process.env.OPENAI_BASE_URL || null;
+        const model =
+            process.env.LLM_MODEL ||
+            process.env.TUDUDI_AI_MODEL ||
+            'gpt-4o-mini';
+
+        res.json({ api_key_set: apiKeySet, base_url: baseUrl, model });
+    },
+
     async getCachedBrief(req, res, next) {
         try {
             const userId = getAuthenticatedUserId(req);

--- a/backend/modules/ai-assistant/routes.js
+++ b/backend/modules/ai-assistant/routes.js
@@ -4,6 +4,7 @@ const express = require('express');
 const router = express.Router();
 const controller = require('./controller');
 
+router.get('/ai-assistant/config', controller.getConfig);
 router.get('/ai-assistant/daily-brief', controller.getCachedBrief);
 router.post('/ai-assistant/daily-brief', controller.getDailyBrief);
 router.get(

--- a/backend/modules/ai-assistant/service.js
+++ b/backend/modules/ai-assistant/service.js
@@ -17,16 +17,34 @@ const STATUS_LABELS = {
 };
 
 function getOpenAIClient() {
-    const apiKey = process.env.OPENAI_API_KEY;
+    const apiKey = process.env.LLM_API_KEY || process.env.OPENAI_API_KEY;
     if (!apiKey) {
-        throw new Error('OPENAI_API_KEY environment variable is not set');
+        throw new Error(
+            'LLM_API_KEY (or OPENAI_API_KEY) environment variable is not set'
+        );
     }
-    return new OpenAI({ apiKey });
+    const options = { apiKey };
+    const baseURL = process.env.LLM_BASE_URL || process.env.OPENAI_BASE_URL;
+    if (baseURL) {
+        options.baseURL = baseURL;
+    }
+    return new OpenAI(options);
+}
+
+function getAIModel() {
+    return (
+        process.env.LLM_MODEL || process.env.TUDUDI_AI_MODEL || 'gpt-4o-mini'
+    );
+}
+
+function extractJSON(raw) {
+    const fenced = raw.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+    return fenced ? fenced[1] : raw;
 }
 
 async function fetchUserContext(userId) {
     const user = await User.findByPk(userId, {
-        attributes: ['id', 'timezone', 'email'],
+        attributes: ['id', 'timezone', 'email', 'ai_profile'],
     });
     if (!user) throw new Error('User not found');
 
@@ -69,6 +87,11 @@ function buildContextSummary({ user, timezone, goals, projects, metrics }) {
 
     lines.push(`# User Context`);
     lines.push(`Date: ${dateStr} | Time: ${timeStr} | Timezone: ${timezone}`);
+    if (user.ai_profile) {
+        lines.push('');
+        lines.push(`## About This User`);
+        lines.push(user.ai_profile);
+    }
     lines.push('');
 
     // Goals
@@ -237,19 +260,20 @@ Rules:
 - Return only the JSON object, no other text`;
 
     const response = await client.chat.completions.create({
-        model: 'gpt-4o-mini',
+        model: getAIModel(),
         messages: [
             { role: 'system', content: systemPrompt },
             { role: 'user', content: contextSummary },
         ],
-        max_tokens: 500,
+        max_tokens: 1500,
+        response_format: { type: 'json_object' },
     });
 
     const raw = response.choices[0]?.message?.content || '{}';
     console.log('[AI Assistant] raw response:', raw);
     let parsed;
     try {
-        parsed = JSON.parse(raw);
+        parsed = JSON.parse(extractJSON(raw));
     } catch {
         parsed = {
             focus: raw,
@@ -436,18 +460,19 @@ Rules:
 - Return only the JSON object, no other text`;
 
     const response = await client.chat.completions.create({
-        model: 'gpt-4o-mini',
+        model: getAIModel(),
         messages: [
             { role: 'system', content: systemPrompt },
             { role: 'user', content: lines.join('\n') },
         ],
         max_tokens: 1000,
+        response_format: { type: 'json_object' },
     });
 
     const raw = response.choices[0]?.message?.content || '{}';
     let parsed;
     try {
-        parsed = JSON.parse(raw);
+        parsed = JSON.parse(extractJSON(raw));
     } catch {
         parsed = {};
     }
@@ -565,18 +590,19 @@ Rules:
 - Return only the JSON object, no other text`;
 
     const response = await client.chat.completions.create({
-        model: 'gpt-4o-mini',
+        model: getAIModel(),
         messages: [
             { role: 'system', content: systemPrompt },
             { role: 'user', content: lines.join('\n') },
         ],
         max_tokens: 600,
+        response_format: { type: 'json_object' },
     });
 
     const raw = response.choices[0]?.message?.content || '{}';
     let parsed;
     try {
-        parsed = JSON.parse(raw);
+        parsed = JSON.parse(extractJSON(raw));
     } catch {
         parsed = {};
     }

--- a/backend/modules/users/repository.js
+++ b/backend/modules/users/repository.js
@@ -24,6 +24,7 @@ const PROFILE_ATTRIBUTES = [
     'sidebar_settings',
     'notification_preferences',
     'keyboard_shortcuts',
+    'ai_profile',
 ];
 
 const PROFILE_UPDATE_ATTRIBUTES = [
@@ -43,6 +44,7 @@ const PROFILE_UPDATE_ATTRIBUTES = [
     'features',
     'notification_preferences',
     'keyboard_shortcuts',
+    'ai_profile',
 ];
 
 class UsersRepository extends BaseRepository {

--- a/backend/modules/users/service.js
+++ b/backend/modules/users/service.js
@@ -148,6 +148,7 @@ class UsersService {
             ui_settings,
             notification_preferences,
             keyboard_shortcuts,
+            ai_profile,
             currentPassword,
             newPassword,
         } = data;
@@ -191,6 +192,8 @@ class UsersService {
             allowedUpdates.notification_preferences = notification_preferences;
         if (keyboard_shortcuts !== undefined)
             allowedUpdates.keyboard_shortcuts = keyboard_shortcuts;
+        if (ai_profile !== undefined)
+            allowedUpdates.ai_profile = ai_profile || null;
 
         // Handle password change/set if provided
         if (newPassword) {

--- a/docs/13-ai-assistant.md
+++ b/docs/13-ai-assistant.md
@@ -8,24 +8,45 @@
 
 The AI Assistant adds three context-aware intelligence features to Tududi:
 
-1. **Daily Brief** — a morning summary with a focus task, top priority actions, and risk flags
-2. **Task Insights** — domain-level analysis, next steps, and useful links for a specific task
-3. **Project Insights** — health assessment, next action, and risk flags for a specific project
+1. **Daily Brief**: a morning summary with a focus task, top priority actions, and risk flags
+2. **Task Insights**: domain-level analysis, next steps, and useful links for a specific task
+3. **Project Insights**: health assessment, next action, and risk flags for a specific project
 
-All three features call the OpenAI API (`gpt-4o-mini`) and cache results in the database. Results persist until the user explicitly regenerates them.
+All three features call an OpenAI-compatible API and cache results in the database. Results persist until the user explicitly regenerates them.
 
 ---
 
 ## Setup
 
-Set the `OPENAI_API_KEY` environment variable before starting the server:
+### Required
+
+Set an API key before starting the server. Use the generic `LLM_API_KEY` for any provider, or `OPENAI_API_KEY` if you're using OpenAI directly (both are supported; `LLM_API_KEY` takes precedence):
 
 ```bash
-# .env or Docker environment
+# Generic: works with any provider
+LLM_API_KEY=sk-...
+
+# OpenAI legacy name: still works as a fallback
 OPENAI_API_KEY=sk-...
 ```
 
-Without this key, all AI Assistant endpoints return HTTP 500.
+Without a key, all AI Assistant endpoints return HTTP 500.
+
+### Optional: custom provider or model
+
+The service uses the [OpenAI Node.js SDK](https://github.com/openai/openai-node), which is compatible with any provider that implements the OpenAI chat completions API (Ollama, LM Studio, Groq, Azure OpenAI, etc.).
+
+```bash
+# Base URL of the provider (defaults to OpenAI)
+LLM_BASE_URL=http://localhost:11434/v1  # e.g. local Ollama
+# OPENAI_BASE_URL is still accepted as a fallback
+
+# Model name the provider expects (defaults to gpt-4o-mini)
+LLM_MODEL=llama3.2
+# TUDUDI_AI_MODEL is still accepted as a fallback
+```
+
+> **Note on reasoning models:** reasoning models (e.g. DeepSeek-R1, o1-mini) consume hidden tokens before producing output. The daily brief allows up to 1500 completion tokens to accommodate this; task and project insights allow 1000 and 600 respectively.
 
 ---
 
@@ -42,7 +63,7 @@ frontend/
 backend/modules/ai-assistant/
   routes.js      # Express route definitions
   controller.js  # Request handlers, auth checks
-  service.js     # OpenAI client, prompt building, caching logic
+  service.js     # API client, prompt building, caching logic
 ```
 
 ---
@@ -68,12 +89,12 @@ Appears on the Today page inside the `DailyAssistant` component. Generates once 
   ],
   "watch_out": ["At-risk task or project name"],
   "generated_at": "ISO timestamp",
-  "model": "gpt-4o-mini",
+  "model": "model name echoed from API response",
   "usage": { "prompt_tokens": 0, "completion_tokens": 0 }
 }
 ```
 
-**Context sent to the model:** active goals, active projects, today's task breakdown (overdue, in-progress, planned, suggested), weekly completion trend.
+**Context sent to the model:** active goals, active projects, today's task breakdown (overdue, in-progress, planned, suggested), weekly completion trend, and the user's "About You" profile text (if set).
 
 **Caching:** stored in `users.ai_daily_brief` and `users.ai_daily_brief_date`. `GET /api/ai-assistant/daily-brief` returns the cache; `POST` regenerates it.
 
@@ -149,13 +170,23 @@ All endpoints require an authenticated session. Unauthenticated requests return 
 
 ## Model and Provider
 
-| Setting | Value |
-|---------|-------|
-| Provider | OpenAI |
-| Model | `gpt-4o-mini` |
-| Environment variable | `OPENAI_API_KEY` |
+| Setting | Primary variable | Fallback variable | Default |
+|---------|-----------------|-------------------|---------|
+| API key | `LLM_API_KEY` | `OPENAI_API_KEY` | (required) |
+| Base URL | `LLM_BASE_URL` | `OPENAI_BASE_URL` | OpenAI (`https://api.openai.com/v1`) |
+| Model | `LLM_MODEL` | `TUDUDI_AI_MODEL` | `gpt-4o-mini` |
 
-The client is initialized in `service.js:getOpenAIClient()`. Switching models or providers requires updating that function and the three `chat.completions.create` calls in the same file.
+The client is initialized in `service.js:getOpenAIClient()`. Any provider that speaks the OpenAI chat completions protocol works: set `LLM_BASE_URL` to the provider's endpoint and `LLM_MODEL` to the model name that provider expects.
+
+All three LLM calls request `response_format: { type: 'json_object' }` for structured output. If your backend does not support this parameter, the response parser will still attempt to extract JSON from raw text (including code-fenced output).
+
+---
+
+## User Profile Context
+
+Users can set an "About You" text in **Profile → Features → Intelligence → About You**. This text is injected into the daily brief prompt as an `## About This User` section, allowing the AI to tailor its language and framing to the user's actual domain (e.g. academic research, healthcare, design) rather than defaulting to software development metaphors.
+
+The field is stored in `users.ai_profile` (TEXT, max 500 chars in the UI).
 
 ---
 
@@ -173,7 +204,7 @@ Cached values are JSON objects stored as TEXT. The `generated_at` timestamp is i
 
 ## Adding a New AI Feature
 
-1. Add a new function in `service.js` that builds a prompt and calls `client.chat.completions.create()`
+1. Add a new function in `service.js` that builds a prompt and calls `client.chat.completions.create()`, using `getAIModel()` for the model name and `response_format: { type: 'json_object' }` for structured output
 2. Add a controller method in `controller.js` with auth check and error delegation via `next(error)`
 3. Register the route in `routes.js`
 4. Add the typed API client function to `frontend/utils/aiAssistantService.ts`

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -127,6 +127,11 @@ EMAIL_SMTP_PASSWORD=pass
 EMAIL_FROM_ADDRESS=noreply@example.com
 EMAIL_FROM_NAME=Tududi
 
+# Optional - AI Assistant (any OpenAI-compatible provider)
+LLM_API_KEY=sk-...            # or OPENAI_API_KEY as fallback
+LLM_BASE_URL=http://localhost:11434/v1  # omit to use OpenAI; set for Ollama etc.
+LLM_MODEL=gpt-4o-mini         # model name for the chosen provider
+
 # Optional - Integrations
 DISABLE_TELEGRAM=false
 GOOGLE_CLIENT_ID=your-google-oauth-client-id

--- a/frontend/components/Profile/ProfileSettings.tsx
+++ b/frontend/components/Profile/ProfileSettings.tsx
@@ -21,6 +21,7 @@ import {
     CommandLineIcon,
     CpuChipIcon,
     CalendarIcon,
+    SparklesIcon,
 } from '@heroicons/react/24/outline';
 import { Squares2X2Icon } from '@heroicons/react/24/solid';
 import TelegramIcon from '../Shared/Icons/TelegramIcon';
@@ -52,6 +53,7 @@ import NotificationsTab from './tabs/NotificationsTab';
 import KeyboardShortcutsTab from './tabs/KeyboardShortcutsTab';
 import McpTab from './tabs/McpTab';
 import CalDAVTab from './tabs/CalDAVTab';
+import AIAssistantTab from './tabs/AIAssistantTab';
 import { getDefaultConfig } from '../../utils/keyboardShortcutsService';
 import {
     getFeatureFlags,
@@ -97,11 +99,12 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
             'oidc',
             'api-keys',
             'productivity',
-            'telegram',
             'notifications',
+            'telegram',
             'keyboard-shortcuts',
             'caldav',
             'mcp',
+            'ai-assistant',
             'features',
         ];
         return section && validTabs.includes(section) ? section : 'general';
@@ -144,6 +147,7 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
         },
         notification_preferences: null,
         keyboard_shortcuts: null,
+        ai_profile: '',
         currentPassword: '',
         newPassword: '',
         confirmPassword: '',
@@ -579,6 +583,7 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
                         data.notification_preferences || null,
                     keyboard_shortcuts:
                         data.keyboard_shortcuts || getDefaultConfig(),
+                    ai_profile: data.ai_profile || '',
                 });
 
                 if (data.telegram_bot_token) {
@@ -1224,6 +1229,11 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
             featureFlag: 'mcp',
         },
         {
+            id: 'ai-assistant',
+            name: t('profile.tabs.aiAssistant', 'AI Assistant'),
+            icon: <SparklesIcon className="w-5 h-5" />,
+        },
+        {
             id: 'features',
             name: t('profile.tabs.features', 'Features & Add-ons'),
             icon: <Squares2X2Icon className="w-5 h-5" />,
@@ -1445,6 +1455,26 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
                                                 ...prev.features,
                                                 [field]: !prev.features?.[field],
                                             },
+                                        }))
+                                    }
+                                />
+
+                                <AIAssistantTab
+                                    isActive={activeTab === 'ai-assistant'}
+                                    formData={formData}
+                                    onToggleAi={(field) =>
+                                        setFormData((prev) => ({
+                                            ...prev,
+                                            features: {
+                                                ...prev.features,
+                                                [field]: !prev.features?.[field],
+                                            },
+                                        }))
+                                    }
+                                    onAiProfileChange={(value) =>
+                                        setFormData((prev) => ({
+                                            ...prev,
+                                            ai_profile: value,
                                         }))
                                     }
                                 />

--- a/frontend/components/Profile/tabs/AIAssistantTab.tsx
+++ b/frontend/components/Profile/tabs/AIAssistantTab.tsx
@@ -1,0 +1,204 @@
+import React, { ChangeEvent, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+    CheckCircleIcon,
+    ExclamationCircleIcon,
+} from '@heroicons/react/24/outline';
+import { getApiPath } from '../../../config/paths';
+import type { ProfileFormData, Features } from '../types';
+
+interface AIAssistantTabProps {
+    isActive: boolean;
+    formData: ProfileFormData;
+    onToggleAi: (field: keyof Features) => void;
+    onAiProfileChange: (value: string) => void;
+}
+
+interface LLMConfig {
+    api_key_set: boolean;
+    base_url: string | null;
+    model: string;
+}
+
+const AIAssistantTab: React.FC<AIAssistantTabProps> = ({
+    isActive,
+    formData,
+    onToggleAi,
+    onAiProfileChange,
+}) => {
+    const { t } = useTranslation();
+    const [config, setConfig] = useState<LLMConfig | null>(null);
+
+    useEffect(() => {
+        if (!isActive) return;
+        fetch(getApiPath('ai-assistant/config'), { credentials: 'include' })
+            .then((r) => r.json())
+            .then(setConfig)
+            .catch(() => setConfig(null));
+    }, [isActive]);
+
+    if (!isActive) return null;
+
+    const aiEnabled = Boolean(formData.features?.ai_assistant_enabled);
+
+    return (
+        <div>
+            <h3 className="text-xl font-semibold text-gray-900 dark:text-white mb-1">
+                {t('profile.aiAssistantTab', 'AI Assistant')}
+            </h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+                {t(
+                    'profile.aiAssistantTabDescription',
+                    'Daily briefs, task insights, and project insights powered by any OpenAI-compatible model.'
+                )}
+            </p>
+
+            {/* Server configuration */}
+            <div className="mb-8">
+                <h4 className="text-base font-semibold text-gray-900 dark:text-white mb-3">
+                    {t('profile.aiServerConfig', 'Server Configuration')}
+                </h4>
+                <div className="rounded-lg border border-gray-200 dark:border-gray-700 divide-y divide-gray-200 dark:divide-gray-700">
+                    {/* API Key */}
+                    <div className="flex items-center justify-between px-4 py-3">
+                        <span className="text-sm text-gray-600 dark:text-gray-400">
+                            {t('profile.aiApiKey', 'API Key')}
+                            <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">
+                                LLM_API_KEY
+                            </span>
+                        </span>
+                        {config === null ? (
+                            <span className="text-xs text-gray-400">-</span>
+                        ) : config.api_key_set ? (
+                            <span className="flex items-center gap-1 text-xs font-medium text-green-600 dark:text-green-400">
+                                <CheckCircleIcon className="w-4 h-4" />
+                                {t('profile.aiKeySet', 'Set')}
+                            </span>
+                        ) : (
+                            <span className="flex items-center gap-1 text-xs font-medium text-red-500 dark:text-red-400">
+                                <ExclamationCircleIcon className="w-4 h-4" />
+                                {t('profile.aiKeyNotSet', 'Not set')}
+                            </span>
+                        )}
+                    </div>
+
+                    {/* Base URL */}
+                    <div className="flex items-center justify-between px-4 py-3">
+                        <span className="text-sm text-gray-600 dark:text-gray-400">
+                            {t('profile.aiBaseUrl', 'Base URL')}
+                            <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">
+                                LLM_BASE_URL
+                            </span>
+                        </span>
+                        <span className="text-sm font-mono text-gray-700 dark:text-gray-300 text-right max-w-xs truncate">
+                            {config === null
+                                ? '-'
+                                : config.base_url ?? (
+                                      <span className="text-gray-400 dark:text-gray-500 font-sans not-italic">
+                                          {t(
+                                              'profile.aiBaseUrlDefault',
+                                              'OpenAI (default)'
+                                          )}
+                                      </span>
+                                  )}
+                        </span>
+                    </div>
+
+                    {/* Model */}
+                    <div className="flex items-center justify-between px-4 py-3">
+                        <span className="text-sm text-gray-600 dark:text-gray-400">
+                            {t('profile.aiModel', 'Model')}
+                            <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">
+                                LLM_MODEL
+                            </span>
+                        </span>
+                        <span className="text-sm font-mono text-gray-700 dark:text-gray-300">
+                            {config === null ? '-' : config.model}
+                        </span>
+                    </div>
+                </div>
+                {config && !config.api_key_set && (
+                    <p className="mt-2 text-xs text-red-500 dark:text-red-400">
+                        {t(
+                            'profile.aiKeyMissingHint',
+                            'Set LLM_API_KEY (or OPENAI_API_KEY) on the server to enable AI features.'
+                        )}
+                    </p>
+                )}
+            </div>
+
+            {/* Enable toggle */}
+            <div className="mb-8">
+                <h4 className="text-base font-semibold text-gray-900 dark:text-white mb-3">
+                    {t('profile.aiEnableSection', 'Enable')}
+                </h4>
+                <div className="rounded-lg border border-gray-200 dark:border-gray-700">
+                    <div className="flex items-center justify-between px-4 py-4">
+                        <div className="pr-8">
+                            <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                {t(
+                                    'profile.aiAssistantLabel',
+                                    'AI Assistant (Insights)'
+                                )}
+                            </label>
+                            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                                {t(
+                                    'profile.aiAssistantDescription',
+                                    'Enable AI-powered daily briefs, task insights, and project insights. Requires LLM_API_KEY (or OPENAI_API_KEY) on the server.'
+                                )}
+                            </p>
+                        </div>
+                        <div
+                            className={`relative inline-block w-12 h-6 flex-shrink-0 transition-colors duration-200 ease-in-out rounded-full cursor-pointer ${
+                                aiEnabled
+                                    ? 'bg-blue-500'
+                                    : 'bg-gray-300 dark:bg-gray-600'
+                            }`}
+                            onClick={() => onToggleAi('ai_assistant_enabled')}
+                        >
+                            <span
+                                className={`absolute left-0 top-0 bottom-0 m-1 w-4 h-4 transition-transform duration-200 ease-in-out transform bg-white rounded-full ${
+                                    aiEnabled
+                                        ? 'translate-x-6'
+                                        : 'translate-x-0'
+                                }`}
+                            />
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            {/* About You */}
+            <div>
+                <h4 className="text-base font-semibold text-gray-900 dark:text-white mb-1">
+                    {t('profile.aiProfileLabel', 'About You')}
+                </h4>
+                <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
+                    {t(
+                        'profile.aiProfileDescription',
+                        'Optional context fed into the AI prompts: your role, field, or anything that helps personalise the briefs and insights (e.g. "Academic researcher focused on grant deadlines and grading cycles").'
+                    )}
+                </p>
+                <textarea
+                    name="ai_profile"
+                    rows={10}
+                    maxLength={500}
+                    value={formData.ai_profile || ''}
+                    onChange={(e: ChangeEvent<HTMLTextAreaElement>) =>
+                        onAiProfileChange(e.target.value)
+                    }
+                    placeholder={t(
+                        'profile.aiProfilePlaceholder',
+                        'e.g. Academic researcher. My work revolves around grant deadlines, paper reviews, and teaching cycles, not sprints or deploys.'
+                    )}
+                    className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-sm text-gray-900 dark:text-gray-100 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                />
+                <p className="mt-1 text-xs text-gray-400 dark:text-gray-500 text-right">
+                    {(formData.ai_profile || '').length} / 500
+                </p>
+            </div>
+        </div>
+    );
+};
+
+export default AIAssistantTab;

--- a/frontend/components/Profile/tabs/FeaturesTab.tsx
+++ b/frontend/components/Profile/tabs/FeaturesTab.tsx
@@ -192,18 +192,6 @@ const FeaturesTab: React.FC<FeaturesTabProps> = ({
                         onToggle={() =>
                             onToggleAi('next_task_suggestion_enabled')
                         }
-                    />
-                    <ToggleRow
-                        label={t(
-                            'profile.aiAssistantLabel',
-                            'AI Assistant (Insights)'
-                        )}
-                        description={t(
-                            'profile.aiAssistantDescription',
-                            'Enable AI-powered task and project insights. Requires OPENAI_API_KEY configured on the server.'
-                        )}
-                        value={Boolean(formData.features?.ai_assistant_enabled)}
-                        onToggle={() => onToggleAi('ai_assistant_enabled')}
                         last
                     />
                 </div>

--- a/frontend/components/Profile/types.ts
+++ b/frontend/components/Profile/types.ts
@@ -72,6 +72,7 @@ export interface Profile {
     features: Features;
     notification_preferences?: NotificationPreferences | null;
     keyboard_shortcuts?: KeyboardShortcutsConfig | null;
+    ai_profile?: string | null;
 }
 
 export interface TelegramBotInfo {


### PR DESCRIPTION
## Description

Addresses feedback from a user running the AI assistant against a local Ollama model. Fixes two blank-brief bugs, adds proper self-hosted LLM support, and moves AI settings into their own profile tab.

## Type of Change

- [x] Bug fix
- [x] New feature

## Related Issues

N/A

## Changes

**Bug fixes (blank briefs):**
- Bump daily brief `max_tokens` from 500 to 1500. Reasoning models (DeepSeek-R1, o1-mini, etc.) burn hidden tokens before producing output; 500 was too low.
- Add `response_format: { type: 'json_object' }` to all three LLM calls. Add `extractJSON()` helper to strip \`\`\`json code fences as a fallback for backends that ignore `response_format`.

**Multi-LLM / self-hosted support:**
- `LLM_API_KEY` (falls back to `OPENAI_API_KEY`)
- `LLM_BASE_URL` (falls back to `OPENAI_BASE_URL`) — point at Ollama, Groq, LM Studio, etc.
- `LLM_MODEL` (falls back to `TUDUDI_AI_MODEL`, then `gpt-4o-mini`)
- New `GET /api/ai-assistant/config` endpoint: returns `base_url`, `model`, and `api_key_set` (boolean — key value is never exposed)

**User profile context:**
- New `ai_profile` TEXT column on `users` (migration included)
- Content is injected into daily brief prompts as `## About This User`, letting the model tailor its language to the user's domain (academic, healthcare, design, etc.) instead of defaulting to software metaphors

**Dedicated AI Assistant settings tab:**
- Moved out of Features & Add-ons into its own tab (SparklesIcon)
- Server config panel shows API Key status (set/not set), Base URL, and Model — fetched live from `/api/ai-assistant/config`
- Enable toggle and About You textarea in the same tab

**Docs:**
- `docs/13-ai-assistant.md` fully updated: provider-agnostic setup, env var fallback table, reasoning model note, `response_format` behaviour, user profile context section
- `docs/development-workflow.md`: AI env vars added to the environment variables reference
- `CLAUDE.md` index entry updated

## Testing

```bash
npm install
npm run db:migrate
npm start

# With OpenAI
LLM_API_KEY=sk-... npm start

# With Ollama
LLM_API_KEY=ollama LLM_BASE_URL=http://localhost:11434/v1 LLM_MODEL=llama3.2 npm start
```

- [ ] Profile > AI Assistant tab shows correct server config
- [ ] API key shown as Set / Not set (value never displayed)
- [ ] Daily brief generates without blank output on reasoning models
- [ ] About You text influences brief language/framing
- [ ] Existing `OPENAI_API_KEY` / `OPENAI_BASE_URL` setups continue to work unchanged

## Checklist

- [x] Code follows project conventions
- [x] No JSDoc comments added
- [x] Migration included for schema change
- [x] Docs updated
- [x] `npm run lint:fix` passes with no errors