### PR TITLE
feat(notes): rich editor with wikilinks, backlinks, slash commands, and note badges

### DIFF
--- a/backend/modules/notes/controller.js
+++ b/backend/modules/notes/controller.js
@@ -125,6 +125,21 @@ const notesController = {
     },
 
     /**
+     * GET /api/note/:uid/backlinks
+     * Get all notes that link to this note via [[title]].
+     */
+    async backlinks(req, res, next) {
+        try {
+            const userId = requireUserId(req);
+            const uid = extractUidFromSlug(req.params.uid);
+            const links = await notesService.getBacklinks(userId, uid);
+            res.json(links);
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    /**
      * Get note UID if exists (for authorization middleware).
      */
     async getNoteUidForAuth(req) {

--- a/backend/modules/notes/repository.js
+++ b/backend/modules/notes/repository.js
@@ -113,6 +113,21 @@ class NotesRepository extends BaseRepository {
             user_id: userId,
         });
     }
+
+    /**
+     * Find notes that contain [[noteTitle]] in their content (backlinks).
+     */
+    async findBacklinks(userId, noteTitle) {
+        const { Op } = require('sequelize');
+        return this.model.findAll({
+            where: {
+                user_id: userId,
+                content: { [Op.like]: `%[[${noteTitle}]]%` },
+            },
+            attributes: ['uid', 'title'],
+            order: [['title', 'ASC']],
+        });
+    }
 }
 
 module.exports = new NotesRepository();

--- a/backend/modules/notes/routes.js
+++ b/backend/modules/notes/routes.js
@@ -40,4 +40,7 @@ router.delete(
     notesController.delete
 );
 
+// Get backlinks — notes that reference this note via [[title]]
+router.get('/note/:uid/backlinks', notesController.backlinks);
+
 module.exports = router;

--- a/backend/modules/notes/service.js
+++ b/backend/modules/notes/service.js
@@ -292,6 +292,24 @@ class NotesService {
     }
 
     /**
+     * Get all notes that contain [[noteTitle]] in their content (backlinks).
+     */
+    async getBacklinks(userId, uid) {
+        const validatedUid = validateUid(uid);
+        const note = await notesRepository.findByUid(validatedUid);
+        if (!note) {
+            throw new NotFoundError('Note not found.');
+        }
+
+        const { title } =
+            await notesRepository.findByUidWithIncludes(validatedUid);
+        const backlinks = await notesRepository.findBacklinks(userId, title);
+        return backlinks
+            .filter((b) => b.uid !== validatedUid)
+            .map((b) => ({ uid: b.uid, title: b.title }));
+    }
+
+    /**
      * Delete a note.
      */
     async delete(uid) {

--- a/frontend/components/Note/BacklinksPanel.tsx
+++ b/frontend/components/Note/BacklinksPanel.tsx
@@ -1,0 +1,74 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { LinkIcon } from '@heroicons/react/24/outline';
+import { fetchNoteBacklinks, BacklinkNote } from '../../utils/notesService';
+
+interface BacklinksPanelProps {
+    noteUid: string;
+    noteTitle: string;
+}
+
+const BacklinksPanel: React.FC<BacklinksPanelProps> = ({ noteUid, noteTitle }) => {
+    const [backlinks, setBacklinks] = useState<BacklinkNote[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+        fetchNoteBacklinks(noteUid)
+            .then((links) => {
+                if (!cancelled) setBacklinks(links);
+            })
+            .catch(() => {
+                if (!cancelled) setBacklinks([]);
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+        return () => { cancelled = true; };
+    }, [noteUid]);
+
+    if (loading) return null;
+    if (backlinks.length === 0) return null;
+
+    return (
+        <div className="mt-6 border-t border-gray-200 dark:border-gray-700 pt-4">
+            <div className="flex items-center gap-2 mb-3">
+                <LinkIcon className="h-4 w-4 text-gray-400 dark:text-gray-500" />
+                <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+                    Backlinks
+                    <span className="ml-1.5 text-gray-300 dark:text-gray-600 font-normal normal-case tracking-normal">
+                        — notes linking to &ldquo;{noteTitle}&rdquo;
+                    </span>
+                </h3>
+            </div>
+            <ul className="space-y-1">
+                {backlinks.map((link) => (
+                    <li key={link.uid}>
+                        <Link
+                            to={`/note/${link.uid}-${slugify(link.title)}`}
+                            className="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors group"
+                        >
+                            <span className="text-gray-300 dark:text-gray-600 group-hover:text-blue-400 text-xs">
+                                [[
+                            </span>
+                            <span className="flex-1 truncate font-medium">{link.title}</span>
+                            <span className="text-gray-300 dark:text-gray-600 group-hover:text-blue-400 text-xs">
+                                ]]
+                            </span>
+                        </Link>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+function slugify(text: string): string {
+    return text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+}
+
+export default BacklinksPanel;

--- a/frontend/components/Note/FormattingToolbar.tsx
+++ b/frontend/components/Note/FormattingToolbar.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+interface FormattingToolbarProps {
+    visible: boolean;
+    x: number;
+    y: number;
+    onBold: () => void;
+    onItalic: () => void;
+    onStrikethrough: () => void;
+    onCode: () => void;
+    onLink: () => void;
+    onHeading: (level: number) => void;
+}
+
+interface ToolbarBtnProps {
+    onClick: () => void;
+    title: string;
+    children: React.ReactNode;
+    style?: React.CSSProperties;
+}
+
+const ToolbarBtn: React.FC<ToolbarBtnProps> = ({ onClick, title, children, style }) => (
+    <button
+        type="button"
+        title={title}
+        onClick={onClick}
+        style={style}
+        className="px-1.5 py-0.5 rounded text-xs text-gray-200 hover:text-white hover:bg-gray-600 transition-colors min-w-[22px] text-center"
+    >
+        {children}
+    </button>
+);
+
+const Divider: React.FC = () => (
+    <div className="w-px h-4 bg-gray-600 mx-0.5 flex-shrink-0" />
+);
+
+const TOOLBAR_HEIGHT = 36;
+const GAP = 6;
+
+const FormattingToolbar: React.FC<FormattingToolbarProps> = ({
+    visible,
+    x,
+    y,
+    onBold,
+    onItalic,
+    onStrikethrough,
+    onCode,
+    onLink,
+    onHeading,
+}) => {
+    if (!visible) return null;
+
+    return ReactDOM.createPortal(
+        <div
+            className="fixed z-[200] flex items-center gap-0.5 px-1.5 py-1 rounded-lg shadow-xl bg-gray-800 border border-gray-700"
+            style={{
+                left: x,
+                top: y - TOOLBAR_HEIGHT - GAP,
+                transform: 'translateX(-50%)',
+                pointerEvents: 'auto',
+            }}
+            onMouseDown={(e) => e.preventDefault()}
+        >
+            <ToolbarBtn onClick={onBold} title="Bold" style={{ fontWeight: 700 }}>
+                B
+            </ToolbarBtn>
+            <ToolbarBtn onClick={onItalic} title="Italic" style={{ fontStyle: 'italic' }}>
+                I
+            </ToolbarBtn>
+            <ToolbarBtn onClick={onStrikethrough} title="Strikethrough" style={{ textDecoration: 'line-through' }}>
+                S
+            </ToolbarBtn>
+            <ToolbarBtn onClick={onCode} title="Inline code" style={{ fontFamily: 'monospace' }}>
+                `
+            </ToolbarBtn>
+            <Divider />
+            <ToolbarBtn onClick={() => onHeading(1)} title="Heading 1">
+                H1
+            </ToolbarBtn>
+            <ToolbarBtn onClick={() => onHeading(2)} title="Heading 2">
+                H2
+            </ToolbarBtn>
+            <ToolbarBtn onClick={() => onHeading(3)} title="Heading 3">
+                H3
+            </ToolbarBtn>
+            <Divider />
+            <ToolbarBtn onClick={onLink} title="Link">
+                🔗
+            </ToolbarBtn>
+        </div>,
+        document.body
+    );
+};
+
+export default FormattingToolbar;

--- a/frontend/components/Note/MarkdownEditor.tsx
+++ b/frontend/components/Note/MarkdownEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { EditorView, ViewUpdate, keymap, placeholder as cmPlaceholder } from '@codemirror/view';
 import { EditorState, Compartment } from '@codemirror/state';
 import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
@@ -6,6 +6,10 @@ import { history, defaultKeymap, historyKeymap } from '@codemirror/commands';
 import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language';
 import { oneDark } from '@codemirror/theme-one-dark';
 import FormattingToolbar from './FormattingToolbar';
+import SlashCommandMenu from './SlashCommandMenu';
+import WikilinkMenu, { NoteTitle } from './WikilinkMenu';
+import { livePreviewExtension } from './livePreviewExtension';
+import { useStore } from '../../store/useStore';
 
 interface MarkdownEditorProps {
     value: string;
@@ -86,6 +90,75 @@ const baseEditorTheme = EditorView.theme({
     '.cm-cursor, .cm-dropCursor': { borderLeftWidth: '2px' },
 });
 
+interface SlashMenuState {
+    open: boolean;
+    x: number;
+    y: number;
+    filter: string;
+    from: number;
+    to: number;
+}
+
+interface WikilinkMenuState {
+    open: boolean;
+    x: number;
+    y: number;
+    filter: string;
+    from: number;
+    to: number;
+}
+
+const CLOSED_SLASH: SlashMenuState = { open: false, x: 0, y: 0, filter: '', from: 0, to: 0 };
+const CLOSED_WIKI: WikilinkMenuState = { open: false, x: 0, y: 0, filter: '', from: 0, to: 0 };
+
+function detectSlashTrigger(
+    view: EditorView
+): { from: number; to: number; filter: string; coords: { x: number; y: number } } | null {
+    const { main } = view.state.selection;
+    if (!main.empty) return null;
+
+    const cursor = main.from;
+    const line = view.state.doc.lineAt(cursor);
+    const textToCursor = line.text.slice(0, cursor - line.from);
+
+    // Match /command at start-of-line or after whitespace
+    const m = textToCursor.match(/(?:^|(?<=\s))\/([a-z0-9-]*)$/i);
+    if (!m) return null;
+
+    const slashRelPos = textToCursor.length - 1 - m[1].length;
+    const slashAbsPos = line.from + slashRelPos;
+    const filter = m[1];
+
+    const coords = view.coordsAtPos(cursor);
+    if (!coords) return null;
+
+    return { from: slashAbsPos, to: cursor, filter, coords: { x: coords.left, y: coords.top } };
+}
+
+function detectWikilinkTrigger(
+    view: EditorView
+): { from: number; to: number; filter: string; coords: { x: number; y: number } } | null {
+    const { main } = view.state.selection;
+    if (!main.empty) return null;
+
+    const cursor = main.from;
+    const line = view.state.doc.lineAt(cursor);
+    const textToCursor = line.text.slice(0, cursor - line.from);
+
+    // Match [[ possibly followed by partial title text (no ]] yet)
+    const m = textToCursor.match(/\[\[([^[\]]*)$/);
+    if (!m) return null;
+
+    const openBracketRelPos = textToCursor.length - 2 - m[1].length;
+    const openBracketAbsPos = line.from + openBracketRelPos;
+    const filter = m[1];
+
+    const coords = view.coordsAtPos(cursor);
+    if (!coords) return null;
+
+    return { from: openBracketAbsPos, to: cursor, filter, coords: { x: coords.left, y: coords.top } };
+}
+
 const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     value,
     onChange,
@@ -101,14 +174,39 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
     const onChangeRef = useRef(onChange);
     onChangeRef.current = onChange;
 
+    // Load notes from store for wikilink autocomplete
+    const storeNotes = useStore((state) => state.notesStore.notes);
+    const hasNotesLoaded = useStore((state) => state.notesStore.hasLoaded);
+    const loadNotes = useStore((state) => state.notesStore.loadNotes);
+
+    useEffect(() => {
+        if (!hasNotesLoaded) loadNotes();
+    }, [hasNotesLoaded, loadNotes]);
+
+    const noteTitles: NoteTitle[] = useMemo(
+        () => storeNotes.filter((n) => n.uid).map((n) => ({ uid: n.uid as string, title: n.title })),
+        [storeNotes]
+    );
+
     const [toolbarState, setToolbarState] = useState<{
         visible: boolean;
         x: number;
         y: number;
     }>({ visible: false, x: 0, y: 0 });
 
+    const [slashMenu, setSlashMenu] = useState<SlashMenuState>(CLOSED_SLASH);
+    const [wikilinkMenu, setWikilinkMenu] = useState<WikilinkMenuState>(CLOSED_WIKI);
+
+    const slashMenuRef = useRef(slashMenu);
+    slashMenuRef.current = slashMenu;
+    const wikilinkMenuRef = useRef(wikilinkMenu);
+    wikilinkMenuRef.current = wikilinkMenu;
+
     const lightText = shouldUseLightText(noteColor);
     const textColor = noteColor ? (lightText ? '#ffffff' : '#333333') : undefined;
+
+    const closeSlash = useCallback(() => setSlashMenu(CLOSED_SLASH), []);
+    const closeWikilink = useCallback(() => setWikilinkMenu(CLOSED_WIKI), []);
 
     useEffect(() => {
         if (!containerRef.current) return;
@@ -138,15 +236,19 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
                 baseEditorTheme,
                 themeCompartment.of(getThemeExtension()),
                 colorOverride,
+                livePreviewExtension,
                 EditorView.updateListener.of((update: ViewUpdate) => {
                     if (update.docChanged) {
                         onChangeRef.current(update.state.doc.toString());
                     }
 
+                    const view = update.view;
+
+                    // Formatting toolbar (on selection)
                     const { main } = update.state.selection;
                     if (!main.empty) {
-                        const fromCoords = update.view.coordsAtPos(main.from);
-                        const toCoords = update.view.coordsAtPos(main.to);
+                        const fromCoords = view.coordsAtPos(main.from);
+                        const toCoords = view.coordsAtPos(main.to);
                         if (fromCoords && toCoords) {
                             const midX = (fromCoords.left + toCoords.right) / 2;
                             const topY = Math.min(fromCoords.top, toCoords.top);
@@ -157,6 +259,37 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
                         }
                     } else {
                         setToolbarState((prev) => (prev.visible ? { ...prev, visible: false } : prev));
+                    }
+
+                    // Slash command trigger detection
+                    const slashTrigger = detectSlashTrigger(view);
+                    if (slashTrigger) {
+                        setSlashMenu({
+                            open: true,
+                            x: slashTrigger.coords.x,
+                            y: slashTrigger.coords.y,
+                            filter: slashTrigger.filter,
+                            from: slashTrigger.from,
+                            to: slashTrigger.to,
+                        });
+                        setWikilinkMenu(CLOSED_WIKI);
+                    } else {
+                        if (slashMenuRef.current.open) setSlashMenu(CLOSED_SLASH);
+
+                        // Wikilink trigger detection (only when slash not active)
+                        const wikilinkTrigger = detectWikilinkTrigger(view);
+                        if (wikilinkTrigger) {
+                            setWikilinkMenu({
+                                open: true,
+                                x: wikilinkTrigger.coords.x,
+                                y: wikilinkTrigger.coords.y,
+                                filter: wikilinkTrigger.filter,
+                                from: wikilinkTrigger.from,
+                                to: wikilinkTrigger.to,
+                            });
+                        } else {
+                            if (wikilinkMenuRef.current.open) setWikilinkMenu(CLOSED_WIKI);
+                        }
                     }
                 }),
             ],
@@ -169,7 +302,6 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
             setTimeout(() => view.focus(), 50);
         }
 
-        // Watch for dark mode class changes and reconfigure theme
         const observer = new MutationObserver(() => {
             view.dispatch({ effects: themeCompartment.reconfigure(getThemeExtension()) });
         });
@@ -219,6 +351,29 @@ const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
                 onLink={handleLink}
                 onHeading={handleHeading}
             />
+            {slashMenu.open && viewRef.current && (
+                <SlashCommandMenu
+                    x={slashMenu.x}
+                    y={slashMenu.y}
+                    filter={slashMenu.filter}
+                    slashFrom={slashMenu.from}
+                    slashTo={slashMenu.to}
+                    view={viewRef.current}
+                    onClose={closeSlash}
+                />
+            )}
+            {wikilinkMenu.open && viewRef.current && (
+                <WikilinkMenu
+                    x={wikilinkMenu.x}
+                    y={wikilinkMenu.y}
+                    filter={wikilinkMenu.filter}
+                    triggerFrom={wikilinkMenu.from}
+                    triggerTo={wikilinkMenu.to}
+                    view={viewRef.current}
+                    noteTitles={noteTitles}
+                    onClose={closeWikilink}
+                />
+            )}
         </div>
     );
 };

--- a/frontend/components/Note/MarkdownEditor.tsx
+++ b/frontend/components/Note/MarkdownEditor.tsx
@@ -1,0 +1,226 @@
+import React, { useEffect, useRef, useState, useCallback } from 'react';
+import { EditorView, ViewUpdate, keymap, placeholder as cmPlaceholder } from '@codemirror/view';
+import { EditorState, Compartment } from '@codemirror/state';
+import { markdown, markdownLanguage } from '@codemirror/lang-markdown';
+import { history, defaultKeymap, historyKeymap } from '@codemirror/commands';
+import { syntaxHighlighting, defaultHighlightStyle } from '@codemirror/language';
+import { oneDark } from '@codemirror/theme-one-dark';
+import FormattingToolbar from './FormattingToolbar';
+
+interface MarkdownEditorProps {
+    value: string;
+    onChange: (value: string) => void;
+    placeholder?: string;
+    noteColor?: string;
+    autoFocus?: boolean;
+    className?: string;
+    minHeight?: string;
+    onClick?: (e: React.MouseEvent) => void;
+}
+
+const shouldUseLightText = (hexColor: string | undefined): boolean => {
+    if (!hexColor) return false;
+    const hex = hexColor.replace('#', '');
+    const r = parseInt(hex.substring(0, 2), 16);
+    const g = parseInt(hex.substring(2, 4), 16);
+    const b = parseInt(hex.substring(4, 6), 16);
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    return luminance < 0.4;
+};
+
+export function wrapSelection(view: EditorView, prefix: string, suffix: string = prefix) {
+    const { from, to } = view.state.selection.main;
+    const selected = view.state.sliceDoc(from, to);
+    if (selected.startsWith(prefix) && selected.endsWith(suffix) && selected.length > prefix.length + suffix.length) {
+        view.dispatch({
+            changes: { from, to, insert: selected.slice(prefix.length, selected.length - suffix.length) },
+            selection: { anchor: from, head: to - prefix.length - suffix.length },
+        });
+    } else {
+        view.dispatch({
+            changes: { from, to, insert: `${prefix}${selected}${suffix}` },
+            selection: { anchor: from, head: to + prefix.length + suffix.length },
+        });
+    }
+    view.focus();
+}
+
+export function setHeading(view: EditorView, level: number) {
+    const prefix = '#'.repeat(level) + ' ';
+    const { from } = view.state.selection.main;
+    const line = view.state.doc.lineAt(from);
+    const existing = line.text.match(/^(#{1,6})\s/);
+    if (existing) {
+        view.dispatch({
+            changes: { from: line.from, to: line.from + existing[0].length, insert: prefix },
+        });
+    } else {
+        view.dispatch({
+            changes: { from: line.from, to: line.from, insert: prefix },
+        });
+    }
+    view.focus();
+}
+
+export function insertLink(view: EditorView) {
+    const { from, to } = view.state.selection.main;
+    const selected = view.state.sliceDoc(from, to);
+    const insertion = selected ? `[${selected}](url)` : '[link text](url)';
+    view.dispatch({ changes: { from, to, insert: insertion } });
+    view.focus();
+}
+
+const baseEditorTheme = EditorView.theme({
+    '&': { fontSize: 'inherit' },
+    '&.cm-focused': { outline: 'none' },
+    '.cm-content': {
+        fontFamily: 'inherit',
+        fontSize: 'inherit',
+        lineHeight: '1.7',
+        padding: '4px 0',
+    },
+    '.cm-line': { padding: '0 2px' },
+    '.cm-scroller': { fontFamily: 'inherit', overflow: 'visible' },
+    '.cm-selectionBackground': { backgroundColor: 'rgba(59, 130, 246, 0.25) !important' },
+    '&.cm-focused .cm-selectionBackground': { backgroundColor: 'rgba(59, 130, 246, 0.35) !important' },
+    '.cm-cursor, .cm-dropCursor': { borderLeftWidth: '2px' },
+});
+
+const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
+    value,
+    onChange,
+    placeholder = 'Write your note here... (Markdown supported)',
+    noteColor,
+    autoFocus = false,
+    className = '',
+    minHeight = '300px',
+    onClick,
+}) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const viewRef = useRef<EditorView | null>(null);
+    const onChangeRef = useRef(onChange);
+    onChangeRef.current = onChange;
+
+    const [toolbarState, setToolbarState] = useState<{
+        visible: boolean;
+        x: number;
+        y: number;
+    }>({ visible: false, x: 0, y: 0 });
+
+    const lightText = shouldUseLightText(noteColor);
+    const textColor = noteColor ? (lightText ? '#ffffff' : '#333333') : undefined;
+
+    useEffect(() => {
+        if (!containerRef.current) return;
+
+        const themeCompartment = new Compartment();
+
+        const getThemeExtension = () => {
+            const isDark = document.documentElement.classList.contains('dark');
+            return isDark ? oneDark : syntaxHighlighting(defaultHighlightStyle);
+        };
+
+        const colorOverride = noteColor
+            ? EditorView.theme({
+                  '.cm-content': { color: textColor, caretColor: textColor },
+                  '.cm-cursor, .cm-dropCursor': { borderLeftColor: textColor || 'auto' },
+              })
+            : [];
+
+        const state = EditorState.create({
+            doc: value,
+            extensions: [
+                markdown({ base: markdownLanguage }),
+                history(),
+                keymap.of([...defaultKeymap, ...historyKeymap]),
+                EditorView.lineWrapping,
+                cmPlaceholder(placeholder),
+                baseEditorTheme,
+                themeCompartment.of(getThemeExtension()),
+                colorOverride,
+                EditorView.updateListener.of((update: ViewUpdate) => {
+                    if (update.docChanged) {
+                        onChangeRef.current(update.state.doc.toString());
+                    }
+
+                    const { main } = update.state.selection;
+                    if (!main.empty) {
+                        const fromCoords = update.view.coordsAtPos(main.from);
+                        const toCoords = update.view.coordsAtPos(main.to);
+                        if (fromCoords && toCoords) {
+                            const midX = (fromCoords.left + toCoords.right) / 2;
+                            const topY = Math.min(fromCoords.top, toCoords.top);
+                            setToolbarState((prev) => {
+                                if (prev.visible && Math.abs(prev.x - midX) < 1 && Math.abs(prev.y - topY) < 1) return prev;
+                                return { visible: true, x: midX, y: topY };
+                            });
+                        }
+                    } else {
+                        setToolbarState((prev) => (prev.visible ? { ...prev, visible: false } : prev));
+                    }
+                }),
+            ],
+        });
+
+        const view = new EditorView({ state, parent: containerRef.current });
+        viewRef.current = view;
+
+        if (autoFocus) {
+            setTimeout(() => view.focus(), 50);
+        }
+
+        // Watch for dark mode class changes and reconfigure theme
+        const observer = new MutationObserver(() => {
+            view.dispatch({ effects: themeCompartment.reconfigure(getThemeExtension()) });
+        });
+        observer.observe(document.documentElement, { attributeFilter: ['class'] });
+
+        return () => {
+            observer.disconnect();
+            view.destroy();
+            viewRef.current = null;
+        };
+    }, []); // Intentionally empty: CodeMirror view is created once on mount; value/onChange synced via refs/separate effects
+
+    // Sync external value changes (switching notes)
+    useEffect(() => {
+        const view = viewRef.current;
+        if (!view) return;
+        const current = view.state.doc.toString();
+        if (current !== value) {
+            view.dispatch({
+                changes: { from: 0, to: view.state.doc.length, insert: value ?? '' },
+            });
+        }
+    }, [value]);
+
+    const handleBold = useCallback(() => { if (viewRef.current) wrapSelection(viewRef.current, '**'); }, []);
+    const handleItalic = useCallback(() => { if (viewRef.current) wrapSelection(viewRef.current, '_'); }, []);
+    const handleStrikethrough = useCallback(() => { if (viewRef.current) wrapSelection(viewRef.current, '~~'); }, []);
+    const handleCode = useCallback(() => { if (viewRef.current) wrapSelection(viewRef.current, '`'); }, []);
+    const handleLink = useCallback(() => { if (viewRef.current) insertLink(viewRef.current); }, []);
+    const handleHeading = useCallback((level: number) => { if (viewRef.current) setHeading(viewRef.current, level); }, []);
+
+    return (
+        <div
+            className={`relative cm-editor-wrapper ${className}`}
+            style={{ minHeight }}
+            onClick={onClick}
+        >
+            <div ref={containerRef} className="w-full" />
+            <FormattingToolbar
+                visible={toolbarState.visible}
+                x={toolbarState.x}
+                y={toolbarState.y}
+                onBold={handleBold}
+                onItalic={handleItalic}
+                onStrikethrough={handleStrikethrough}
+                onCode={handleCode}
+                onLink={handleLink}
+                onHeading={handleHeading}
+            />
+        </div>
+    );
+};
+
+export default MarkdownEditor;

--- a/frontend/components/Note/NoteDetails.tsx
+++ b/frontend/components/Note/NoteDetails.tsx
@@ -12,6 +12,7 @@ import { useToast } from '../Shared/ToastContext';
 import ConfirmDialog from '../Shared/ConfirmDialog';
 import NoteModal from './NoteModal';
 import MarkdownRenderer from '../Shared/MarkdownRenderer';
+import BacklinksPanel from './BacklinksPanel';
 import { Note } from '../../entities/Note';
 import {
     fetchNoteBySlug,
@@ -304,6 +305,9 @@ const NoteDetails: React.FC = () => {
                             }
                         }}
                     />
+                    {note.uid && (
+                        <BacklinksPanel noteUid={note.uid} noteTitle={note.title} />
+                    )}
                 </div>
                 {/* NoteModal for editing */}
                 {isNoteModalOpen && (

--- a/frontend/components/Note/NoteFocusMode.tsx
+++ b/frontend/components/Note/NoteFocusMode.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import ReactDOM from 'react-dom';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import MarkdownRenderer from '../Shared/MarkdownRenderer';
+import MarkdownEditor from './MarkdownEditor';
 import { Note } from '../../entities/Note';
 import { ENABLE_NOTE_COLOR } from '../../config/featureFlags';
 
@@ -38,7 +39,6 @@ const NoteFocusMode: React.FC<NoteFocusModeProps> = ({
     onClose,
 }) => {
     const { t } = useTranslation();
-    const textareaRef = useRef<HTMLTextAreaElement>(null);
     const noteColor = ENABLE_NOTE_COLOR ? note.color : undefined;
     const lightText = shouldUseLightText(noteColor);
 
@@ -65,12 +65,6 @@ const NoteFocusMode: React.FC<NoteFocusModeProps> = ({
         document.addEventListener('keydown', handleKeyDown, true);
         return () => document.removeEventListener('keydown', handleKeyDown, true);
     }, [isEditing, onExitEditing, onClose]);
-
-    useEffect(() => {
-        if (isEditing && textareaRef.current) {
-            textareaRef.current.focus();
-        }
-    }, [isEditing]);
 
     const textColor = noteColor
         ? lightText
@@ -152,15 +146,14 @@ const NoteFocusMode: React.FC<NoteFocusModeProps> = ({
                                     paddingRight: 0,
                                 }}
                             />
-                            <textarea
-                                ref={textareaRef}
+                            <MarkdownEditor
                                 value={note.content || ''}
-                                onChange={(e) =>
-                                    onNoteChange({ content: e.target.value })
-                                }
+                                onChange={(val) => onNoteChange({ content: val })}
                                 placeholder={t('notes.contentPlaceholderFocus')}
-                                className="w-full h-full min-h-[60vh] bg-transparent text-gray-900 dark:text-gray-100 border-none focus:outline-none focus:ring-0 resize-none text-lg leading-relaxed"
-                                style={textColor ? { color: textColor } : undefined}
+                                noteColor={noteColor}
+                                autoFocus={isEditing}
+                                minHeight="60vh"
+                                className="text-lg"
                             />
                         </>
                     ) : (

--- a/frontend/components/Note/NoteModal.tsx
+++ b/frontend/components/Note/NoteModal.tsx
@@ -10,6 +10,7 @@ import { Project } from '../../entities/Project';
 import { useToast } from '../Shared/ToastContext';
 import TagInput from '../Tag/TagInput';
 import MarkdownRenderer from '../Shared/MarkdownRenderer';
+import MarkdownEditor from './MarkdownEditor';
 import { Tag } from '../../entities/Tag';
 import { useStore } from '../../store/useStore';
 import { useTranslation } from 'react-i18next';
@@ -576,21 +577,17 @@ const NoteModal: React.FC<NoteModalProps> = ({
                                                     </div>
 
                                                     {activeTab === 'edit' ? (
-                                                        <textarea
-                                                            id="noteContent"
-                                                            name="content"
-                                                            value={
-                                                                formData.content ||
-                                                                ''
-                                                            }
-                                                            onChange={
-                                                                handleChange
-                                                            }
-                                                            className="block w-full h-full min-h-0 sm:border sm:border-gray-300 sm:dark:border-gray-600 sm:rounded-md shadow-sm py-2 sm:py-3 px-3 sm:px-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 sm:focus:ring-2 sm:focus:ring-blue-500 transition duration-150 ease-in-out resize-none"
-                                                            placeholder={t('notes.contentPlaceholderMarkdown')}
-                                                            autoComplete="off"
-                                                            data-testid="note-content-textarea"
-                                                        />
+                                                        <div className="block w-full h-full min-h-0 sm:border sm:border-gray-300 sm:dark:border-gray-600 sm:rounded-md shadow-sm py-2 sm:py-3 px-3 text-sm bg-white dark:bg-gray-900">
+                                                            <MarkdownEditor
+                                                                value={formData.content || ''}
+                                                                onChange={(val) =>
+                                                                    setFormData((prev) => ({ ...prev, content: val }))
+                                                                }
+                                                                placeholder={t('notes.contentPlaceholderMarkdown')}
+                                                                minHeight="200px"
+                                                                data-testid="note-content-textarea"
+                                                            />
+                                                        </div>
                                                     ) : (
                                                         <div className="block w-full h-full min-h-0 sm:border sm:border-gray-300 sm:dark:border-gray-600 sm:rounded-md shadow-sm py-2 px-3 sm:py-3 sm:px-3 text-sm bg-gray-50 dark:bg-gray-800 overflow-y-auto">
                                                             {formData.content ? (

--- a/frontend/components/Note/NoteModal.tsx
+++ b/frontend/components/Note/NoteModal.tsx
@@ -578,7 +578,7 @@ const NoteModal: React.FC<NoteModalProps> = ({
                                                     </div>
 
                                                     {activeTab === 'edit' ? (
-                                                        <div className="block w-full h-full min-h-0 sm:border sm:border-gray-300 sm:dark:border-gray-600 sm:rounded-md shadow-sm py-2 sm:py-3 px-3 text-sm bg-white dark:bg-gray-900">
+                                                        <div className="block w-full min-h-[200px] sm:border sm:border-gray-300 sm:dark:border-gray-600 sm:rounded-md shadow-sm py-2 sm:py-3 px-3 text-sm bg-white dark:bg-gray-900">
                                                             <MarkdownEditor
                                                                 value={formData.content || ''}
                                                                 onChange={(val) =>
@@ -590,7 +590,7 @@ const NoteModal: React.FC<NoteModalProps> = ({
                                                             />
                                                         </div>
                                                     ) : (
-                                                        <div className="block w-full h-full min-h-0 sm:border sm:border-gray-300 sm:dark:border-gray-600 sm:rounded-md shadow-sm py-2 px-3 sm:py-3 sm:px-3 text-sm bg-gray-50 dark:bg-gray-800 overflow-y-auto">
+                                                        <div className="block w-full min-h-[200px] sm:border sm:border-gray-300 sm:dark:border-gray-600 sm:rounded-md shadow-sm py-2 sm:py-3 px-3 text-sm bg-white dark:bg-gray-900">
                                                             {formData.content ? (
                                                                 <MarkdownRenderer
                                                                     content={

--- a/frontend/components/Note/NoteModal.tsx
+++ b/frontend/components/Note/NoteModal.tsx
@@ -48,6 +48,7 @@ const NoteModal: React.FC<NoteModalProps> = ({
     const { tagsStore } = useStore();
     const availableTagsStore = tagsStore.getTags();
     const { addNewTags } = tagsStore;
+
     const [formData, setFormData] = useState<Note>(
         note || {
             title: '',

--- a/frontend/components/Note/SlashCommandMenu.tsx
+++ b/frontend/components/Note/SlashCommandMenu.tsx
@@ -1,0 +1,309 @@
+import React, { useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { EditorView } from '@codemirror/view';
+
+export interface SlashCommand {
+    id: string;
+    label: string;
+    description: string;
+    keywords: string[];
+    icon: string;
+    insert: (view: EditorView, from: number, to: number) => void;
+}
+
+function makeInserter(text: string, cursorOffset = 0) {
+    return (view: EditorView, from: number, to: number) => {
+        view.dispatch({
+            changes: { from, to, insert: text },
+            selection: { anchor: from + text.length + cursorOffset },
+        });
+        view.focus();
+    };
+}
+
+export const SLASH_COMMANDS: SlashCommand[] = [
+    {
+        id: 'h1',
+        label: 'Heading 1',
+        description: 'Large section heading',
+        keywords: ['h1', 'heading', 'heading1', 'title'],
+        icon: 'H1',
+        insert: makeInserter('# '),
+    },
+    {
+        id: 'h2',
+        label: 'Heading 2',
+        description: 'Medium section heading',
+        keywords: ['h2', 'heading', 'heading2', 'subtitle'],
+        icon: 'H2',
+        insert: makeInserter('## '),
+    },
+    {
+        id: 'h3',
+        label: 'Heading 3',
+        description: 'Small section heading',
+        keywords: ['h3', 'heading', 'heading3'],
+        icon: 'H3',
+        insert: makeInserter('### '),
+    },
+    {
+        id: 'bold',
+        label: 'Bold',
+        description: 'Bold text',
+        keywords: ['bold', 'strong', 'b'],
+        icon: 'B',
+        insert: makeInserter('****', -2),
+    },
+    {
+        id: 'italic',
+        label: 'Italic',
+        description: 'Italic text',
+        keywords: ['italic', 'em', 'i'],
+        icon: 'I',
+        insert: makeInserter('__', -1),
+    },
+    {
+        id: 'strikethrough',
+        label: 'Strikethrough',
+        description: 'Strike through text',
+        keywords: ['strikethrough', 'strike', 'del'],
+        icon: 'S̶',
+        insert: makeInserter('~~~~', -2),
+    },
+    {
+        id: 'code',
+        label: 'Inline Code',
+        description: 'Inline code snippet',
+        keywords: ['code', 'inline', 'mono'],
+        icon: '`',
+        insert: makeInserter('``', -1),
+    },
+    {
+        id: 'codeblock',
+        label: 'Code Block',
+        description: 'Fenced code block',
+        keywords: ['codeblock', 'fence', 'pre'],
+        icon: '{}',
+        insert: makeInserter('```\n\n```', -4),
+    },
+    {
+        id: 'quote',
+        label: 'Quote',
+        description: 'Block quote',
+        keywords: ['quote', 'blockquote', 'bq'],
+        icon: '❝',
+        insert: makeInserter('> '),
+    },
+    {
+        id: 'checklist',
+        label: 'To-do',
+        description: 'Checkbox task item',
+        keywords: ['todo', 'checklist', 'task', 'checkbox'],
+        icon: '☐',
+        insert: makeInserter('- [ ] '),
+    },
+    {
+        id: 'list',
+        label: 'Bulleted List',
+        description: 'Unordered list item',
+        keywords: ['list', 'ul', 'bullet', 'item'],
+        icon: '•',
+        insert: makeInserter('- '),
+    },
+    {
+        id: 'ordered',
+        label: 'Numbered List',
+        description: 'Ordered list item',
+        keywords: ['ordered', 'ol', 'numbered', 'number'],
+        icon: '1.',
+        insert: makeInserter('1. '),
+    },
+    {
+        id: 'divider',
+        label: 'Divider',
+        description: 'Horizontal rule',
+        keywords: ['divider', 'hr', 'rule', 'separator'],
+        icon: '—',
+        insert: makeInserter('\n---\n'),
+    },
+    {
+        id: 'link',
+        label: 'Link',
+        description: 'Hyperlink',
+        keywords: ['link', 'url', 'href', 'a'],
+        icon: '🔗',
+        insert: makeInserter('[](url)', -4),
+    },
+    {
+        id: 'wikilink',
+        label: 'Note Link',
+        description: 'Link to another note',
+        keywords: ['wikilink', 'notelink', 'note', 'wiki', 'internal'],
+        icon: '[[]]',
+        insert: makeInserter('[[]]', -2),
+    },
+    {
+        id: 'callout-note',
+        label: 'Callout: Note',
+        description: 'Informational callout',
+        keywords: ['callout', 'note', 'info'],
+        icon: 'ℹ',
+        insert: makeInserter('> [!NOTE]\n> '),
+    },
+    {
+        id: 'callout-tip',
+        label: 'Callout: Tip',
+        description: 'Tip callout',
+        keywords: ['callout', 'tip'],
+        icon: '💡',
+        insert: makeInserter('> [!TIP]\n> '),
+    },
+    {
+        id: 'callout-warning',
+        label: 'Callout: Warning',
+        description: 'Warning callout',
+        keywords: ['callout', 'warning', 'warn'],
+        icon: '⚠',
+        insert: makeInserter('> [!WARNING]\n> '),
+    },
+    {
+        id: 'callout-important',
+        label: 'Callout: Important',
+        description: 'Important callout',
+        keywords: ['callout', 'important'],
+        icon: '❗',
+        insert: makeInserter('> [!IMPORTANT]\n> '),
+    },
+    {
+        id: 'callout-danger',
+        label: 'Callout: Danger',
+        description: 'Danger callout',
+        keywords: ['callout', 'danger', 'error'],
+        icon: '🚨',
+        insert: makeInserter('> [!DANGER]\n> '),
+    },
+];
+
+function filterCommands(filter: string): SlashCommand[] {
+    if (!filter) return SLASH_COMMANDS;
+    const q = filter.toLowerCase();
+    return SLASH_COMMANDS.filter(
+        (cmd) =>
+            cmd.label.toLowerCase().includes(q) ||
+            cmd.keywords.some((k) => k.includes(q))
+    );
+}
+
+interface SlashCommandMenuProps {
+    x: number;
+    y: number;
+    filter: string;
+    slashFrom: number;
+    slashTo: number;
+    view: EditorView;
+    onClose: () => void;
+}
+
+const SlashCommandMenu: React.FC<SlashCommandMenuProps> = ({
+    x,
+    y,
+    filter,
+    slashFrom,
+    slashTo,
+    view,
+    onClose,
+}) => {
+    const commands = filterCommands(filter);
+    const [activeIndex, setActiveIndex] = useState(0);
+    const listRef = useRef<HTMLDivElement>(null);
+    const activeItemRef = useRef<HTMLButtonElement | null>(null);
+
+    // Clamp activeIndex when filtered list shrinks
+    const clampedIndex = Math.min(activeIndex, Math.max(0, commands.length - 1));
+
+    useEffect(() => {
+        setActiveIndex(0);
+    }, [filter]);
+
+    useEffect(() => {
+        activeItemRef.current?.scrollIntoView({ block: 'nearest' });
+    }, [clampedIndex]);
+
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                onClose();
+                return;
+            }
+            if (commands.length === 0) return;
+
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setActiveIndex((i) => (i + 1) % commands.length);
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setActiveIndex((i) => (i - 1 + commands.length) % commands.length);
+            } else if (e.key === 'Enter' || e.key === 'Tab') {
+                e.preventDefault();
+                const cmd = commands[clampedIndex];
+                if (cmd) {
+                    cmd.insert(view, slashFrom, slashTo);
+                    onClose();
+                }
+            }
+        };
+        window.addEventListener('keydown', handler, true);
+        return () => window.removeEventListener('keydown', handler, true);
+    }, [commands, clampedIndex, view, slashFrom, slashTo, onClose]);
+
+    if (commands.length === 0) return null;
+
+    // Position: prefer below cursor, flip up if near bottom
+    const MENU_HEIGHT = Math.min(commands.length, 8) * 44;
+    const spaceBelow = window.innerHeight - y;
+    const top = spaceBelow > MENU_HEIGHT + 16 ? y + 4 : y - MENU_HEIGHT - 4;
+
+    return ReactDOM.createPortal(
+        <div
+            ref={listRef}
+            className="fixed z-[300] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-xl overflow-y-auto"
+            style={{ left: x, top, minWidth: 220, maxWidth: 320, maxHeight: 352 }}
+            onMouseDown={(e) => e.preventDefault()}
+        >
+            {commands.map((cmd, i) => (
+                <button
+                    key={cmd.id}
+                    ref={i === clampedIndex ? activeItemRef : null}
+                    type="button"
+                    className={`w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors ${
+                        i === clampedIndex
+                            ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+                            : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                    }`}
+                    onMouseDown={(e) => {
+                        e.preventDefault();
+                        cmd.insert(view, slashFrom, slashTo);
+                        onClose();
+                    }}
+                    onMouseEnter={() => setActiveIndex(i)}
+                >
+                    <span className="flex-shrink-0 w-7 h-7 flex items-center justify-center rounded text-xs font-mono bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300">
+                        {cmd.icon}
+                    </span>
+                    <span className="flex-1 min-w-0">
+                        <span className="block text-sm font-medium leading-tight">
+                            {cmd.label}
+                        </span>
+                        <span className="block text-xs text-gray-500 dark:text-gray-400 leading-tight">
+                            {cmd.description}
+                        </span>
+                    </span>
+                </button>
+            ))}
+        </div>,
+        document.body
+    );
+};
+
+export default SlashCommandMenu;

--- a/frontend/components/Note/WikilinkMenu.tsx
+++ b/frontend/components/Note/WikilinkMenu.tsx
@@ -1,0 +1,146 @@
+import React, { useEffect, useRef, useState } from 'react';
+import ReactDOM from 'react-dom';
+import { EditorView } from '@codemirror/view';
+
+export interface NoteTitle {
+    uid: string;
+    title: string;
+}
+
+interface WikilinkMenuProps {
+    x: number;
+    y: number;
+    filter: string;
+    triggerFrom: number;
+    triggerTo: number;
+    view: EditorView;
+    noteTitles: NoteTitle[];
+    onClose: () => void;
+}
+
+function filterNotes(notes: NoteTitle[], filter: string): NoteTitle[] {
+    if (!filter) return notes.slice(0, 10);
+    const q = filter.toLowerCase();
+    return notes
+        .filter((n) => n.title.toLowerCase().includes(q))
+        .slice(0, 10);
+}
+
+const WikilinkMenu: React.FC<WikilinkMenuProps> = ({
+    x,
+    y,
+    filter,
+    triggerFrom,
+    triggerTo,
+    view,
+    noteTitles,
+    onClose,
+}) => {
+    const matches = filterNotes(noteTitles, filter);
+    const [activeIndex, setActiveIndex] = useState(0);
+    const activeItemRef = useRef<HTMLButtonElement | null>(null);
+
+    const clampedIndex = Math.min(activeIndex, Math.max(0, matches.length - 1));
+
+    useEffect(() => {
+        setActiveIndex(0);
+    }, [filter]);
+
+    useEffect(() => {
+        activeItemRef.current?.scrollIntoView({ block: 'nearest' });
+    }, [clampedIndex]);
+
+    useEffect(() => {
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                e.preventDefault();
+                onClose();
+                return;
+            }
+            if (matches.length === 0) return;
+
+            if (e.key === 'ArrowDown') {
+                e.preventDefault();
+                setActiveIndex((i) => (i + 1) % matches.length);
+            } else if (e.key === 'ArrowUp') {
+                e.preventDefault();
+                setActiveIndex((i) => (i - 1 + matches.length) % matches.length);
+            } else if (e.key === 'Enter' || e.key === 'Tab') {
+                e.preventDefault();
+                const note = matches[clampedIndex];
+                if (note) {
+                    insertWikilink(note.title, view, triggerFrom, triggerTo);
+                    onClose();
+                }
+            }
+        };
+        window.addEventListener('keydown', handler, true);
+        return () => window.removeEventListener('keydown', handler, true);
+    }, [matches, clampedIndex, view, triggerFrom, triggerTo, onClose]);
+
+    if (matches.length === 0 && !filter) return null;
+
+    const MENU_HEIGHT = Math.min(matches.length, 8) * 40;
+    const spaceBelow = window.innerHeight - y;
+    const top = spaceBelow > MENU_HEIGHT + 16 ? y + 4 : y - MENU_HEIGHT - 4;
+
+    return ReactDOM.createPortal(
+        <div
+            className="fixed z-[300] bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-xl overflow-y-auto"
+            style={{ left: x, top, minWidth: 200, maxWidth: 320, maxHeight: 320 }}
+            onMouseDown={(e) => e.preventDefault()}
+        >
+            {matches.length === 0 ? (
+                <div className="px-3 py-2.5 text-sm text-gray-400 dark:text-gray-500">
+                    No matching notes
+                </div>
+            ) : (
+                matches.map((note, i) => (
+                    <button
+                        key={note.uid}
+                        ref={i === clampedIndex ? activeItemRef : null}
+                        type="button"
+                        className={`w-full flex items-center gap-2 px-3 py-2 text-left transition-colors ${
+                            i === clampedIndex
+                                ? 'bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300'
+                                : 'text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700'
+                        }`}
+                        onMouseDown={(e) => {
+                            e.preventDefault();
+                            insertWikilink(note.title, view, triggerFrom, triggerTo);
+                            onClose();
+                        }}
+                        onMouseEnter={() => setActiveIndex(i)}
+                    >
+                        <span className="text-gray-400 dark:text-gray-500 text-xs">
+                            [[
+                        </span>
+                        <span className="flex-1 text-sm font-medium truncate">
+                            {note.title}
+                        </span>
+                        <span className="text-gray-400 dark:text-gray-500 text-xs">
+                            ]]
+                        </span>
+                    </button>
+                ))
+            )}
+        </div>,
+        document.body
+    );
+};
+
+function insertWikilink(
+    title: string,
+    view: EditorView,
+    from: number,
+    to: number
+) {
+    const insertion = `[[${title}]]`;
+    view.dispatch({
+        changes: { from, to, insert: insertion },
+        selection: { anchor: from + insertion.length },
+    });
+    view.focus();
+}
+
+export default WikilinkMenu;

--- a/frontend/components/Note/livePreviewExtension.ts
+++ b/frontend/components/Note/livePreviewExtension.ts
@@ -1,0 +1,271 @@
+import {
+    EditorView,
+    ViewPlugin,
+    ViewUpdate,
+    Decoration,
+    DecorationSet,
+    WidgetType,
+} from '@codemirror/view';
+import { RangeSetBuilder } from '@codemirror/state';
+
+
+const HEADING_CLASSES = [
+    'cm-preview-h1',
+    'cm-preview-h2',
+    'cm-preview-h3',
+    'cm-preview-h4',
+    'cm-preview-h5',
+    'cm-preview-h6',
+];
+
+function isCursorOnLine(view: EditorView, from: number, to: number): boolean {
+    return view.state.selection.ranges.some(
+        (r) => r.from <= to && r.to >= from
+    );
+}
+
+class HRWidget extends WidgetType {
+    toDOM(): HTMLElement {
+        const el = document.createElement('div');
+        el.className = 'cm-preview-hr';
+        return el;
+    }
+    eq(): boolean {
+        return true;
+    }
+    ignoreEvent(): boolean {
+        return true;
+    }
+}
+
+interface DecoRange {
+    from: number;
+    to: number;
+    deco: Decoration;
+}
+
+function collectInlineDecos(text: string, lineFrom: number): DecoRange[] {
+    const ranges: DecoRange[] = [];
+    const claimed = new Uint8Array(text.length + 1);
+
+    function canClaim(start: number, end: number): boolean {
+        for (let i = start; i < end; i++) {
+            if (claimed[i]) return false;
+        }
+        return true;
+    }
+
+    function claimRange(start: number, end: number) {
+        for (let i = start; i < end; i++) claimed[i] = 1;
+    }
+
+    function applyPattern(
+        regex: RegExp,
+        markerLen: number,
+        cssClass: string
+    ) {
+        let m: RegExpExecArray | null;
+        regex.lastIndex = 0;
+        while ((m = regex.exec(text)) !== null) {
+            const start = m.index;
+            const end = start + m[0].length;
+            const contentLen = end - start - markerLen * 2;
+            if (contentLen <= 0) continue;
+            if (!canClaim(start, end)) continue;
+            claimRange(start, end);
+
+            ranges.push({
+                from: lineFrom + start,
+                to: lineFrom + start + markerLen,
+                deco: Decoration.replace({}),
+            });
+            ranges.push({
+                from: lineFrom + start + markerLen,
+                to: lineFrom + end - markerLen,
+                deco: Decoration.mark({ class: cssClass }),
+            });
+            ranges.push({
+                from: lineFrom + end - markerLen,
+                to: lineFrom + end,
+                deco: Decoration.replace({}),
+            });
+        }
+    }
+
+    // Process longer/higher-priority markers first to prevent partial overlap
+    applyPattern(/\*\*([^*\n]+?)\*\*/g, 2, 'cm-preview-bold');
+    applyPattern(/__([^_\n]+?)__/g, 2, 'cm-preview-bold');
+    applyPattern(/~~([^\n]+?)~~/g, 2, 'cm-preview-strikethrough');
+    applyPattern(/`([^`\n]+?)`/g, 1, 'cm-preview-inline-code');
+    applyPattern(/(?<!\*)\*(?!\*)([^*\n]+?)(?<!\*)\*(?!\*)/g, 1, 'cm-preview-italic');
+    applyPattern(/(?<!_)_(?!_)([^_\n]+?)(?<!_)_(?!_)/g, 1, 'cm-preview-italic');
+    // Wikilinks: always show as styled [[title]] text
+    {
+        const regex = /\[\[([^[\]\n]+?)\]\]/g;
+        let m: RegExpExecArray | null;
+        regex.lastIndex = 0;
+        while ((m = regex.exec(text)) !== null) {
+            const start = m.index;
+            const end = start + m[0].length;
+            if (!canClaim(start, end)) continue;
+            claimRange(start, end);
+
+            ranges.push({
+                from: lineFrom + start,
+                to: lineFrom + end,
+                deco: Decoration.mark({ class: 'cm-preview-wikilink-edit' }),
+            });
+        }
+    }
+
+    return ranges;
+}
+
+function collectWikilinkEditDecos(text: string, lineFrom: number): DecoRange[] {
+    const ranges: DecoRange[] = [];
+    const regex = /\[\[([^[\]\n]+?)\]\]/g;
+    let m: RegExpExecArray | null;
+    while ((m = regex.exec(text)) !== null) {
+        ranges.push({
+            from: lineFrom + m.index,
+            to: lineFrom + m.index + m[0].length,
+            deco: Decoration.mark({ class: 'cm-preview-wikilink-edit' }),
+        });
+    }
+    return ranges;
+}
+
+function buildDecorations(view: EditorView): DecorationSet {
+    const allRanges: DecoRange[] = [];
+    const processedLines = new Set<number>();
+
+    for (const { from, to } of view.visibleRanges) {
+        let pos = from;
+        while (pos <= to) {
+            const line = view.state.doc.lineAt(pos);
+            if (!processedLines.has(line.from)) {
+                processedLines.add(line.from);
+                const lineText = line.text;
+                const lineFrom = line.from;
+                const lineTo = line.to;
+
+                if (!isCursorOnLine(view, lineFrom, lineTo)) {
+                    const headingMatch = lineText.match(/^(#{1,6}) /);
+
+                    if (headingMatch) {
+                        const level = Math.min(headingMatch[1].length, 6);
+                        const prefixLen = headingMatch[0].length;
+
+                        allRanges.push({
+                            from: lineFrom,
+                            to: lineFrom,
+                            deco: Decoration.line({
+                                attributes: { class: HEADING_CLASSES[level - 1] },
+                            }),
+                        });
+                        allRanges.push({
+                            from: lineFrom,
+                            to: lineFrom + prefixLen,
+                            deco: Decoration.replace({}),
+                        });
+                        allRanges.push(
+                            ...collectInlineDecos(
+                                lineText.slice(prefixLen),
+                                lineFrom + prefixLen
+                            )
+                        );
+                    } else if (
+                        /^(-{3,}|\*{3,}|_{3,})\s*$/.test(lineText) &&
+                        lineText.trim().length >= 3
+                    ) {
+                        allRanges.push({
+                            from: lineFrom,
+                            to: lineTo,
+                            deco: Decoration.replace({ widget: new HRWidget() }),
+                        });
+                    } else {
+                        allRanges.push(...collectInlineDecos(lineText, lineFrom));
+                    }
+                } else {
+                    // Cursor is on this line — show wikilinks as styled [[ title ]] only
+                    allRanges.push(...collectWikilinkEditDecos(lineText, lineFrom));
+                }
+            }
+            pos = line.to + 1;
+        }
+    }
+
+    // Sort by from, then to (ascending) — required by RangeSetBuilder
+    allRanges.sort((a, b) => {
+        if (a.from !== b.from) return a.from - b.from;
+        return a.to - b.to;
+    });
+
+    const builder = new RangeSetBuilder<Decoration>();
+    for (const { from, to, deco } of allRanges) {
+        builder.add(from, to, deco);
+    }
+    return builder.finish();
+}
+
+class LivePreviewPlugin {
+    decorations: DecorationSet;
+
+    constructor(view: EditorView) {
+        this.decorations = buildDecorations(view);
+    }
+
+    update(update: ViewUpdate) {
+        if (update.docChanged || update.selectionSet || update.viewportChanged) {
+            this.decorations = buildDecorations(update.view);
+        }
+    }
+}
+
+export const livePreviewPlugin = ViewPlugin.fromClass(LivePreviewPlugin, {
+    decorations: (v) => v.decorations,
+});
+
+export const livePreviewTheme = EditorView.baseTheme({
+    '.cm-preview-h1': { fontSize: '1.8em', fontWeight: '700', lineHeight: '1.3' },
+    '.cm-preview-h2': { fontSize: '1.5em', fontWeight: '700', lineHeight: '1.3' },
+    '.cm-preview-h3': { fontSize: '1.25em', fontWeight: '600', lineHeight: '1.4' },
+    '.cm-preview-h4': { fontSize: '1.1em', fontWeight: '600' },
+    '.cm-preview-h5': { fontSize: '1em', fontWeight: '600', opacity: '0.85' },
+    '.cm-preview-h6': { fontSize: '0.9em', fontWeight: '600', opacity: '0.7' },
+    '.cm-preview-bold': { fontWeight: '700' },
+    '.cm-preview-italic': { fontStyle: 'italic' },
+    '.cm-preview-strikethrough': {
+        textDecoration: 'line-through',
+        opacity: '0.65',
+    },
+    '.cm-preview-inline-code': {
+        fontFamily:
+            'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+        fontSize: '0.875em',
+        borderRadius: '3px',
+        padding: '1px 4px',
+    },
+    '&light .cm-preview-inline-code': {
+        background: 'rgba(0,0,0,0.07)',
+    },
+    '&dark .cm-preview-inline-code': {
+        background: 'rgba(255,255,255,0.1)',
+    },
+    '&light .cm-preview-wikilink-edit': { color: '#2563eb' },
+    '&dark .cm-preview-wikilink-edit': { color: '#60a5fa' },
+
+    '.cm-preview-hr': {
+        height: '2px',
+        margin: '8px 0',
+        borderRadius: '1px',
+    },
+    '&light .cm-preview-hr': {
+        background: 'rgba(0,0,0,0.15)',
+    },
+    '&dark .cm-preview-hr': {
+        background: 'rgba(255,255,255,0.2)',
+    },
+});
+
+export const livePreviewExtension = [livePreviewPlugin, livePreviewTheme];

--- a/frontend/components/Notes.tsx
+++ b/frontend/components/Notes.tsx
@@ -36,6 +36,7 @@ import { createProject } from '../utils/projectsService';
 import { ENABLE_NOTE_COLOR } from '../config/featureFlags';
 import { COLORS } from './Shared/ColorPicker';
 import NoteFocusMode from './Note/NoteFocusMode';
+import MarkdownEditor from './Note/MarkdownEditor';
 
 
 const shouldUseLightText = (hexColor: string | undefined): boolean => {
@@ -1000,26 +1001,16 @@ const Notes: React.FC = () => {
                                     </div>
                                 )}
 
-                                <div className="flex-1 overflow-y-auto px-6 md:px-8">
-                                    <textarea
+                                <div className="flex-1 overflow-y-auto px-6 md:px-8 py-4">
+                                    <MarkdownEditor
                                         value={editingNote.content || ''}
-                                        onChange={(e) =>
-                                            handleNoteChange({
-                                                content: e.target.value,
-                                            })
+                                        onChange={(val) =>
+                                            handleNoteChange({ content: val })
                                         }
                                         onClick={(e) => e.stopPropagation()}
                                         placeholder={t('notes.contentPlaceholder')}
-                                        className="w-full h-full min-h-[300px] bg-transparent text-gray-900 dark:text-gray-100 border-none focus:outline-none focus:ring-0 resize-none py-4"
-                                        style={{
-                                            color: editingNoteColor
-                                                ? shouldUseLightText(
-                                                      editingNoteColor
-                                                  )
-                                                    ? '#ffffff'
-                                                    : '#333333'
-                                                : undefined,
-                                        }}
+                                        noteColor={editingNoteColor}
+                                        minHeight="300px"
                                     />
                                 </div>
                             </div>

--- a/frontend/components/Shared/CalloutBlock.tsx
+++ b/frontend/components/Shared/CalloutBlock.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+
+export type CalloutType = 'NOTE' | 'WARNING' | 'TIP' | 'IMPORTANT' | 'DANGER';
+
+interface CalloutConfig {
+    borderClass: string;
+    bgClass: string;
+    headerClass: string;
+    icon: string;
+    defaultLabel: string;
+}
+
+const CALLOUT_CONFIG: Record<CalloutType, CalloutConfig> = {
+    NOTE: {
+        borderClass: 'border-blue-400 dark:border-blue-500',
+        bgClass: 'bg-blue-50 dark:bg-blue-950/30',
+        headerClass: 'text-blue-700 dark:text-blue-300',
+        icon: 'ℹ️',
+        defaultLabel: 'Note',
+    },
+    TIP: {
+        borderClass: 'border-green-400 dark:border-green-500',
+        bgClass: 'bg-green-50 dark:bg-green-950/30',
+        headerClass: 'text-green-700 dark:text-green-300',
+        icon: '💡',
+        defaultLabel: 'Tip',
+    },
+    WARNING: {
+        borderClass: 'border-amber-400 dark:border-amber-500',
+        bgClass: 'bg-amber-50 dark:bg-amber-950/30',
+        headerClass: 'text-amber-700 dark:text-amber-300',
+        icon: '⚠️',
+        defaultLabel: 'Warning',
+    },
+    IMPORTANT: {
+        borderClass: 'border-purple-400 dark:border-purple-500',
+        bgClass: 'bg-purple-50 dark:bg-purple-950/30',
+        headerClass: 'text-purple-700 dark:text-purple-300',
+        icon: '📌',
+        defaultLabel: 'Important',
+    },
+    DANGER: {
+        borderClass: 'border-red-400 dark:border-red-500',
+        bgClass: 'bg-red-50 dark:bg-red-950/30',
+        headerClass: 'text-red-700 dark:text-red-300',
+        icon: '🔥',
+        defaultLabel: 'Danger',
+    },
+};
+
+interface CalloutBlockProps {
+    type: CalloutType;
+    title?: string;
+    children?: React.ReactNode;
+}
+
+const CalloutBlock: React.FC<CalloutBlockProps> = ({ type, title, children }) => {
+    const config = CALLOUT_CONFIG[type] ?? CALLOUT_CONFIG.NOTE;
+
+    return (
+        <div
+            className={`callout callout-${type.toLowerCase()} rounded-lg border-l-4 ${config.borderClass} ${config.bgClass} px-4 py-3 my-4 not-prose`}
+        >
+            <div className={`flex items-center gap-1.5 font-semibold text-sm mb-1 ${config.headerClass}`}>
+                <span role="img" aria-hidden="true">{config.icon}</span>
+                <span>{title || config.defaultLabel}</span>
+            </div>
+            {children && (
+                <div className="text-sm text-gray-700 dark:text-gray-200 leading-relaxed [&>p:last-child]:mb-0">
+                    {children}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default CalloutBlock;

--- a/frontend/components/Shared/MarkdownRenderer.tsx
+++ b/frontend/components/Shared/MarkdownRenderer.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import hljs from 'highlight.js';
+import CalloutBlock, { CalloutType } from './CalloutBlock';
 
 const CodeBlock: React.FC<React.HTMLAttributes<HTMLPreElement>> = ({ children, ...props }) => {
     const preRef = useRef<HTMLPreElement>(null);
@@ -340,13 +341,36 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
                     },
                     pre: ({ ...props }) => <CodeBlock {...props} />,
 
-                    // Customize blockquote styles
-                    blockquote: ({ ...props }) => (
-                        <blockquote
-                            className="mb-4 pl-4 border-l-4 border-gray-300 dark:border-gray-600 italic text-gray-600 dark:text-gray-400"
-                            {...props}
-                        />
-                    ),
+                    // Customize blockquote styles — detect Obsidian-style callouts
+                    blockquote: ({ node, children, ...props }) => {
+                        const firstHastChild = (node as any)?.children?.[0];
+                        if (firstHastChild?.type === 'element' && firstHastChild?.tagName === 'p') {
+                            const firstText = firstHastChild?.children?.[0];
+                            if (firstText?.type === 'text') {
+                                const match = (firstText.value as string)?.match(
+                                    /^\[!(NOTE|WARNING|TIP|IMPORTANT|DANGER)\](?:\s+(.*))?$/i
+                                );
+                                if (match) {
+                                    const calloutType = match[1].toUpperCase() as CalloutType;
+                                    const title = match[2]?.trim();
+                                    const contentChildren = React.Children.toArray(children).slice(1);
+                                    return (
+                                        <CalloutBlock type={calloutType} title={title}>
+                                            {contentChildren.length > 0 ? contentChildren : null}
+                                        </CalloutBlock>
+                                    );
+                                }
+                            }
+                        }
+                        return (
+                            <blockquote
+                                className="mb-4 pl-4 border-l-4 border-gray-300 dark:border-gray-600 italic text-gray-600 dark:text-gray-400"
+                                {...props}
+                            >
+                                {children}
+                            </blockquote>
+                        );
+                    },
 
                     // Customize table styles - hide tables in summary mode
                     table: ({ ...props }) =>

--- a/frontend/components/Shared/MarkdownRenderer.tsx
+++ b/frontend/components/Shared/MarkdownRenderer.tsx
@@ -330,7 +330,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
                             const slug = noteTitleToSlug.get(title.toLowerCase());
                             const to = slug ? `/note/${slug}` : null;
                             const badge = (
-                                <span className="inline-flex items-stretch rounded overflow-hidden align-middle border border-blue-200 dark:border-blue-700/70 mt-1">
+                                <span className="inline-flex items-stretch rounded overflow-hidden align-middle border border-blue-200 dark:border-blue-700/70 mt-2">
                                     <span className="flex items-center px-1.5 text-[0.72em] font-bold uppercase tracking-wide text-blue-800 dark:text-blue-200 bg-blue-200/70 dark:bg-blue-700/60">
                                         NOTE:
                                     </span>

--- a/frontend/components/Shared/MarkdownRenderer.tsx
+++ b/frontend/components/Shared/MarkdownRenderer.tsx
@@ -1,9 +1,24 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import hljs from 'highlight.js';
 import CalloutBlock, { CalloutType } from './CalloutBlock';
+import { useStore } from '../../store/useStore';
+
+const WIKILINK_PREFIX = '/__wikilink__/';
+
+function preprocessWikilinks(content: string): string {
+    return content.replace(/\[\[([^\][\n]+?)\]\]/g, (_match, title: string) => {
+        const t = title.trim();
+        return `[${t}](${WIKILINK_PREFIX}${encodeURIComponent(t)})`;
+    });
+}
+
+function slugify(text: string): string {
+    return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+}
 
 const CodeBlock: React.FC<React.HTMLAttributes<HTMLPreElement>> = ({ children, ...props }) => {
     const preRef = useRef<HTMLPreElement>(null);
@@ -52,6 +67,23 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
     onContentChange,
     noteColor,
 }) => {
+    const storeNotes = useStore((state) => state.notesStore.notes);
+
+    const noteTitleToSlug = useMemo(() => {
+        const map = new Map<string, string>();
+        for (const n of storeNotes) {
+            if (n.uid && n.title) {
+                map.set(n.title.toLowerCase(), `${n.uid}-${slugify(n.title)}`);
+            }
+        }
+        return map;
+    }, [storeNotes]);
+
+    const processedContent = useMemo(
+        () => preprocessWikilinks(content),
+        [content]
+    );
+
     // Determine text color based on background
     const getTextColor = () => {
         if (!noteColor) return undefined;
@@ -291,13 +323,42 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
                         />
                     ),
 
-                    // Customize link styles
-                    a: ({ ...props }) => (
-                        <a
-                            className="text-blue-600 dark:text-blue-400 hover:underline"
-                            {...props}
-                        />
-                    ),
+                    // Customize link styles — wikilinks get a note-chip style
+                    a: ({ href, children, ...props }) => {
+                        if (href?.startsWith(WIKILINK_PREFIX)) {
+                            const title = decodeURIComponent(href.slice(WIKILINK_PREFIX.length));
+                            const slug = noteTitleToSlug.get(title.toLowerCase());
+                            const to = slug ? `/note/${slug}` : null;
+                            const badge = (
+                                <span className="inline-flex items-stretch rounded overflow-hidden align-middle border border-blue-200 dark:border-blue-700/70 mt-1">
+                                    <span className="flex items-center px-1.5 text-[0.72em] font-bold uppercase tracking-wide text-blue-800 dark:text-blue-200 bg-blue-200/70 dark:bg-blue-700/60">
+                                        NOTE:
+                                    </span>
+                                    <span className="flex items-center px-1.5 py-0.5 text-[0.9em] text-blue-700 dark:text-blue-300 bg-blue-50/80 dark:bg-blue-900/30">
+                                        {title}
+                                    </span>
+                                </span>
+                            );
+                            return to ? (
+                                <Link to={to} className="no-underline">
+                                    {badge}
+                                </Link>
+                            ) : (
+                                <span className="cursor-default" title="Note not found">
+                                    {badge}
+                                </span>
+                            );
+                        }
+                        return (
+                            <a
+                                className="text-blue-600 dark:text-blue-400 hover:underline"
+                                href={href}
+                                {...props}
+                            >
+                                {children}
+                            </a>
+                        );
+                    },
 
                     // Customize code styles
                     code: ({ className, children, ...props }) => {
@@ -470,7 +531,7 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
                     },
                 }}
             >
-                {content}
+                {processedContent}
             </ReactMarkdown>
         </div>
     );

--- a/frontend/styles/markdown.css
+++ b/frontend/styles/markdown.css
@@ -340,9 +340,126 @@
   .markdown-content table {
     font-size: 0.875rem;
   }
-  
+
   .markdown-content th,
   .markdown-content td {
     padding: 0.5rem;
   }
+}
+
+/* =====================================================
+   CodeMirror editor integration
+   ===================================================== */
+
+/* Transparent background so parent container controls bg color */
+.cm-editor-wrapper .cm-editor {
+  background-color: transparent !important;
+}
+
+/* Remove default CodeMirror focus outline (we handle focus styling via parent) */
+.cm-editor-wrapper .cm-editor.cm-focused {
+  outline: none !important;
+}
+
+/* Ensure the editor grows with content, never clips */
+.cm-editor-wrapper .cm-scroller {
+  overflow: visible !important;
+}
+
+/* Text color inherits from parent in light mode */
+.cm-editor-wrapper .cm-content {
+  color: inherit;
+}
+
+/* Dark mode: ensure text color is light when oneDark theme isn't set */
+.dark .cm-editor-wrapper .cm-content {
+  color: #e5e7eb; /* gray-200 */
+}
+
+/* Selection highlight */
+.cm-editor-wrapper .cm-selectionBackground {
+  background-color: rgba(59, 130, 246, 0.2) !important;
+}
+.cm-editor-wrapper .cm-focused .cm-selectionBackground {
+  background-color: rgba(59, 130, 246, 0.3) !important;
+}
+
+/* Cursor */
+.cm-editor-wrapper .cm-cursor,
+.cm-editor-wrapper .cm-dropCursor {
+  border-left-color: #6b7280;
+}
+.dark .cm-editor-wrapper .cm-cursor,
+.dark .cm-editor-wrapper .cm-dropCursor {
+  border-left-color: #9ca3af;
+}
+
+/* Heading sizes in syntax-highlighted markdown editing */
+.cm-editor-wrapper .cm-line .tok-heading1 {
+  font-size: 1.5em;
+  font-weight: 700;
+}
+.cm-editor-wrapper .cm-line .tok-heading2 {
+  font-size: 1.25em;
+  font-weight: 600;
+}
+.cm-editor-wrapper .cm-line .tok-heading3 {
+  font-size: 1.1em;
+  font-weight: 600;
+}
+
+/* =====================================================
+   Callout blocks (Obsidian-style > [!TYPE])
+   ===================================================== */
+
+.callout {
+  border-radius: 0.5rem;
+  border-left-width: 4px;
+  padding: 0.75rem 1rem;
+  margin: 1rem 0;
+}
+
+.callout-note {
+  border-color: #60a5fa;
+  background-color: rgba(239, 246, 255, 0.8);
+}
+.dark .callout-note {
+  border-color: #3b82f6;
+  background-color: rgba(23, 37, 84, 0.3);
+}
+
+.callout-tip {
+  border-color: #4ade80;
+  background-color: rgba(240, 253, 244, 0.8);
+}
+.dark .callout-tip {
+  border-color: #22c55e;
+  background-color: rgba(5, 46, 22, 0.3);
+}
+
+.callout-warning {
+  border-color: #fbbf24;
+  background-color: rgba(255, 251, 235, 0.8);
+}
+.dark .callout-warning {
+  border-color: #f59e0b;
+  background-color: rgba(69, 26, 3, 0.3);
+}
+
+.callout-important {
+  border-color: #c084fc;
+  background-color: rgba(250, 245, 255, 0.8);
+}
+.dark .callout-important {
+  border-color: #a855f7;
+  background-color: rgba(59, 7, 100, 0.3);
+}
+
+.callout-danger {
+  border-color: #f87171;
+  background-color: rgba(254, 242, 242, 0.8);
+}
+.dark .callout-danger {
+  border-color: #ef4444;
+  background-color: rgba(69, 10, 10, 0.3);
 }

--- a/frontend/utils/notesService.ts
+++ b/frontend/utils/notesService.ts
@@ -88,6 +88,21 @@ export const deleteNote = async (noteUid: string): Promise<void> => {
     await handleAuthResponse(response, 'Failed to delete note.');
 };
 
+export interface BacklinkNote {
+    uid: string;
+    title: string;
+}
+
+export const fetchNoteBacklinks = async (noteUid: string): Promise<BacklinkNote[]> => {
+    const response = await fetch(getApiPath(`note/${noteUid}/backlinks`), {
+        credentials: 'include',
+        headers: getDefaultHeaders(),
+        cache: 'no-store',
+    });
+    await handleAuthResponse(response, 'Failed to fetch backlinks.');
+    return await response.json();
+};
+
 export const fetchNoteBySlug = async (uidSlug: string): Promise<Note> => {
     const response = await fetch(getApiPath(`note/${uidSlug}`), {
         credentials: 'include',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,21 @@
 {
   "name": "tududi",
-  "version": "v1.3.0",
+  "version": "v1.3.1-rc.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tududi",
-      "version": "v1.3.0",
+      "version": "v1.3.1-rc.3",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.106.0",
+        "@codemirror/commands": "^6.10.4",
+        "@codemirror/lang-markdown": "^6.5.1",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "@codemirror/view": "^6.43.6",
         "@dr.pogodin/csurf": "^1.16.9",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@playwright/test": "^1.57.0",
@@ -2112,6 +2118,148 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-css": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.3.1.tgz",
+      "integrity": "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.2",
+        "@lezer/css": "^1.1.7"
+      }
+    },
+    "node_modules/@codemirror/lang-html": {
+      "version": "6.4.11",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+      "integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.4.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/css": "^1.1.0",
+        "@lezer/html": "^1.3.12"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.1.tgz",
+      "integrity": "sha512-6re5avCNfyRMIoi3XNjbEfQM1vTeVD3JS3g/Fyegyso/eoANFM71Cyvbb66LDyYtQLMEcRFlzioywCqDo9SlLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.2.1",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
     "node_modules/@csstools/color-helpers": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
@@ -3538,6 +3686,79 @@
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/css": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.4.tgz",
+      "integrity": "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/html": {
+      "version": "1.3.13",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+      "integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.7.2.tgz",
+      "integrity": "sha512-iTkYvoVcKt3WkeL7qUDyXHONZEwLio4wj8KTNi2dnjQEXBZKMV63BpQrPqfsM+OkvuRbiSTAcycYAsQzLhRNoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
       "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -7829,6 +8050,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -19859,6 +20086,12 @@
         "webpack": "^5.27.0"
       }
     },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.19",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.19.tgz",
@@ -20357,6 +20590,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {
@@ -21576,6 +21827,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -138,6 +138,12 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.106.0",
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/lang-markdown": "^6.5.1",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/theme-one-dark": "^6.1.3",
+    "@codemirror/view": "^6.43.6",
     "@dr.pogodin/csurf": "^1.16.9",
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@playwright/test": "^1.57.0",


### PR DESCRIPTION
## Description

Replaces the plain textarea with a CodeMirror-based rich editor for notes, adding live Markdown preview, wikilink support (`[[note title]]`), slash commands, backlinks, and a badge chip rendering in the read-only view.

**Key features added:**
- **CodeMirror editor** with live inline preview (bold, italic, strikethrough, headings, HR, inline code)
- **Wikilinks** (`[[note title]]`) — autocomplete menu while typing `[[`, styled as blue text in editor, rendered as a clickable NOTE: badge chip in read-only view
- **Slash command menu** (`/`) — insert headings, lists, code blocks, callouts, task items
- **Backlinks panel** — shows all notes that reference the current note via `[[title]]`
- **Formatting toolbar** — appears on text selection for quick bold/italic/link/heading actions
- **Badge chip styling** — wikilinks in read-only view render as a two-tone NOTE:/title badge with correct alignment and spacing

## Type of Change

- [x] New feature (adds functionality)

## Related Issues

Fixes #

## Testing

**How did you test this?**

Tested manually in browser: editor rendering, wikilink autocomplete and navigation, slash command menu, backlinks panel, badge appearance in read-only view.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code

## Additional Notes

- Wikilinks in the editor always render as `[[title]]` styled text (no badge) — badges only appear in the read-only MarkdownRenderer
- The backlinks API endpoint is `GET /api/note/:uid/backlinks`