### PR TITLE
fix(caldav): align sync direction values with model constraints

### DIFF
--- a/backend/modules/caldav/api/calendar-controller.js
+++ b/backend/modules/caldav/api/calendar-controller.js
@@ -71,7 +71,7 @@ class CalendarController {
                 throw new AppError('Calendar name is required', 400);
             }
 
-            const validDirections = ['bidirectional', 'pull', 'push'];
+            const validDirections = ['bidirectional', 'pull_only', 'push_only'];
             if (!validDirections.includes(sync_direction)) {
                 throw new AppError(
                     `Invalid sync direction. Must be one of: ${validDirections.join(', ')}`,
@@ -153,7 +153,11 @@ class CalendarController {
             if (color !== undefined) updates.color = color;
             if (enabled !== undefined) updates.enabled = enabled;
             if (sync_direction !== undefined) {
-                const validDirections = ['bidirectional', 'pull', 'push'];
+                const validDirections = [
+                    'bidirectional',
+                    'pull_only',
+                    'push_only',
+                ];
                 if (!validDirections.includes(sync_direction)) {
                     throw new AppError(
                         `Invalid sync direction. Must be one of: ${validDirections.join(', ')}`,

--- a/backend/modules/caldav/api/remote-calendar-controller.js
+++ b/backend/modules/caldav/api/remote-calendar-controller.js
@@ -176,7 +176,7 @@ class RemoteCalendarController {
                 );
             }
 
-            const validDirections = ['bidirectional', 'pull', 'push'];
+            const validDirections = ['bidirectional', 'pull_only', 'push_only'];
             if (!validDirections.includes(sync_direction)) {
                 throw new AppError(
                     `Invalid sync direction. Must be one of: ${validDirections.join(', ')}`,
@@ -288,7 +288,11 @@ class RemoteCalendarController {
             }
             if (enabled !== undefined) updates.enabled = enabled;
             if (sync_direction !== undefined) {
-                const validDirections = ['bidirectional', 'pull', 'push'];
+                const validDirections = [
+                    'bidirectional',
+                    'pull_only',
+                    'push_only',
+                ];
                 if (!validDirections.includes(sync_direction)) {
                     throw new AppError(
                         `Invalid sync direction. Must be one of: ${validDirections.join(', ')}`,


### PR DESCRIPTION
## Description

The CalDAV sync direction dropdown allowed users to select "Pull only" or "Push only", but changing to either option produced a `SequelizeValidationError`. The root cause was a mismatch between the controller's validation allowlist and the Sequelize model constraints:

- **Controller** validated against: `['bidirectional', 'pull', 'push']`
- **Model** (and frontend) expected: `['bidirectional', 'pull_only', 'push_only']`

This affected both `calendar-controller.js` (local calendars) and `remote-calendar-controller.js` (remote/CalDAV calendars). The fix updates both controllers to use the correct `pull_only` / `push_only` values.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1188

## Testing

- [x] Ran full test suite: `npm test` — 1604 tests pass, 0 failures
- [x] Ran `npm run lint:fix` — 0 errors

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have tested my changes
- [x] No new warnings introduced