### PR TITLE
feat(inbox): multiline capture with autogrow textarea

### DIFF
--- a/frontend/components/Inbox/InboxItemDetail.tsx
+++ b/frontend/components/Inbox/InboxItemDetail.tsx
@@ -250,9 +250,15 @@ const InboxItemDetail: React.FC<InboxItemDetailProps> = ({
     );
     const projectRefs = parseProjectRefs(fullContent);
     const hasLongContent =
-        Boolean(item.title && item.title.trim()) &&
-        item.title !== null &&
-        item.title !== fullContent;
+        (Boolean(item.title && item.title.trim()) &&
+            item.title !== null &&
+            item.title !== fullContent) ||
+        fullContent.includes('\n');
+
+    const previewFirstLine = previewText.split('\n')[0];
+    const extraLineCount = previewText
+        .split('\n')
+        .filter((l) => l.trim().length > 0).length - 1;
     const iconTooltip = isBookmarkItem
         ? t('inbox.iconTooltip.bookmark', 'Bookmark link')
         : t('inbox.iconTooltip.text', 'Captured text');
@@ -677,7 +683,7 @@ const InboxItemDetail: React.FC<InboxItemDetailProps> = ({
                     openProjectModal={openProjectModal}
                     openNoteModal={openNoteModal}
                     cardClassName="mb-0"
-                    multiline={hasLongContent}
+                    multiline={true}
                 />
             ) : (
                 <InboxCard className="w-full">
@@ -705,7 +711,15 @@ const InboxItemDetail: React.FC<InboxItemDetailProps> = ({
                                     onClick={handleStartEdit}
                                     className="text-base font-medium text-gray-900 dark:text-gray-300 break-all text-left cursor-pointer w-full hover:text-blue-600 dark:hover:text-blue-400"
                                 >
-                                    {linkifyContent(previewText)}
+                                    {linkifyContent(previewFirstLine)}
+                                    {extraLineCount > 0 && (
+                                        <span className="ml-2 text-xs font-normal text-gray-400 dark:text-gray-500 align-middle">
+                                            +{extraLineCount}{' '}
+                                            {extraLineCount === 1
+                                                ? 'line'
+                                                : 'lines'}
+                                        </span>
+                                    )}
                                 </button>
                             </div>
                         </div>

--- a/frontend/components/Inbox/QuickCaptureInput.tsx
+++ b/frontend/components/Inbox/QuickCaptureInput.tsx
@@ -128,7 +128,7 @@ const QuickCaptureInput = React.forwardRef<
             openProjectModal,
             openNoteModal,
             cardClassName,
-            multiline = false,
+            multiline = true,
         },
         ref
     ) => {
@@ -187,6 +187,17 @@ const QuickCaptureInput = React.forwardRef<
                 inputRef.current.focus();
             }
         }, [autoFocus]);
+
+        useEffect(() => {
+            if (!multiline) return;
+            const el = inputRef.current;
+            if (!el) return;
+            el.style.height = 'auto';
+            const maxHeight = 300;
+            el.style.height = `${Math.min(el.scrollHeight, maxHeight)}px`;
+            (el as HTMLElement).style.overflowY =
+                el.scrollHeight > maxHeight ? 'auto' : 'hidden';
+        }, [inputText, multiline]);
 
         const clearComposerText = useCallback(() => {
             setInputText('');
@@ -1436,7 +1447,7 @@ const QuickCaptureInput = React.forwardRef<
                                             inputRef.current = el;
                                         }}
                                         value={inputText}
-                                        rows={6}
+                                        rows={2}
                                         onChange={handleChange}
                                         onSelect={(e) => {
                                             const pos =
@@ -1489,10 +1500,10 @@ const QuickCaptureInput = React.forwardRef<
                                                 setDropdownPosition(position);
                                             }
                                         }}
-                                        className="w-full text-base font-normal bg-transparent text-gray-900 dark:text-gray-100 border-0 focus:outline-none focus:ring-0 px-0 py-2 placeholder-gray-400 dark:placeholder-gray-500 resize-none"
+                                        className="w-full text-base font-normal bg-transparent text-gray-900 dark:text-gray-100 border-0 focus:outline-none focus:ring-0 px-0 py-2 placeholder-gray-400 dark:placeholder-gray-500 resize-none overflow-hidden"
                                         placeholder={t(
-                                            'inbox.captureThought',
-                                            'Capture a thought...'
+                                            'inbox.captureThoughtMultiline',
+                                            'Capture a thought...  ·  Shift+Enter for new line'
                                         )}
                                         onKeyDown={(e) => {
                                             const hasTagSuggestions =


### PR DESCRIPTION
## Description

The inbox capture input was a single-line `<input type="text">`, which physically cannot accept newlines. Any thought longer than one sentence had to go somewhere else and never came back.

This PR switches the capture surface to an autogrow textarea following the chat-input convention: **Enter submits, Shift+Enter inserts a newline**. The list view stays scannable by showing only the first line with a `+N lines` badge when more exists. Edit mode always opens a textarea so multiline items can be round-tripped correctly.

No backend changes — the `content` column is already `TEXT` and `validateContent` only calls `.trim()`, which preserves internal newlines.

## Type of Change

- [x] New feature (adds functionality)

## Related Issues

Fixes #

## Testing

**How did you test this?**

- Typed multiline text in the capture input using Shift+Enter; newlines persisted through save and reload
- Verified Enter still submits without adding a newline
- Verified existing single-line items render unchanged in the list
- Verified the `+N lines` badge appears for multiline items and disappears after editing back to one line
- Verified edit mode opens a textarea pre-filled with full multiline content

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

The `inbox.captureThoughtMultiline` i18n key was added with a default of `"Capture a thought...  ·  Shift+Enter for new line"`. Translators will need to add it to their locale files; until then the English default is shown.

The autogrow is capped at 300px with `overflow-y: auto` beyond that, so very long captures don't push the submit button off-screen.