### PR TITLE
fix(notes): fix new note "+" button opening then immediately closing

### DIFF
--- a/frontend/components/Notes.tsx
+++ b/frontend/components/Notes.tsx
@@ -234,14 +234,11 @@ const Notes: React.FC = () => {
     };
 
     const handleNewNote = () => {
-        setEditingNote({
-            title: '',
-            content: '',
-            tags: [],
-        });
         setIsEditing(true);
+        setEditingNote({ title: '', content: '', tags: [] });
+        setPreviewNote(null);
         setSaveStatus('saved');
-        handleSelectNote(null);
+        navigate('/notes', { replace: true });
     };
 
     const handleSaveInlineNote = async () => {
@@ -463,6 +460,7 @@ const Notes: React.FC = () => {
             !uid &&
             sortedNotes.length > 0 &&
             !previewNote &&
+            !isEditing &&
             !hasAutoSelected.current
         ) {
             const isDesktop = window.innerWidth >= 768;
@@ -471,7 +469,7 @@ const Notes: React.FC = () => {
                 hasAutoSelected.current = true;
             }
         }
-    }, [sortedNotes, previewNote, uid]);
+    }, [sortedNotes, previewNote, uid, isEditing]);
 
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {


### PR DESCRIPTION
## Description

The "+" button in the Notes view would briefly flash the new note editor and then revert to the previously selected note, making it impossible to create a new note inline.

**Root cause:** `handleNewNote` called `handleSelectNote(null)` at the end. Because React 18 batches state updates within an event handler, the `isEditing` and `editingNote` values read inside `handleSelectNote` were stale (pre-batch), so its internal `setIsEditing(false)` / `setEditingNote(null)` calls overrode the `setIsEditing(true)` / `setEditingNote({...})` set earlier in the same batch. Additionally, navigating to `/notes` with `previewNote = null` triggered the auto-select effect, which immediately selected the first existing note.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

<!-- No issue number — reported directly -->

## Changes

- **`handleNewNote`**: Removed the `handleSelectNote(null)` call and replaced it with direct state updates (`setIsEditing`, `setEditingNote`, `setPreviewNote`) plus `navigate('/notes')`. This avoids the state-update ordering problem.
- **Auto-select effect**: Added `!isEditing` guard to the condition so the effect does not auto-select an existing note while the user is creating a new one.

## Testing

1. Go to Notes view
2. Click the "+" button
3. Verify the new note editor opens and stays open
4. Type a title — auto-save should work as before
5. Verify clicking an existing note in the list still works (switches away from the new note form)

```bash
npm run lint:fix   # clean (2 pre-existing warnings, 0 errors)
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have tested this change manually
- [x] Lint passes with no new errors