### PR TITLE
fix(caldav): fix date timezone handling and ETag on collection GET

### DIFF
--- a/backend/modules/caldav/icalendar/vtodo-parser.js
+++ b/backend/modules/caldav/icalendar/vtodo-parser.js
@@ -4,8 +4,12 @@ const {
     icalToTududiPriority,
 } = require('./field-mappings');
 const { parseRRULE } = require('./rrule-parser');
+const {
+    processDueDateForStorage,
+    processDeferUntilForStorage,
+} = require('../../../utils/timezone-utils');
 
-async function parseVTODOToTask(vtodoString) {
+async function parseVTODOToTask(vtodoString, userTimezone) {
     try {
         if (!vtodoString || typeof vtodoString !== 'string') {
             throw new Error('Invalid VTODO data: expected a non-empty string');
@@ -81,11 +85,13 @@ async function parseVTODOToTask(vtodoString) {
         const due = vtodo.getFirstPropertyValue('due');
         if (due) {
             if (due.isDate) {
-                const year = due.year;
-                const month = due.month - 1;
-                const day = due.day;
-                task.due_date = new Date(
-                    Date.UTC(year, month, day, 0, 0, 0, 0)
+                // DATE-only values are timezone-independent; store as end-of-day
+                // in the user's timezone so Tududi's date display is consistent
+                // with tasks created via the web UI.
+                const dateStr = `${due.year}-${String(due.month).padStart(2, '0')}-${String(due.day).padStart(2, '0')}`;
+                task.due_date = processDueDateForStorage(
+                    dateStr,
+                    userTimezone || 'UTC'
                 );
             } else {
                 task.due_date = due.toJSDate();
@@ -95,11 +101,10 @@ async function parseVTODOToTask(vtodoString) {
         const dtstart = vtodo.getFirstPropertyValue('dtstart');
         if (dtstart) {
             if (dtstart.isDate) {
-                const year = dtstart.year;
-                const month = dtstart.month - 1;
-                const day = dtstart.day;
-                task.defer_until = new Date(
-                    Date.UTC(year, month, day, 0, 0, 0, 0)
+                const dateStr = `${dtstart.year}-${String(dtstart.month).padStart(2, '0')}-${String(dtstart.day).padStart(2, '0')}`;
+                task.defer_until = processDeferUntilForStorage(
+                    dateStr,
+                    userTimezone || 'UTC'
                 );
             } else {
                 task.defer_until = dtstart.toJSDate();

--- a/backend/modules/caldav/icalendar/vtodo-serializer.js
+++ b/backend/modules/caldav/icalendar/vtodo-serializer.js
@@ -4,8 +4,11 @@ const {
     tududiToIcalPriority,
 } = require('./field-mappings');
 const { generateRRULE } = require('./rrule-generator');
+const { utcToUserDateString } = require('../../../utils/timezone-utils');
 
 function serializeTaskToVTODO(task, options = {}) {
+    const { userTimezone } = options;
+
     const comp = new ICAL.Component('vcalendar');
     comp.addPropertyWithValue('version', '2.0');
     comp.addPropertyWithValue('prodid', '-//Tududi//Task Manager//EN');
@@ -28,12 +31,16 @@ function serializeTaskToVTODO(task, options = {}) {
     if (task.due_date) {
         try {
             const d = new Date(task.due_date);
-            const dueDate = new ICAL.Time({
-                year: d.getUTCFullYear(),
-                month: d.getUTCMonth() + 1,
-                day: d.getUTCDate(),
-                isDate: true,
-            });
+            // Use user timezone to get the correct calendar date; Tududi stores
+            // due_date as end-of-day in the user's timezone, so converting with
+            // UTC date parts gives the wrong date for non-UTC users.
+            const dateStr = userTimezone
+                ? utcToUserDateString(d, userTimezone)
+                : null;
+            const [year, month, day] = dateStr
+                ? dateStr.split('-').map(Number)
+                : [d.getUTCFullYear(), d.getUTCMonth() + 1, d.getUTCDate()];
+            const dueDate = new ICAL.Time({ year, month, day, isDate: true });
             vtodo.addPropertyWithValue('due', dueDate);
         } catch (error) {
             console.error('Error formatting due date:', error);
@@ -43,12 +50,14 @@ function serializeTaskToVTODO(task, options = {}) {
     if (task.defer_until) {
         try {
             const d = new Date(task.defer_until);
-            const startDate = new ICAL.Time({
-                year: d.getUTCFullYear(),
-                month: d.getUTCMonth() + 1,
-                day: d.getUTCDate(),
-                isDate: true,
-            });
+            // Same timezone-aware conversion for DTSTART.
+            const dateStr = userTimezone
+                ? utcToUserDateString(d, userTimezone)
+                : null;
+            const [year, month, day] = dateStr
+                ? dateStr.split('-').map(Number)
+                : [d.getUTCFullYear(), d.getUTCMonth() + 1, d.getUTCDate()];
+            const startDate = new ICAL.Time({ year, month, day, isDate: true });
             vtodo.addPropertyWithValue('dtstart', startDate);
         } catch (error) {
             console.error('Error formatting defer_until date:', error);
@@ -201,6 +210,32 @@ function getStatusName(status) {
     return statusMap[status];
 }
 
+async function serializeCollectionToVCALENDAR(tasks, options = {}) {
+    const comp = new ICAL.Component('vcalendar');
+    comp.addPropertyWithValue('version', '2.0');
+    comp.addPropertyWithValue('prodid', '-//Tududi//Task Manager//EN');
+    comp.addPropertyWithValue('calscale', 'GREGORIAN');
+
+    for (const task of tasks) {
+        try {
+            const vtodoStr = serializeTaskToVTODO(task, options);
+            const taskComp = new ICAL.Component(ICAL.parse(vtodoStr));
+            const vtodo = taskComp.getFirstSubcomponent('vtodo');
+            if (vtodo) {
+                comp.addSubcomponent(vtodo);
+            }
+        } catch (err) {
+            console.error(
+                `Error serializing task ${task.uid} for collection:`,
+                err
+            );
+        }
+    }
+
+    return comp.toString();
+}
+
 module.exports = {
     serializeTaskToVTODO,
+    serializeCollectionToVCALENDAR,
 };

--- a/backend/modules/caldav/routes.js
+++ b/backend/modules/caldav/routes.js
@@ -22,6 +22,9 @@ const {
 } = require('./webdav/projects');
 const apiRoutes = require('./api/routes');
 const { requireAuth } = require('../../middleware/auth');
+const taskRepository = require('../tasks/repository');
+const vtodoSerializer = require('./icalendar/vtodo-serializer');
+const { generateCTag } = require('./utils/ctag-generator');
 
 const router = express.Router();
 
@@ -176,11 +179,43 @@ router.all(
     }
 );
 
-router.get('/caldav/:username/tasks/', xmlParser, caldavAuth, (req, res) => {
-    res.status(207).send(
-        '<?xml version="1.0"?><D:multistatus xmlns:D="DAV:"/>'
-    );
-});
+// GET on the calendar collection: return the aggregated iCalendar so that
+// clients (Tasks.org, DAVx5) receive a proper 200 with an ETag (CTag).
+// Responding with 207 here breaks those clients with "GET response without ETag".
+router.get(
+    '/caldav/:username/tasks/',
+    xmlParser,
+    caldavAuth,
+    async (req, res) => {
+        try {
+            if (
+                !req.currentUser ||
+                req.currentUser.email !== req.params.username
+            ) {
+                return res.status(403).send('Forbidden');
+            }
+            const userId = req.currentUser.id;
+            const userTimezone = req.currentUser.timezone || 'UTC';
+            const tasks = await taskRepository.findByUser(userId);
+            const ctag = generateCTag(tasks);
+            const ical = await vtodoSerializer.serializeCollectionToVCALENDAR(
+                tasks,
+                { userTimezone }
+            );
+            return res
+                .status(200)
+                .set({
+                    'Content-Type': 'text/calendar; charset=utf-8',
+                    ETag: ctag,
+                    'Last-Modified': new Date().toUTCString(),
+                })
+                .send(ical);
+        } catch (err) {
+            console.error('GET collection error:', err);
+            return res.status(500).send('Internal Server Error');
+        }
+    }
+);
 
 router.get(
     '/caldav/:username/tasks/:uid',

--- a/backend/modules/caldav/webdav/propfind.js
+++ b/backend/modules/caldav/webdav/propfind.js
@@ -35,6 +35,7 @@ async function handlePropfind(req, res) {
 
         const isTaskRequest = req.params.uid;
         const responses = [];
+        const userTimezone = req.currentUser.timezone || 'UTC';
 
         if (isTaskRequest) {
             const taskUid = req.params.uid.replace('.ics', '');
@@ -47,7 +48,8 @@ async function handlePropfind(req, res) {
             const response = await buildTaskResponse(
                 task,
                 username,
-                propfindRequest
+                propfindRequest,
+                userTimezone
             );
             responses.push(response);
         } else {
@@ -64,7 +66,8 @@ async function handlePropfind(req, res) {
                     const taskResponse = await buildTaskResponse(
                         task,
                         username,
-                        propfindRequest
+                        propfindRequest,
+                        userTimezone
                     );
                     responses.push(taskResponse);
                 }
@@ -122,12 +125,19 @@ async function buildCalendarResponse(username, userId, propfindRequest) {
     return buildResponse(href, propstat);
 }
 
-async function buildTaskResponse(task, username, propfindRequest) {
+async function buildTaskResponse(
+    task,
+    username,
+    propfindRequest,
+    userTimezone
+) {
     const href = buildHref(username, task.uid);
     const etag = generateETag(task);
 
     try {
-        const vtodo = await vtodoSerializer.serializeTaskToVTODO(task);
+        const vtodo = await vtodoSerializer.serializeTaskToVTODO(task, {
+            userTimezone,
+        });
 
         const props = {
             'D:resourcetype': '',

--- a/backend/modules/caldav/webdav/report.js
+++ b/backend/modules/caldav/webdav/report.js
@@ -30,6 +30,8 @@ async function handleReport(req, res) {
                 .json({ error: 'Invalid calendar-query request' });
         }
 
+        const userTimezone = req.currentUser.timezone || 'UTC';
+
         if (queryRequest.isMultiget) {
             const responses = [];
 
@@ -60,8 +62,10 @@ async function handleReport(req, res) {
 
                 try {
                     const etag = generateETag(task);
-                    const vtodo =
-                        await vtodoSerializer.serializeTaskToVTODO(task);
+                    const vtodo = await vtodoSerializer.serializeTaskToVTODO(
+                        task,
+                        { userTimezone }
+                    );
                     const propstat = buildPropstat({
                         'D:getetag': etag,
                         'C:calendar-data': vtodo,
@@ -141,7 +145,8 @@ async function handleReport(req, res) {
             const response = await buildCalendarQueryResponse(
                 task,
                 username,
-                queryRequest
+                queryRequest,
+                userTimezone
             );
             if (response) {
                 responses.push(response);
@@ -159,7 +164,12 @@ async function handleReport(req, res) {
     }
 }
 
-async function buildCalendarQueryResponse(task, username, queryRequest) {
+async function buildCalendarQueryResponse(
+    task,
+    username,
+    queryRequest,
+    userTimezone
+) {
     try {
         const href = buildHref(username, task.uid);
         const etag = generateETag(task);
@@ -173,7 +183,9 @@ async function buildCalendarQueryResponse(task, username, queryRequest) {
         );
 
         if (includeCalendarData) {
-            const vtodo = await vtodoSerializer.serializeTaskToVTODO(task);
+            const vtodo = await vtodoSerializer.serializeTaskToVTODO(task, {
+                userTimezone,
+            });
             props['C:calendar-data'] = vtodo;
         }
 

--- a/backend/modules/caldav/webdav/task-handlers.js
+++ b/backend/modules/caldav/webdav/task-handlers.js
@@ -26,10 +26,15 @@ async function handleGetTask(req, res) {
         const ifNoneMatch = req.headers['if-none-match'];
 
         if (ifNoneMatch && matchesETag(ifNoneMatch, etag)) {
-            return res.status(304).end();
+            // RFC 7232 §4.1: a 304 SHOULD echo the ETag so the client can
+            // confirm which version it already has cached.
+            return res.status(304).set('ETag', etag).end();
         }
 
-        const vtodo = await vtodoSerializer.serializeTaskToVTODO(task);
+        const userTimezone = req.currentUser.timezone || 'UTC';
+        const vtodo = await vtodoSerializer.serializeTaskToVTODO(task, {
+            userTimezone,
+        });
 
         res.status(200)
             .set({
@@ -81,7 +86,11 @@ async function handlePutTask(req, res) {
 
         let taskData;
         try {
-            taskData = await vtodoParser.parseVTODOToTask(vtodoData);
+            const userTimezone = req.currentUser.timezone || 'UTC';
+            taskData = await vtodoParser.parseVTODOToTask(
+                vtodoData,
+                userTimezone
+            );
         } catch (error) {
             console.error('VTODO parse error:', error);
             return res.status(400).send('Bad Request: Invalid VTODO data');

--- a/backend/tests/integration/caldav-protocol.test.js
+++ b/backend/tests/integration/caldav-protocol.test.js
@@ -145,10 +145,12 @@ describe('CalDAV Protocol - Phase 3', () => {
 
         // eslint-disable-next-line jest/expect-expect
         test('should accept requests with valid HTTP Basic Auth', async () => {
-            await request(app)
+            // Collection GET now returns 200 with iCalendar data and an ETag.
+            const response = await request(app)
                 .get('/caldav/caldav@test.com/tasks/')
                 .set('Authorization', authHeader)
-                .expect(207);
+                .expect(200);
+            expect(response.headers.etag).toBeDefined();
         });
 
         // eslint-disable-next-line jest/expect-expect

--- a/backend/tests/unit/modules/caldav/icalendar/round-trip.test.js
+++ b/backend/tests/unit/modules/caldav/icalendar/round-trip.test.js
@@ -27,8 +27,10 @@ describe('CalDAV Round-Trip Conversion', () => {
         expect(parsedTask.status).toBe(originalTask.status);
         expect(parsedTask.priority).toBe(originalTask.priority);
         expect(parsedTask.note).toBe(originalTask.note);
+        // DATE-only values are stored as end-of-day in UTC (the fallback timezone
+        // when no user timezone is passed to the parser).
         expect(parsedTask.due_date.toISOString()).toBe(
-            '2026-06-01T00:00:00.000Z'
+            '2026-06-01T23:59:59.999Z'
         );
         expect(parsedTask.defer_until.toISOString()).toBe(
             '2026-05-25T00:00:00.000Z'
@@ -50,9 +52,10 @@ describe('CalDAV Round-Trip Conversion', () => {
         const vtodoString = await serializeTaskToVTODO(originalTask);
         const parsedTask = await parseVTODOToTask(vtodoString);
 
-        // DUE/DTSTART are always emitted as VALUE=DATE - time is stripped
+        // DUE/DTSTART are always emitted as VALUE=DATE; after parsing the date
+        // is stored as end-of-day in UTC (fallback when no user timezone provided).
         expect(parsedTask.due_date.toISOString()).toBe(
-            '2026-06-04T00:00:00.000Z'
+            '2026-06-04T23:59:59.999Z'
         );
         expect(parsedTask.defer_until.toISOString()).toBe(
             '2026-06-04T00:00:00.000Z'


### PR DESCRIPTION
## Description

Fixes two bugs in the CalDAV server affecting Tasks.org and DAVx5 integration (#1332).

### Bug 1: Off-by-one date errors via DAVx5

Tududi stores due dates as end-of-day in the user's timezone (e.g. `2026-07-26T23:59:59Z` for a UTC+0 user, or `2026-07-27T03:59:59Z` for a UTC-4 user). CalDAV clients like DAVx5 send and expect `DATE`-only values (e.g. `DUE:20260726`), which are timezone-independent.

**Parser bug**: `DATE` values were stored as UTC midnight (`2026-07-26T00:00:00Z`). For users in negative-offset timezones (America/New_York = UTC-4 in summer), `processDueDateForResponse` would then convert that back to July 25 — one day early.

**Serializer bug**: tasks stored as end-of-day `2026-07-27T03:59:59Z` were serialized using UTC date parts → `DUE:20260727` instead of `DUE:20260726`.

**Fix**: thread `req.currentUser.timezone` through all CalDAV handlers into the parser (`processDueDateForStorage` / `processDeferUntilForStorage`) and serializer (`utcToUserDateString`). Falls back to `'UTC'` when no timezone is configured.

### Bug 2: "GET response without ETag" — one-way sync only

The tasks calendar collection GET (`/caldav/:user/tasks/`) returned a `207 Multi-Status` without an `ETag` header. CalDAV clients (Tasks.org, DAVx5) expect a `200 OK` with a CTag-based `ETag` for collection GETs; getting a `207` without one causes the "GET response without ETag" warning that disrupts two-way sync.

**Fix**: replaced the stub `207` handler with a proper handler that returns `200 OK` with the full aggregated `VCALENDAR` (all user VTODOs) and a deterministic `ETag` (CTag).

**Bonus**: `304 Not Modified` responses now echo the `ETag` header as required by RFC 7232 §4.1.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1332

## Testing

- All 190 existing CalDAV tests pass
- Updated two unit tests that expected UTC midnight for `DATE`-only values (now correctly expect end-of-day UTC)
- Updated one integration test that expected `207` for collection GET (now correctly expects `200` with ETag)

```
npx jest --testPathPattern="caldav" --no-coverage
Tests: 190 passed, 190 total
```

## Checklist

- [x] Tests pass
- [x] Lint clean (`npm run lint:fix`)
- [x] No breaking changes to existing behavior for UTC users