### PR TITLE
fix(caldav): eager load task associations so tags and parent links reach clients

### DIFF
--- a/backend/modules/caldav/task-includes.js
+++ b/backend/modules/caldav/task-includes.js
@@ -1,0 +1,22 @@
+const { Project, Tag, Task } = require('../../models');
+
+// Associations the VTODO serializer depends on.
+//
+// vtodo-serializer.js emits:
+//   CATEGORIES + X-TUDUDI-TAG-UIDS   when task.Tags is populated
+//   RELATED-TO;RELTYPE=PARENT        when task.parent_task_id && task.ParentTask
+//   X-TUDUDI-PROJECT-UID             when task.Project is populated
+//
+// Without eager loading these associations the serializer silently skips those
+// properties, so tags and parent links never reach CalDAV clients.
+const CALDAV_TASK_INCLUDES = [
+    { model: Project, attributes: ['id', 'uid', 'name'] },
+    {
+        model: Tag,
+        attributes: ['id', 'uid', 'name'],
+        through: { attributes: [] },
+    },
+    { model: Task, as: 'ParentTask', attributes: ['id', 'uid'] },
+];
+
+module.exports = { CALDAV_TASK_INCLUDES };

--- a/backend/modules/caldav/webdav/projects.js
+++ b/backend/modules/caldav/webdav/projects.js
@@ -18,12 +18,13 @@ const {
 const { generateETag } = require('../utils/etag-generator');
 const { generateCTag } = require('../utils/ctag-generator');
 const taskRepository = require('../../tasks/repository');
+const { CALDAV_TASK_INCLUDES } = require('../task-includes');
 const vtodoSerializer = require('../icalendar/vtodo-serializer');
 const { Project } = require('../../../models');
 const { Op } = require('sequelize');
 
 const INBOX_UID = '__inbox__';
-const INCLUDE_PROJECT = [{ model: Project, attributes: ['id', 'uid', 'name'] }];
+const INCLUDE_PROJECT = CALDAV_TASK_INCLUDES;
 const EMPTY_PROPFIND =
     '<?xml version="1.0"?><D:propfind xmlns:D="DAV:"><D:allprop/></D:propfind>';
 

--- a/backend/modules/caldav/webdav/propfind.js
+++ b/backend/modules/caldav/webdav/propfind.js
@@ -9,6 +9,7 @@ const { generateETag } = require('../utils/etag-generator');
 const { generateCTag } = require('../utils/ctag-generator');
 const calendarRepository = require('../repositories/calendar-repository');
 const taskRepository = require('../../tasks/repository');
+const { CALDAV_TASK_INCLUDES } = require('../task-includes');
 const vtodoSerializer = require('../icalendar/vtodo-serializer');
 
 async function handlePropfind(req, res) {
@@ -39,7 +40,9 @@ async function handlePropfind(req, res) {
 
         if (isTaskRequest) {
             const taskUid = req.params.uid.replace('.ics', '');
-            const task = await taskRepository.findByUid(taskUid);
+            const task = await taskRepository.findByUid(taskUid, {
+                include: CALDAV_TASK_INCLUDES,
+            });
 
             if (!task || task.user_id !== userId) {
                 return res.status(404).json({ error: 'Task not found' });
@@ -61,7 +64,13 @@ async function handlePropfind(req, res) {
             responses.push(calendarResponse);
 
             if (depth > 0) {
-                const tasks = await taskRepository.findByUser(userId);
+                const tasks = await taskRepository.findByUser(
+                    userId,
+                    {},
+                    {
+                        include: CALDAV_TASK_INCLUDES,
+                    }
+                );
                 for (const task of tasks) {
                     const taskResponse = await buildTaskResponse(
                         task,
@@ -87,7 +96,13 @@ async function handlePropfind(req, res) {
 
 async function buildCalendarResponse(username, userId, propfindRequest) {
     const href = buildHref(username);
-    const tasks = await taskRepository.findByUser(userId);
+    const tasks = await taskRepository.findByUser(
+        userId,
+        {},
+        {
+            include: CALDAV_TASK_INCLUDES,
+        }
+    );
     const ctag = generateCTag(tasks);
 
     const props = {

--- a/backend/modules/caldav/webdav/report.js
+++ b/backend/modules/caldav/webdav/report.js
@@ -7,6 +7,7 @@ const {
 } = require('./utils');
 const { generateETag } = require('../utils/etag-generator');
 const taskRepository = require('../../tasks/repository');
+const { CALDAV_TASK_INCLUDES } = require('../task-includes');
 const vtodoSerializer = require('../icalendar/vtodo-serializer');
 const { Op } = require('sequelize');
 
@@ -48,7 +49,9 @@ async function handleReport(req, res) {
                 }
 
                 const uid = decodeURIComponent(match[1]);
-                const task = await taskRepository.findByUid(uid);
+                const task = await taskRepository.findByUid(uid, {
+                    include: CALDAV_TASK_INCLUDES,
+                });
 
                 if (!task || task.user_id !== userId) {
                     responses.push(
@@ -138,7 +141,9 @@ async function handleReport(req, res) {
             }
         }
 
-        const tasks = await taskRepository.findAll(where);
+        const tasks = await taskRepository.findAll(where, {
+            include: CALDAV_TASK_INCLUDES,
+        });
 
         const responses = [];
         for (const task of tasks) {

--- a/backend/modules/caldav/webdav/task-handlers.js
+++ b/backend/modules/caldav/webdav/task-handlers.js
@@ -1,6 +1,7 @@
 const { generateETag } = require('../utils/etag-generator');
 const { matchesETag } = require('../utils/etag-generator');
 const taskRepository = require('../../tasks/repository');
+const { CALDAV_TASK_INCLUDES } = require('../task-includes');
 const vtodoSerializer = require('../icalendar/vtodo-serializer');
 const vtodoParser = require('../icalendar/vtodo-parser');
 const syncStateRepository = require('../repositories/sync-state-repository');
@@ -16,7 +17,9 @@ async function handleGetTask(req, res) {
         }
 
         const taskUid = uid.replace('.ics', '');
-        const task = await taskRepository.findByUid(taskUid);
+        const task = await taskRepository.findByUid(taskUid, {
+            include: CALDAV_TASK_INCLUDES,
+        });
 
         if (!task || task.user_id !== req.currentUser.id) {
             return res.status(404).send('Not Found');
@@ -70,7 +73,9 @@ async function handlePutTask(req, res) {
             return res.status(400).send('Bad Request: No data provided');
         }
 
-        const existingTask = await taskRepository.findByUid(taskUid);
+        const existingTask = await taskRepository.findByUid(taskUid, {
+            include: CALDAV_TASK_INCLUDES,
+        });
 
         if (existingTask && existingTask.user_id !== userId) {
             return res.status(403).json({ error: 'Forbidden' });
@@ -142,7 +147,9 @@ async function handleDeleteTask(req, res) {
         }
 
         const taskUid = uid.replace('.ics', '');
-        const task = await taskRepository.findByUid(taskUid);
+        const task = await taskRepository.findByUid(taskUid, {
+            include: CALDAV_TASK_INCLUDES,
+        });
 
         if (!task) {
             return res.status(404).send('Not Found');

--- a/backend/tests/integration/caldav-task-associations.test.js
+++ b/backend/tests/integration/caldav-task-associations.test.js
@@ -1,0 +1,111 @@
+const app = require('../../app');
+const { sequelize, User, Project, Tag, Task } = require('../../models');
+const bcrypt = require('bcrypt');
+const { report } = require('../helpers/caldav-test-utils');
+
+const ENC = encodeURIComponent;
+
+// Regression guard: the VTODO serializer only emits CATEGORIES /
+// X-TUDUDI-TAG-UIDS / RELATED-TO when the corresponding associations are eager
+// loaded. When the CalDAV queries dropped the `include`, those properties were
+// silently omitted for every task and no client ever saw tags or parent links.
+describe('CalDAV task associations reach the client', () => {
+    let testUser;
+    let authHeader;
+
+    beforeEach(async () => {
+        const hashedPassword = await bcrypt.hash('password123', 10);
+        testUser = await User.create({
+            email: 'associations-caldav@test.com',
+            password_digest: hashedPassword,
+            verified: true,
+        });
+
+        authHeader =
+            'Basic ' +
+            Buffer.from('associations-caldav@test.com:password123').toString(
+                'base64'
+            );
+    });
+
+    afterAll(async () => {
+        await sequelize.close();
+    });
+
+    const tasksUrl = () => `/caldav/${ENC(testUser.email)}/tasks/`;
+
+    const REPORT_XML = `<?xml version="1.0"?>
+        <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
+          <D:prop><C:calendar-data/></D:prop>
+          <C:filter>
+            <C:comp-filter name="VCALENDAR">
+              <C:comp-filter name="VTODO"/>
+            </C:comp-filter>
+          </C:filter>
+        </C:calendar-query>`;
+
+    const queryAll = () =>
+        report(app, tasksUrl())
+            .set('Authorization', authHeader)
+            .set('Content-Type', 'application/xml')
+            .send(REPORT_XML);
+
+    it('exposes tags as CATEGORIES', async () => {
+        const task = await Task.create({
+            uid: 'assoc-task-tagged',
+            user_id: testUser.id,
+            name: 'Tagged task',
+        });
+        const tag = await Tag.create({
+            uid: 'assoc-tag-1',
+            user_id: testUser.id,
+            name: 'errands',
+        });
+        await task.addTag(tag);
+
+        const res = await queryAll();
+
+        expect(res.status).toBe(207);
+        expect(res.text).toContain('CATEGORIES:errands');
+        expect(res.text).toContain('X-TUDUDI-TAG-UIDS:assoc-tag-1');
+    });
+
+    it('exposes the parent task as RELATED-TO', async () => {
+        const parent = await Task.create({
+            uid: 'assoc-task-parent',
+            user_id: testUser.id,
+            name: 'Parent task',
+        });
+        await Task.create({
+            uid: 'assoc-task-child',
+            user_id: testUser.id,
+            name: 'Child task',
+            parent_task_id: parent.id,
+        });
+
+        const res = await queryAll();
+
+        expect(res.status).toBe(207);
+        expect(res.text).toContain('RELATED-TO');
+        expect(res.text).toContain('assoc-task-parent');
+    });
+
+    it('exposes the project as X-TUDUDI-PROJECT-UID', async () => {
+        const project = await Project.create({
+            uid: 'assoc-project-1',
+            user_id: testUser.id,
+            name: 'Some project',
+        });
+        await Task.create({
+            uid: 'assoc-task-in-project',
+            user_id: testUser.id,
+            name: 'Task in a project',
+            project_id: project.id,
+        });
+
+        const res = await queryAll();
+
+        expect(res.status).toBe(207);
+        expect(res.text).toContain('X-TUDUDI-PROJECT-UID:assoc-project-1');
+    });
+});


### PR DESCRIPTION
## Problem

The VTODO serializer already knows how to emit tag, parent and project information:

- `CATEGORIES` + `X-TUDUDI-TAG-UIDS` — from `task.Tags` ([vtodo-serializer.js](https://github.com/chrisvel/tududi/blob/main/backend/modules/caldav/icalendar/vtodo-serializer.js))
- `RELATED-TO;RELTYPE=PARENT` — from `task.ParentTask`
- `X-TUDUDI-PROJECT-UID` — from `task.Project`

But the CalDAV layer loads tasks without eager loading those associations, e.g. `webdav/report.js`:

```js
const tasks = await taskRepository.findAll(where);
```

`taskRepository.findAll` passes options straight through to Sequelize, so with no `include` the associations are never populated. `task.Tags` and `task.ParentTask` are always `undefined`, the serializer branches never run, and those properties silently disappear from every VTODO.

Nothing errors out — the data simply never leaves the server, which makes this hard to notice.

## Real-world impact

On my instance: **50 tags applied to 167 of 268 tasks, and not one `CATEGORIES` property was ever sent.** I only found it while investigating why tags were missing in a client — the assumption was "Apple Reminders doesn't support tags for third-party CalDAV accounts" (which is also true), but the tags were not even on the wire, so no client could show them: not Apple Reminders, not 2Do, not tasks.org, not Thunderbird.

Same for subtasks: `RELATED-TO` never reaches clients that do support task hierarchies.

## Fix

Adds `backend/modules/caldav/task-includes.js` with a shared `CALDAV_TASK_INCLUDES` list, and uses it everywhere the CalDAV layer loads tasks for serialization:

- `webdav/report.js` — calendar-query and single-task lookup
- `webdav/propfind.js` — collection and single-task lookups
- `webdav/task-handlers.js` — `GET`/`PUT`/`DELETE` handlers
- `webdav/projects.js` — the existing `INCLUDE_PROJECT` becomes that shared list, so per-project calendars get tags and parent links too

The list keeps `attributes` narrow and uses `through: { attributes: [] }` for the tag join table, so the extra load stays small.

## Verification

Live instance (v1.3.0, ~278 tasks, `CALDAV_PROJECTS_AS_CALENDARS=true`), same task before and after:

Before:
```
BEGIN:VTODO
UID:tp9bnp57r60by7g
SUMMARY:Купить воду в маленьких бутылках для Victory Vienna
...
END:VTODO
```

After:
```
BEGIN:VTODO
UID:tp9bnp57r60by7g
SUMMARY:Купить воду в маленьких бутылках для Victory Vienna
CATEGORIES:victory-vienna
X-TUDUDI-TAG-UIDS:hs8cbzpmm7xji9y
...
END:VTODO
```

Across the whole collection after the change: **177 of 278 tasks carry `CATEGORIES` — exactly matching the 177 tagged tasks in the database** (`select count(distinct task_id) from tasks_tags`). Project UIDs are present on 184 tasks. No change in task count, no errors in the log, clients re-synced cleanly.

## Tests

Adds `backend/tests/integration/caldav-task-associations.test.js` covering all three properties. It **fails on current `main` (3/3) and passes with this change (3/3)** — I verified both directions by reverting `report.js` and re-running.

`prettier --check` is clean on all touched files.
