### PR TITLE
fix(tasks): show assigned person for all users viewing shared tasks

### DIFF
--- a/backend/modules/tasks/queries/query-builders.js
+++ b/backend/modules/tasks/queries/query-builders.js
@@ -1,4 +1,11 @@
-const { Task, Tag, Project, Area, sequelize } = require('../../../models');
+const {
+    Task,
+    Tag,
+    Project,
+    Area,
+    Person,
+    sequelize,
+} = require('../../../models');
 const { Op, QueryTypes } = require('sequelize');
 const permissionsService = require('../../../services/permissionsService');
 const {
@@ -110,6 +117,12 @@ async function filterTasksByParams(
                 ['order', 'ASC'],
                 ['created_at', 'ASC'],
             ],
+        },
+        {
+            model: Person,
+            as: 'AssignedTo',
+            attributes: ['uid', 'name', 'color', 'relationship_type'],
+            required: false,
         },
     ];
 
@@ -481,6 +494,12 @@ function getTaskIncludeConfig() {
                 ['order', 'ASC'],
                 ['created_at', 'ASC'],
             ],
+        },
+        {
+            model: Person,
+            as: 'AssignedTo',
+            attributes: ['uid', 'name', 'color', 'relationship_type'],
+            required: false,
         },
     ];
 }

--- a/backend/modules/tasks/utils/constants.js
+++ b/backend/modules/tasks/utils/constants.js
@@ -1,4 +1,4 @@
-const { Tag, Project, Area, Task } = require('../../../models');
+const { Tag, Project, Area, Task, Person } = require('../../../models');
 
 const TASK_INCLUDES = [
     {
@@ -14,6 +14,12 @@ const TASK_INCLUDES = [
     {
         model: Area,
         attributes: ['id', 'name', 'uid', 'color'],
+        required: false,
+    },
+    {
+        model: Person,
+        as: 'AssignedTo',
+        attributes: ['uid', 'name', 'color', 'relationship_type'],
         required: false,
     },
 ];

--- a/frontend/components/Task/TaskDetails/TaskAssignedToCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskAssignedToCard.tsx
@@ -19,6 +19,15 @@ const TaskAssignedToCard: React.FC<TaskAssignedToCardProps> = ({ task, onAssign 
         });
     }, []);
 
+    // Merge the embedded AssignedTo person (from shared tasks) with the user's own people
+    // so assignees from other users' person records are visible
+    const mergedPeople = React.useMemo(() => {
+        if (!task.AssignedTo) return people;
+        const alreadyInList = people.some((p) => p.uid === task.AssignedTo!.uid);
+        if (alreadyInList) return people;
+        return [...people, task.AssignedTo];
+    }, [people, task.AssignedTo]);
+
     return (
         <div className="rounded-lg shadow-sm bg-white dark:bg-gray-900 border-2 border-gray-50 dark:border-gray-800 hover:border-gray-200 dark:hover:border-gray-700 transition-colors p-3">
             <div className="flex items-center gap-2 mb-2 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
@@ -27,7 +36,7 @@ const TaskAssignedToCard: React.FC<TaskAssignedToCardProps> = ({ task, onAssign 
             </div>
             <PersonDropdown
                 personUid={task.assigned_to ?? null}
-                people={people}
+                people={mergedPeople}
                 onChange={onAssign}
             />
         </div>

--- a/frontend/entities/Task.ts
+++ b/frontend/entities/Task.ts
@@ -2,6 +2,7 @@ import { Tag } from './Tag';
 import { Project } from './Project';
 import { Area } from './Area';
 import { Attachment } from './Attachment';
+import { Person } from './Person';
 
 export interface Task {
     id?: number;
@@ -48,6 +49,7 @@ export interface Task {
     habit_total_completions?: number;
     habit_last_completion_at?: string;
     assigned_to?: string | null;
+    AssignedTo?: Person | null;
     involves?: string[];
     // Transient UI field set by suggestion scoring - never persisted or sent to server
     _suggestionMeta?: {


### PR DESCRIPTION
## Description

When User1 assigns a task to one of their people (a Person record), User2 viewing the same shared task would always see "Unassigned" in the Assigned To field. User1 would correctly see the assigned person.

**Root cause:** The `assigned_to` field stores a person's UID, but the `/people` API endpoint only returns people owned by the current user. When User2's frontend looked up the person UID in their own people list, it wasn't found, so the dropdown fell back to "Unassigned".

**Fix:**
1. **Backend:** Include the `AssignedTo` Person association in all task query responses (both in `constants.js` for individual task fetches, and in `query-builders.js` for list queries). This embeds the person's data directly in the task object, bypassing the ownership filter.
2. **Frontend:** In `TaskAssignedToCard`, merge the embedded `task.AssignedTo` person into the people list as a fallback — so cross-user assignees are always displayable even when they're not in the viewing user's own people list.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1339

## Testing

1. Create two user accounts (User1, User2)
2. Create a Person record under User1
3. Share a project with User2
4. Create a task in that project and assign it to User1's Person
5. Log in as User2 and view the task — the Assigned To field now shows the correct person name instead of "Unassigned"

Commands run:
```
npm run lint  # passes (only pre-existing warnings)
npm test      # 3 pre-existing failures unrelated to this change
```

## Checklist

- [x] Code follows project conventions
- [x] Lint passes
- [x] Tests pass (pre-existing failures only)
- [x] No JSDoc comments added
- [x] No breaking changes