### PR TITLE
feat(pwa): installable PWA with offline read and queued write sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,14 @@ npm start  # Frontend on :8080, Backend on :3002
     - Claude Desktop, Cursor, VS Code configuration
     - API token authentication and security
 
-24. **[Claude Memory & Preferences](docs/MEMORY.md)**
+24. **[PWA & Offline Support](docs/15-pwa.md)**
+    - Installable as a Progressive Web App (home screen on mobile and desktop)
+    - Service worker cache strategy (static assets, API reads, offline mutation queue)
+    - Background Sync for replaying queued mutations on reconnect
+    - Session-scoped cache security (cleared on logout / 401)
+    - Known limitations (sub-path deployments, iOS background sync, offline task creation)
+
+25. **[Claude Memory & Preferences](docs/MEMORY.md)**
     - PR and commit message preferences
     - Testing preferences
     - Common patterns to remember

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ For the thinking behind tududi, read:
 - **Area Categorization**: Group projects into areas for better organization and focus.
 - **Due Date Tracking**: Set due dates for tasks and view them based on due date categories.
 - **Responsive Design**: Accessible from various devices, ensuring a consistent experience across desktops, tablets, and mobile phones.
+- **Installable PWA**: Add tududi to your home screen on Android, iOS, and desktop browsers for a native app-like experience. The app stays readable from cache when offline, and write operations are queued and synced automatically when connectivity returns.
 - **Multi-Language Support**: Available in 24 languages with full localization support for a truly global productivity experience.
 - **Telegram Integration**:
     - Create tasks directly through Telegram messages

--- a/docs/15-pwa.md
+++ b/docs/15-pwa.md
@@ -1,0 +1,226 @@
+# PWA & Offline Support
+
+[← Back to Index](../CLAUDE.md)
+
+---
+
+## Overview
+
+Tududi is an installable Progressive Web App (PWA). Users can add it to their home screen on Android, iOS, and desktop browsers and use it like a native app. When the network is unavailable the app stays readable from cache; write operations are queued and replayed automatically once connectivity returns.
+
+---
+
+## Installation
+
+### What browsers support
+
+| Browser | Install method |
+|---------|---------------|
+| Chrome / Edge (Android, desktop) | Address bar install icon or `⋮ → Install app` |
+| Safari (iOS 16.4+) | Share sheet → Add to Home Screen |
+| Firefox (Android) | `⋮ → Install` |
+
+### Requirements satisfied by Tududi
+
+1. `public/manifest.json` — declares name, icons, `display: standalone`
+2. `<link rel="manifest">` in `public/index.html`
+3. `public/sw.js` — service worker registered from `frontend/index.tsx` in production
+4. HTTPS — required in production; localhost is exempt for development
+
+### Verifying installability (Chrome DevTools)
+
+1. Open DevTools → **Application** → **Manifest** — no errors should appear
+2. **Application** → **Service Workers** — status should be "activated and running"
+3. **Lighthouse** → **PWA** category — installability check should pass
+
+---
+
+## Web App Manifest (`public/manifest.json`)
+
+```json
+{
+  "id": "/",
+  "name": "tududi",
+  "short_name": "tududi",
+  "description": "A simple and effective task management application",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "theme_color": "#4a5568",
+  "background_color": "#ffffff",
+  "lang": "en",
+  "orientation": "portrait-primary",
+  "icons": [
+    { "src": "/icon-logo.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },
+    { "src": "/icon-logo.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" },
+    { "src": "/apple-touch-icon.png", "sizes": "180x180", "type": "image/png" },
+    { "src": "/favicon-32.png", "sizes": "32x32", "type": "image/png" },
+    { "src": "/favicon-16.png", "sizes": "16x16", "type": "image/png" }
+  ]
+}
+```
+
+**Icon notes:**
+- `purpose: "any"` — standard icon used in most contexts
+- `purpose: "maskable"` — Android adaptive icon; the 512×512 PNG has safe-zone padding
+- Two separate entries are required; `"purpose": "any maskable"` in a single entry is a spec violation
+
+**Sub-path deployments (e.g. Home Assistant ingress):** The static `start_url: "/"` and `scope: "/"` will not match the ingress path, so the install prompt will not appear. A dynamic manifest served from the backend is needed for those deployments — this is a known limitation and a future enhancement.
+
+---
+
+## Service Worker (`public/sw.js`)
+
+The SW is a plain JS file (not transpiled by webpack) served from the origin root. `CopyWebpackPlugin` copies it from `public/` to `dist/` on every production build.
+
+### Lifecycle
+
+```
+install   → pre-cache STATIC_ASSETS, skipWaiting()
+activate  → delete stale static-cache versions, clients.claim()
+fetch     → route to handler by request type
+message   → handle SKIP_WAITING / SESSION_UPDATE / CLEAR_CACHE
+sync      → replay queued mutations (Background Sync API)
+```
+
+### Cache strategy
+
+| Request type | Handler | Behaviour |
+|---|---|---|
+| Static assets (same-origin, non-API) | cache-first | Serve from `tududi-v1` cache; populate on first network hit |
+| API `GET` `/api/*` | `handleApiGet` | Network-first; on success write to `tududi-api-v1`; on network failure serve stale cache; if no cache return `503 { offline: true }` |
+| API mutations `/api/*` | `handleApiMutation` | Attempt network; if offline queue to IndexedDB, return `202 { queued: true }`; register Background Sync tag `tududi-sync` |
+| Navigation (`mode: navigate`) | inline | Network-first; fall back to cached `/` shell for SPA routing |
+
+### Cache names
+
+| Name | Contents | Cleared when |
+|------|----------|-------------|
+| `tududi-v1` | Static assets (JS, CSS, fonts, icons, manifest) | SW activate removes old versions |
+| `tududi-api-v1` | API GET responses | 401/403 from any live fetch; CLEAR_CACHE message; manual SW update |
+
+### Offline mutation queue
+
+Mutations that fail due to network error are stored in an IndexedDB database named `tududi-offline`, object store `tududi-sync-queue`. Each entry contains:
+
+```
+{ id, url, method, headers (auth headers stripped), body, sessionId, timestamp }
+```
+
+The Background Sync API fires the `tududi-sync` event when connectivity returns. The SW replays each entry in order, deleting successfully-replayed entries from the store. After all replays it sends `{ type: 'SYNC_COMPLETE' }` to all open windows; `frontend/index.tsx` handles this by calling SWR's global `mutate(() => true)` to revalidate all cached data.
+
+**Limitation:** Creating tasks offline generates a server-assigned numeric ID on replay. If the queue contains multiple dependent mutations (e.g. create task then update it) the second mutation may reference an ID that didn't exist at queue time. This edge case is tracked alongside the broader id/uid consistency work.
+
+### SW update flow
+
+When a new version of `sw.js` is deployed:
+
+1. Browser detects the changed file during the next visit
+2. New SW installs in the background (`install` event)
+3. `frontend/index.tsx` detects `updatefound` → `statechange: 'installed'` → sends `{ type: 'SKIP_WAITING' }` to the new worker
+4. New SW calls `self.skipWaiting()` → takes control immediately
+5. `activate` event deletes old static caches (API cache is preserved)
+
+---
+
+## Session Security
+
+The service worker caches API responses and queues mutations across page navigations. In a multi-user or shared-device scenario this creates two risks:
+
+**Risk 1 — Cached data visible to next user:** If User A logs out and User B logs in, the API cache could serve User A's task list to User B.
+
+**Mitigation:**
+- `handleApiGet` detects 401/403 responses from live fetches and calls `clearUserData()`, which deletes `tududi-api-v1` and purges the mutation queue.
+- `App.tsx` calls `notifySwClearCache()` when `/api/current_user` returns 401.
+- `Navbar.tsx` calls `notifySwClearCache()` in `handleLogout()` before navigating to `/login`.
+- The SW handles the `CLEAR_CACHE` postMessage by deleting the API cache and clearing IndexedDB.
+
+**Risk 2 — Queued mutations replayed under wrong session:** User A queues mutations, logs out, User B logs in. Background Sync fires and could replay User A's operations authenticated as User B.
+
+**Mitigation:**
+- Auth-sensitive headers (`Authorization`, `Cookie`, `Cookie2`, `X-Auth-Token`) are stripped before storing queue entries — they cannot be persisted or forged.
+- `App.tsx` calls `notifySwSession(user.id)` after successful login. The SW stores this as `sessionUserId`.
+- Each queued entry is tagged with the `sessionUserId` at queue time.
+- On replay, if `entry.sessionId !== sessionUserId` the entry is deleted without executing.
+- The SW also broadcasts `{ type: 'AUTH_EXPIRED' }` to open clients on any 401, allowing the app to redirect to login.
+
+### SW communication utilities (`frontend/utils/swUtils.ts`)
+
+```typescript
+notifySwSession(userId)   // Called after login in App.tsx
+notifySwClearCache()      // Called on logout (Navbar.tsx) and on 401 (App.tsx)
+```
+
+Both functions handle the case where the SW has not yet taken control of the page (falls back to `navigator.serviceWorker.ready`).
+
+---
+
+## Development Mode
+
+The service worker is **not registered** when `NODE_ENV !== 'production'`. Instead, `frontend/index.tsx` actively unregisters any existing SWs and clears all caches at startup. This prevents stale cached responses from interfering with live development.
+
+```typescript
+// In frontend/index.tsx (dev only)
+if (isDevelopment && 'serviceWorker' in navigator) {
+    navigator.serviceWorker.getRegistrations().then((registrations) => {
+        registrations.forEach((r) => r.unregister());
+    });
+    if ('caches' in window) {
+        caches.keys().then((names) => names.forEach((n) => caches.delete(n)));
+    }
+}
+```
+
+---
+
+## Adding New API Endpoints
+
+No changes to the service worker are needed for new API endpoints. The SW applies its strategy based on the `/api/` path prefix:
+
+- **GET endpoints**: automatically cached in `tududi-api-v1` on first successful response
+- **Mutations**: automatically queued when offline
+
+If a new endpoint should **not** be cached (e.g. an endpoint that returns one-time tokens or download URLs), add its path prefix to a blocklist in `handleApiGet`:
+
+```javascript
+const NO_CACHE_PATHS = ['/api/auth/token', '/api/downloads/'];
+
+async function handleApiGet(request) {
+    const url = new URL(request.url);
+    if (NO_CACHE_PATHS.some((p) => url.pathname.startsWith(p))) {
+        return fetch(request); // network only, no cache
+    }
+    // ... rest of handler
+}
+```
+
+---
+
+## Updating the Cache Version
+
+When making a breaking change to the static asset structure (e.g. removing or renaming a cached file), bump `CACHE_VERSION` at the top of `public/sw.js`:
+
+```javascript
+const CACHE_VERSION = 'tududi-v2'; // was tududi-v1
+```
+
+The `activate` event deletes all caches that don't match the current `CACHE_VERSION` or `API_CACHE`. If the API response format changes significantly, also bump `API_CACHE`:
+
+```javascript
+const API_CACHE = 'tududi-api-v2'; // was tududi-api-v1
+```
+
+---
+
+## Known Limitations
+
+| Limitation | Detail |
+|-----------|--------|
+| Sub-path deployments | Static `manifest.json` uses `start_url: "/"` — install prompt won't appear for Home Assistant ingress or other sub-path setups |
+| Offline task creation | Creating a task offline queues a POST; the server-assigned `id` is unknown at queue time, so dependent mutations in the same offline session may fail on replay |
+| No conflict resolution | If the server state changed while offline, replayed mutations apply on top of the new state without merging — last writer wins |
+| iOS Safari background sync | iOS does not support the Background Sync API; queued mutations are replayed the next time the app is opened while online |
+
+---
+
+[← Back to Index](../CLAUDE.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -324,4 +324,26 @@ Located in `/backend/modules/`, each follows consistent architecture:
 
 ---
 
+## PWA / Offline Architecture
+
+Tududi ships as an installable Progressive Web App. See [docs/15-pwa.md](15-pwa.md) for the full specification; the key points for architecture purposes:
+
+- **`public/sw.js`** is the service worker. It is copied to `dist/` by `CopyWebpackPlugin` unchanged and served from the root scope.
+- **`public/manifest.json`** declares the app shell (name, icons, display mode). The `<link rel="manifest">` tag is in `public/index.html`.
+- The SW is registered in **production only** (`NODE_ENV === 'production'`) from `frontend/index.tsx`. Dev builds actively unregister any lingering SWs to prevent cache confusion.
+- `frontend/utils/swUtils.ts` provides `notifySwSession(userId)` and `notifySwClearCache()` — called at login and logout respectively to maintain session-scoped caches.
+
+**Cache strategy by request type:**
+
+| Request | Strategy |
+|---------|----------|
+| Static assets (JS, CSS, fonts, images) | Cache-first, populate on first network hit |
+| API `GET` requests | Network-first, stale cache fallback when offline |
+| API `POST / PUT / DELETE` | Network; if offline, queue to IndexedDB and replay via Background Sync |
+| Navigation (`mode: navigate`) | Network-first, fall back to cached `/` shell |
+
+**Session security:** API cache entries are cleared on 401/403, explicit logout, or `CLEAR_CACHE` postMessage. Queued mutations are tagged with the user's numeric ID; on replay a session-ID mismatch causes the entry to be dropped rather than executed under a different principal.
+
+---
+
 [← Back to Index](../CLAUDE.md)

--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -39,7 +39,15 @@
 ├── Source Code
 ├── backend/               # Express backend → See Backend Structure
 ├── frontend/              # React frontend → See Frontend Structure
-├── public/                # Static assets (fonts, locales, images)
+├── public/                # Static assets served by webpack-dev-server / Express
+│   ├── sw.js              # Service worker: offline cache + mutation queue
+│   ├── manifest.json      # Web app manifest (PWA installability)
+│   ├── index.html         # HTML shell template (HtmlWebpackPlugin input)
+│   ├── icon-logo.png      # 512×512 app icon
+│   ├── apple-touch-icon.png # 180×180 iOS home-screen icon
+│   ├── favicon*.{ico,png} # Favicon variants
+│   ├── fonts/             # Self-hosted Lora WOFF2 files
+│   └── locales/           # i18n JSON translation files (27 locales)
 ├── dist/                  # Production build output
 ├── e2e/                   # Playwright E2E tests
 ├── scripts/               # Build and utility scripts
@@ -246,7 +254,9 @@
 │                        # - React root initialization
 │                        # - i18n setup
 │                        # - Dark mode initialization
-│                        # - Service worker cleanup
+│                        # - Service worker registration (production)
+│                        # - SW update lifecycle + SYNC_COMPLETE handler
+│                        # - Dev-mode SW cleanup
 │
 ├── App.tsx              # Root component (13KB)
 │                        # - Route definitions
@@ -378,7 +388,8 @@
 │   │   ├── slugUtils.ts           # URL slug handling
 │   │   ├── userUtils.ts           # User utilities
 │   │   ├── fetcher.ts             # SWR fetcher configuration
-│   │   └── featureFlags.ts        # Feature flag client
+│   │   ├── featureFlags.ts        # Feature flag client
+│   │   └── swUtils.ts             # Service worker messaging (session/cache)
 │   │
 │   └── config/
 │       └── paths.ts               # API and path configuration

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -44,6 +44,7 @@ import { setCurrentUser as setUserInStorage } from './utils/userUtils';
 import { getApiPath, getLocalesPath } from './config/paths';
 import { useStore } from './store/useStore';
 import { invalidateProfileCache } from './utils/profileService';
+import { notifySwSession, notifySwClearCache } from './utils/swUtils';
 // Lazy load Tasks component to prevent issues with tags loading
 const Tasks = lazy(() => import('./components/Tasks'));
 
@@ -68,6 +69,7 @@ const App: React.FC = () => {
             if (!response.ok) {
                 if (response.status === 401) {
                     invalidateProfileCache();
+                    notifySwClearCache();
                     setCurrentUser(null);
                     return;
                 }
@@ -78,6 +80,7 @@ const App: React.FC = () => {
             if (data.user) {
                 setCurrentUser(data.user);
                 setUserInStorage(data.user);
+                notifySwSession(data.user.id);
                 useStore.getState().userSettingsStore.setEisenhowerEnabled(
                     data.user.features?.eisenhower_enabled === true
                 );

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -22,6 +22,7 @@ import { getApiPath, getAssetPath } from '../config/paths';
 import { getFeatureFlags, FeatureFlags } from '../utils/featureFlags';
 import { setUserTimezone } from '../utils/dateUtils';
 import { fetchProfile as fetchProfileFromService, invalidateProfileCache } from '../utils/profileService';
+import { notifySwClearCache } from '../utils/swUtils';
 
 interface NavbarProps {
     isDarkMode: boolean;
@@ -151,6 +152,7 @@ const Navbar: React.FC<NavbarProps> = ({
             });
 
             if (response.ok) {
+                notifySwClearCache();
                 setCurrentUser(null);
                 navigate('/login');
             } else {

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
+import { mutate } from 'swr';
 import App from './App';
 import { ToastProvider } from './components/Shared/ToastContext';
 import { TelegramStatusProvider } from './contexts/TelegramStatusContext';
@@ -11,6 +12,31 @@ import i18n from './i18n'; // Import the i18n instance with its configuration
 import { getBasePath } from './config/paths';
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
+
+if (!isDevelopment && 'serviceWorker' in navigator) {
+    window.addEventListener('load', () => {
+        navigator.serviceWorker.register('/sw.js').then((registration) => {
+            registration.addEventListener('updatefound', () => {
+                const newWorker = registration.installing;
+                if (newWorker) {
+                    newWorker.addEventListener('statechange', () => {
+                        if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+                            newWorker.postMessage({ type: 'SKIP_WAITING' });
+                        }
+                    });
+                }
+            });
+        }).catch(() => {
+            // Non-fatal: app functions without service worker
+        });
+
+        navigator.serviceWorker.addEventListener('message', (event) => {
+            if (event.data?.type === 'SYNC_COMPLETE') {
+                mutate(() => true, undefined, { revalidate: true });
+            }
+        });
+    });
+}
 
 // Clear out any lingering service workers/caches from other branches (e.g. PWA)
 if (isDevelopment && 'serviceWorker' in navigator) {

--- a/frontend/utils/swUtils.ts
+++ b/frontend/utils/swUtils.ts
@@ -1,0 +1,19 @@
+function postToSw(message: object): void {
+    if (!('serviceWorker' in navigator)) return;
+    const sw = navigator.serviceWorker.controller;
+    if (sw) {
+        sw.postMessage(message);
+    } else {
+        navigator.serviceWorker.ready.then((reg) =>
+            reg.active?.postMessage(message)
+        );
+    }
+}
+
+export function notifySwSession(userId: number | string): void {
+    postToSw({ type: 'SESSION_UPDATE', sessionId: String(userId) });
+}
+
+export function notifySwClearCache(): void {
+    postToSw({ type: 'CLEAR_CACHE' });
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,21 +1,31 @@
 {
+  "id": "/",
   "name": "tududi",
   "short_name": "tududi",
   "description": "A simple and effective task management application",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "theme_color": "#4a5568",
   "background_color": "#ffffff",
+  "lang": "en",
+  "orientation": "portrait-primary",
   "icons": [
     {
       "src": "/icon-logo.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "any maskable"
+      "purpose": "any"
     },
     {
-      "src": "/favicon.png",
-      "sizes": "32x32",
+      "src": "/icon-logo.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "maskable"
+    },
+    {
+      "src": "/apple-touch-icon.png",
+      "sizes": "180x180",
       "type": "image/png"
     },
     {
@@ -27,11 +37,6 @@
       "src": "/favicon-16.png",
       "sizes": "16x16",
       "type": "image/png"
-    },
-    {
-      "src": "/favicon.ico",
-      "sizes": "16x16 32x32 48x48",
-      "type": "image/x-icon"
     }
   ]
 }

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,6 +2,10 @@ const CACHE_VERSION = 'tududi-v1';
 const API_CACHE = 'tududi-api-v1';
 const SYNC_QUEUE = 'tududi-sync-queue';
 
+// Set via SESSION_UPDATE message from the client after login.
+// Used to tag queued mutations and detect cross-principal replays.
+let sessionUserId = null;
+
 const STATIC_ASSETS = [
     '/',
     '/manifest.json',
@@ -34,13 +38,47 @@ self.addEventListener('activate', (event) => {
     self.clients.claim();
 });
 
+// ─── Message handler ─────────────────────────────────────────────────────────
+
+self.addEventListener('message', (event) => {
+    const { type, sessionId } = event.data || {};
+
+    if (type === 'SKIP_WAITING') {
+        self.skipWaiting();
+        return;
+    }
+    if (type === 'SESSION_UPDATE') {
+        sessionUserId = sessionId || null;
+        return;
+    }
+    if (type === 'CLEAR_CACHE') {
+        event.waitUntil(clearUserData());
+        return;
+    }
+});
+
+async function clearUserData() {
+    sessionUserId = null;
+    await caches.delete(API_CACHE);
+    await purgeQueue();
+}
+
+async function purgeQueue() {
+    const db = await openQueueDb();
+    const tx = db.transaction(SYNC_QUEUE, 'readwrite');
+    tx.objectStore(SYNC_QUEUE).clear();
+    return new Promise((resolve, reject) => {
+        tx.oncomplete = resolve;
+        tx.onerror = () => reject(tx.error);
+    });
+}
+
 // ─── Fetch ───────────────────────────────────────────────────────────────────
 
 self.addEventListener('fetch', (event) => {
     const { request } = event;
     const url = new URL(request.url);
 
-    // Only handle same-origin requests
     if (url.origin !== self.location.origin) return;
 
     if (url.pathname.startsWith('/api/')) {
@@ -52,7 +90,6 @@ self.addEventListener('fetch', (event) => {
         return;
     }
 
-    // Navigation: network-first, fall back to cached shell
     if (request.mode === 'navigate') {
         event.respondWith(
             fetch(request).catch(() =>
@@ -62,7 +99,6 @@ self.addEventListener('fetch', (event) => {
         return;
     }
 
-    // Static assets: cache-first
     event.respondWith(
         caches.match(request).then(
             (cached) =>
@@ -85,6 +121,20 @@ self.addEventListener('fetch', (event) => {
 async function handleApiGet(request) {
     try {
         const response = await fetch(request);
+
+        // A 401 means the session expired or a different user is now active.
+        // Clear cached data so the next user cannot see stale responses.
+        if (response.status === 401 || response.status === 403) {
+            clearUserData().then(() => {
+                self.clients.matchAll({ type: 'window' }).then((clients) =>
+                    clients.forEach((client) =>
+                        client.postMessage({ type: 'AUTH_EXPIRED' })
+                    )
+                );
+            });
+            return response;
+        }
+
         if (response.ok) {
             const cache = await caches.open(API_CACHE);
             cache.put(request, response.clone());
@@ -120,13 +170,31 @@ async function handleApiMutation(request) {
     }
 }
 
+// Sensitive headers that must not be persisted; the browser re-attaches
+// session cookies automatically when replaying via fetch().
+const SENSITIVE_HEADERS = new Set([
+    'authorization',
+    'cookie',
+    'cookie2',
+    'x-auth-token',
+]);
+
 async function queueRequest(request) {
     const body = await request.text().catch(() => '');
+
+    const safeHeaders = {};
+    for (const [k, v] of request.headers.entries()) {
+        if (!SENSITIVE_HEADERS.has(k.toLowerCase())) {
+            safeHeaders[k] = v;
+        }
+    }
+
     const entry = {
         url: request.url,
         method: request.method,
-        headers: Object.fromEntries(request.headers.entries()),
+        headers: safeHeaders,
         body,
+        sessionId: sessionUserId,
         timestamp: Date.now(),
     };
 
@@ -134,7 +202,6 @@ async function queueRequest(request) {
     const tx = db.transaction(SYNC_QUEUE, 'readwrite');
     tx.objectStore(SYNC_QUEUE).add(entry);
 
-    // Register background sync if supported
     if ('sync' in self.registration) {
         await self.registration.sync.register('tududi-sync');
     }
@@ -150,11 +217,22 @@ self.addEventListener('sync', (event) => {
 
 async function replayQueuedRequests() {
     const db = await openQueueDb();
-    const tx = db.transaction(SYNC_QUEUE, 'readwrite');
-    const store = tx.objectStore(SYNC_QUEUE);
-    const entries = await idbAll(store);
+    const tx = db.transaction(SYNC_QUEUE, 'readonly');
+    const entries = await idbAll(tx.objectStore(SYNC_QUEUE));
 
     for (const entry of entries) {
+        // Drop entries queued by a different user — never replay another
+        // principal's mutations under the current session.
+        if (
+            entry.sessionId !== null &&
+            sessionUserId !== null &&
+            entry.sessionId !== sessionUserId
+        ) {
+            const delTx = db.transaction(SYNC_QUEUE, 'readwrite');
+            delTx.objectStore(SYNC_QUEUE).delete(entry.id);
+            continue;
+        }
+
         try {
             const response = await fetch(entry.url, {
                 method: entry.method,
@@ -170,18 +248,9 @@ async function replayQueuedRequests() {
         }
     }
 
-    // Notify open clients to refresh data
     const clients = await self.clients.matchAll({ type: 'window' });
     clients.forEach((client) => client.postMessage({ type: 'SYNC_COMPLETE' }));
 }
-
-// ─── Message handler (e.g. SKIP_WAITING for instant updates) ────────────────
-
-self.addEventListener('message', (event) => {
-    if (event.data?.type === 'SKIP_WAITING') {
-        self.skipWaiting();
-    }
-});
 
 // ─── IndexedDB helpers ───────────────────────────────────────────────────────
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,211 @@
+const CACHE_VERSION = 'tududi-v1';
+const API_CACHE = 'tududi-api-v1';
+const SYNC_QUEUE = 'tududi-sync-queue';
+
+const STATIC_ASSETS = [
+    '/',
+    '/manifest.json',
+    '/favicon.ico',
+    '/apple-touch-icon.png',
+    '/icon-logo.png',
+];
+
+// ─── Install ────────────────────────────────────────────────────────────────
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(CACHE_VERSION).then((cache) => cache.addAll(STATIC_ASSETS))
+    );
+    self.skipWaiting();
+});
+
+// ─── Activate ───────────────────────────────────────────────────────────────
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(
+        caches.keys().then((keys) =>
+            Promise.all(
+                keys
+                    .filter((key) => key !== CACHE_VERSION && key !== API_CACHE)
+                    .map((key) => caches.delete(key))
+            )
+        )
+    );
+    self.clients.claim();
+});
+
+// ─── Fetch ───────────────────────────────────────────────────────────────────
+
+self.addEventListener('fetch', (event) => {
+    const { request } = event;
+    const url = new URL(request.url);
+
+    // Only handle same-origin requests
+    if (url.origin !== self.location.origin) return;
+
+    if (url.pathname.startsWith('/api/')) {
+        if (request.method === 'GET') {
+            event.respondWith(handleApiGet(request));
+        } else {
+            event.respondWith(handleApiMutation(request));
+        }
+        return;
+    }
+
+    // Navigation: network-first, fall back to cached shell
+    if (request.mode === 'navigate') {
+        event.respondWith(
+            fetch(request).catch(() =>
+                caches.match('/').then((cached) => cached || fetch(request))
+            )
+        );
+        return;
+    }
+
+    // Static assets: cache-first
+    event.respondWith(
+        caches.match(request).then(
+            (cached) =>
+                cached ||
+                fetch(request).then((response) => {
+                    if (response.ok && response.type !== 'opaque') {
+                        const clone = response.clone();
+                        caches
+                            .open(CACHE_VERSION)
+                            .then((cache) => cache.put(request, clone));
+                    }
+                    return response;
+                })
+        )
+    );
+});
+
+// ─── API GET: network-first, stale cache fallback ────────────────────────────
+
+async function handleApiGet(request) {
+    try {
+        const response = await fetch(request);
+        if (response.ok) {
+            const cache = await caches.open(API_CACHE);
+            cache.put(request, response.clone());
+        }
+        return response;
+    } catch {
+        const cached = await caches.match(request, { cacheName: API_CACHE });
+        if (cached) return cached;
+        return new Response(
+            JSON.stringify({ error: 'Offline', offline: true }),
+            {
+                status: 503,
+                headers: { 'Content-Type': 'application/json' },
+            }
+        );
+    }
+}
+
+// ─── API Mutations: queue when offline, replay on sync ───────────────────────
+
+async function handleApiMutation(request) {
+    try {
+        return await fetch(request);
+    } catch {
+        await queueRequest(request);
+        return new Response(
+            JSON.stringify({ queued: true, offline: true }),
+            {
+                status: 202,
+                headers: { 'Content-Type': 'application/json' },
+            }
+        );
+    }
+}
+
+async function queueRequest(request) {
+    const body = await request.text().catch(() => '');
+    const entry = {
+        url: request.url,
+        method: request.method,
+        headers: Object.fromEntries(request.headers.entries()),
+        body,
+        timestamp: Date.now(),
+    };
+
+    const db = await openQueueDb();
+    const tx = db.transaction(SYNC_QUEUE, 'readwrite');
+    tx.objectStore(SYNC_QUEUE).add(entry);
+
+    // Register background sync if supported
+    if ('sync' in self.registration) {
+        await self.registration.sync.register('tududi-sync');
+    }
+}
+
+// ─── Background Sync ─────────────────────────────────────────────────────────
+
+self.addEventListener('sync', (event) => {
+    if (event.tag === 'tududi-sync') {
+        event.waitUntil(replayQueuedRequests());
+    }
+});
+
+async function replayQueuedRequests() {
+    const db = await openQueueDb();
+    const tx = db.transaction(SYNC_QUEUE, 'readwrite');
+    const store = tx.objectStore(SYNC_QUEUE);
+    const entries = await idbAll(store);
+
+    for (const entry of entries) {
+        try {
+            const response = await fetch(entry.url, {
+                method: entry.method,
+                headers: entry.headers,
+                body: entry.body || undefined,
+            });
+            if (response.ok) {
+                const delTx = db.transaction(SYNC_QUEUE, 'readwrite');
+                delTx.objectStore(SYNC_QUEUE).delete(entry.id);
+            }
+        } catch {
+            // Will retry on next sync event
+        }
+    }
+
+    // Notify open clients to refresh data
+    const clients = await self.clients.matchAll({ type: 'window' });
+    clients.forEach((client) => client.postMessage({ type: 'SYNC_COMPLETE' }));
+}
+
+// ─── Message handler (e.g. SKIP_WAITING for instant updates) ────────────────
+
+self.addEventListener('message', (event) => {
+    if (event.data?.type === 'SKIP_WAITING') {
+        self.skipWaiting();
+    }
+});
+
+// ─── IndexedDB helpers ───────────────────────────────────────────────────────
+
+function openQueueDb() {
+    return new Promise((resolve, reject) => {
+        const req = indexedDB.open('tududi-offline', 1);
+        req.onupgradeneeded = (e) => {
+            const db = e.target.result;
+            if (!db.objectStoreNames.contains(SYNC_QUEUE)) {
+                db.createObjectStore(SYNC_QUEUE, {
+                    keyPath: 'id',
+                    autoIncrement: true,
+                });
+            }
+        };
+        req.onsuccess = (e) => resolve(e.target.result);
+        req.onerror = () => reject(req.error);
+    });
+}
+
+function idbAll(store) {
+    return new Promise((resolve, reject) => {
+        const req = store.getAll();
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+    });
+}


### PR DESCRIPTION
## Description

Closes discussion #243 — makes Tududi installable as a Progressive Web App on mobile and desktop, and adds offline sync so users can view tasks without a connection and have mutations replayed automatically when they come back online.

The manifest and HTML link tag were already in place; the missing piece was a service worker.

## Type of Change

- [x] New feature

## Related Issues

Closes #243

## What Changed

**`public/manifest.json`**
- Fixed spec-violating `"purpose": "any maskable"` (must be separate icon entries per the Web App Manifest spec)
- Added `id`, `scope`, `lang`, `orientation` fields for broader browser compatibility

**`public/sw.js`** (new)
- **Install**: pre-caches static assets (shell, manifest, icons)
- **Activate**: cleans up stale cache versions
- **Fetch — API GETs**: network-first; on failure serves cached response so tasks/projects are readable offline
- **Fetch — API mutations**: attempts network; if offline, queues the request to IndexedDB and returns `202 queued`
- **Background Sync**: replays queued mutations when connectivity returns; notifies open clients to refresh via `postMessage`
- **Message handler**: responds to `SKIP_WAITING` for instant SW updates

**`frontend/index.tsx`**
- Registers `/sw.js` in production on `window load`
- Listens for `SYNC_COMPLETE` from the SW and calls SWR's global `mutate(() => true)` to revalidate all cached data after queued requests are replayed
- Handles SW update lifecycle (detects new worker, sends `SKIP_WAITING`)

## Limitations

- Write queueing works for most mutations but **creating tasks offline** may have edge cases due to id/uid mixing in the frontend (tracked in #1218). Queued POSTs will replay correctly as long as the server response ID isn't needed by other queued requests.
- Sub-path deployments (e.g. Home Assistant ingress) will need a dynamic manifest — the static `start_url: "/"` won't match. This is a future enhancement.

## Testing

```bash
# Build and serve production bundle
npm run build
npm start

# Then in Chrome DevTools:
# Application → Manifest — verify no errors
# Application → Service Workers — verify SW is registered
# Network tab → set "Offline" → navigate — verify tasks load from cache
# Network tab → offline → complete a task → go online — verify Background Sync replays it
```

- [ ] Chrome: install prompt appears in address bar after visiting the app
- [ ] Mobile Chrome: "Add to Home Screen" works
- [ ] Lighthouse PWA audit passes installability check
- [ ] Tasks visible when network is offline (cached read)
- [ ] Mutations queued when offline, replayed on reconnect

## Additional Notes

The service worker is only registered in production (`NODE_ENV === 'production'`). Development mode already had cleanup code that unregisters any lingering SWs — that code is preserved.