### PR TITLE
feat(goals): full goals UX overhaul with area integration

### DIFF
--- a/backend/migrations/20260730000001-make-goals-area-id-nullable.js
+++ b/backend/migrations/20260730000001-make-goals-area-id-nullable.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { safeChangeColumn } = require('../utils/migration-utils');
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await safeChangeColumn(queryInterface, 'goals', 'area_id', {
+            type: Sequelize.INTEGER,
+            allowNull: true,
+            references: {
+                model: 'areas',
+                key: 'id',
+            },
+            onUpdate: 'CASCADE',
+            onDelete: 'SET NULL',
+        });
+    },
+
+    async down(queryInterface, Sequelize) {
+        await queryInterface.sequelize.query(
+            'UPDATE goals SET area_id = 0 WHERE area_id IS NULL;'
+        );
+        await safeChangeColumn(queryInterface, 'goals', 'area_id', {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+            references: {
+                model: 'areas',
+                key: 'id',
+            },
+        });
+    },
+};

--- a/backend/migrations/20260730000002-add-goal-id-to-tasks.js
+++ b/backend/migrations/20260730000002-add-goal-id-to-tasks.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { safeAddColumns, safeAddIndex } = require('../utils/migration-utils');
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await safeAddColumns(queryInterface, 'tasks', [
+            {
+                name: 'goal_id',
+                definition: {
+                    type: Sequelize.INTEGER,
+                    allowNull: true,
+                    references: {
+                        model: 'goals',
+                        key: 'id',
+                    },
+                    onUpdate: 'CASCADE',
+                    onDelete: 'SET NULL',
+                },
+            },
+        ]);
+
+        await safeAddIndex(queryInterface, 'tasks', ['goal_id'], {
+            name: 'tasks_goal_id_idx',
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeIndex('tasks', 'tasks_goal_id_idx');
+        await queryInterface.removeColumn('tasks', 'goal_id');
+    },
+};

--- a/backend/models/goal.js
+++ b/backend/models/goal.js
@@ -18,7 +18,7 @@ module.exports = (sequelize) => {
             },
             area_id: {
                 type: DataTypes.INTEGER,
-                allowNull: false,
+                allowNull: true,
                 references: {
                     model: 'areas',
                     key: 'id',

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -112,6 +112,8 @@ Goal.belongsTo(User, { foreignKey: 'user_id' });
 Area.hasMany(Goal, { foreignKey: 'area_id', as: 'Goals' });
 Goal.belongsTo(Area, { foreignKey: 'area_id' });
 Goal.hasMany(Project, { foreignKey: 'goal_id', as: 'Projects' });
+Goal.hasMany(Task, { foreignKey: 'goal_id', as: 'Tasks' });
+Task.belongsTo(Goal, { foreignKey: 'goal_id', allowNull: true, as: 'Goal' });
 
 User.hasMany(Project, { foreignKey: 'user_id' });
 Project.belongsTo(User, { foreignKey: 'user_id' });

--- a/backend/models/task.js
+++ b/backend/models/task.js
@@ -134,6 +134,14 @@ module.exports = (sequelize) => {
                     key: 'id',
                 },
             },
+            goal_id: {
+                type: DataTypes.INTEGER,
+                allowNull: true,
+                references: {
+                    model: 'goals',
+                    key: 'id',
+                },
+            },
             recurring_parent_id: {
                 type: DataTypes.INTEGER,
                 allowNull: true,

--- a/backend/modules/goals/controller.js
+++ b/backend/modules/goals/controller.js
@@ -26,7 +26,7 @@ const goalsController = {
         try {
             const userId = requireUserId(req);
             const goal = await goalsService.getByUid(userId, req.params.uid);
-            res.json(goal);
+            res.json({ goal });
         } catch (err) {
             next(err);
         }

--- a/backend/modules/goals/repository.js
+++ b/backend/modules/goals/repository.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Goal, Area } = require('../../models');
+const { Goal, Area, Project, Task } = require('../../models');
 
 class GoalsRepository {
     async findAllByUser(userId) {
@@ -28,6 +28,25 @@ class GoalsRepository {
             where: { uid, user_id: userId },
             include: [
                 { model: Area, attributes: ['id', 'uid', 'name', 'color'] },
+                {
+                    model: Project,
+                    as: 'Projects',
+                    attributes: ['id', 'uid', 'name', 'status', 'active_until'],
+                },
+                {
+                    model: Task,
+                    as: 'Tasks',
+                    attributes: [
+                        'id',
+                        'uid',
+                        'name',
+                        'status',
+                        'priority',
+                        'due_date',
+                        'project_id',
+                        'area_id',
+                    ],
+                },
             ],
         });
     }

--- a/backend/modules/goals/repository.js
+++ b/backend/modules/goals/repository.js
@@ -4,14 +4,14 @@ const { Goal, Area, Project, Task, sequelize } = require('../../models');
 const { Op } = require('sequelize');
 
 class GoalsRepository {
-    async _attachCounts(goals) {
+    async _attachCounts(goals, userId) {
         if (goals.length === 0) return [];
 
         const goalIds = goals.map((g) => g.id);
 
         const [projectCounts, taskCounts] = await Promise.all([
             Project.findAll({
-                where: { goal_id: { [Op.in]: goalIds } },
+                where: { goal_id: { [Op.in]: goalIds }, user_id: userId },
                 attributes: [
                     'goal_id',
                     [sequelize.fn('COUNT', sequelize.col('id')), 'count'],
@@ -20,7 +20,11 @@ class GoalsRepository {
                 raw: true,
             }),
             Task.findAll({
-                where: { goal_id: { [Op.in]: goalIds }, parent_task_id: null },
+                where: {
+                    goal_id: { [Op.in]: goalIds },
+                    user_id: userId,
+                    parent_task_id: null,
+                },
                 attributes: [
                     'goal_id',
                     [sequelize.fn('COUNT', sequelize.col('id')), 'count'],
@@ -54,7 +58,7 @@ class GoalsRepository {
             ],
             order: [['title', 'ASC']],
         });
-        return this._attachCounts(goals);
+        return this._attachCounts(goals, userId);
     }
 
     async findAllByArea(userId, areaId) {
@@ -65,7 +69,7 @@ class GoalsRepository {
             ],
             order: [['title', 'ASC']],
         });
-        return this._attachCounts(goals);
+        return this._attachCounts(goals, userId);
     }
 
     async findByUid(userId, uid) {
@@ -76,11 +80,15 @@ class GoalsRepository {
                 {
                     model: Project,
                     as: 'Projects',
+                    where: { user_id: userId },
+                    required: false,
                     attributes: ['id', 'uid', 'name', 'status', 'color'],
                 },
                 {
                     model: Task,
                     as: 'Tasks',
+                    where: { user_id: userId },
+                    required: false,
                     attributes: [
                         'id',
                         'uid',

--- a/backend/modules/goals/repository.js
+++ b/backend/modules/goals/repository.js
@@ -1,26 +1,71 @@
 'use strict';
 
-const { Goal, Area, Project, Task } = require('../../models');
+const { Goal, Area, Project, Task, sequelize } = require('../../models');
+const { Op } = require('sequelize');
 
 class GoalsRepository {
+    async _attachCounts(goals) {
+        if (goals.length === 0) return [];
+
+        const goalIds = goals.map((g) => g.id);
+
+        const [projectCounts, taskCounts] = await Promise.all([
+            Project.findAll({
+                where: { goal_id: { [Op.in]: goalIds } },
+                attributes: [
+                    'goal_id',
+                    [sequelize.fn('COUNT', sequelize.col('id')), 'count'],
+                ],
+                group: ['goal_id'],
+                raw: true,
+            }),
+            Task.findAll({
+                where: { goal_id: { [Op.in]: goalIds }, parent_task_id: null },
+                attributes: [
+                    'goal_id',
+                    [sequelize.fn('COUNT', sequelize.col('id')), 'count'],
+                ],
+                group: ['goal_id'],
+                raw: true,
+            }),
+        ]);
+
+        const projectMap = {};
+        projectCounts.forEach((r) => {
+            projectMap[r.goal_id] = parseInt(r.count, 10);
+        });
+        const taskMap = {};
+        taskCounts.forEach((r) => {
+            taskMap[r.goal_id] = parseInt(r.count, 10);
+        });
+
+        return goals.map((goal) => ({
+            ...goal.toJSON(),
+            projects_count: projectMap[goal.id] || 0,
+            tasks_count: taskMap[goal.id] || 0,
+        }));
+    }
+
     async findAllByUser(userId) {
-        return Goal.findAll({
+        const goals = await Goal.findAll({
             where: { user_id: userId },
             include: [
                 { model: Area, attributes: ['id', 'uid', 'name', 'color'] },
             ],
             order: [['title', 'ASC']],
         });
+        return this._attachCounts(goals);
     }
 
     async findAllByArea(userId, areaId) {
-        return Goal.findAll({
+        const goals = await Goal.findAll({
             where: { user_id: userId, area_id: areaId },
             include: [
                 { model: Area, attributes: ['id', 'uid', 'name', 'color'] },
             ],
             order: [['title', 'ASC']],
         });
+        return this._attachCounts(goals);
     }
 
     async findByUid(userId, uid) {
@@ -31,7 +76,7 @@ class GoalsRepository {
                 {
                     model: Project,
                     as: 'Projects',
-                    attributes: ['id', 'uid', 'name', 'status', 'active_until'],
+                    attributes: ['id', 'uid', 'name', 'status', 'color'],
                 },
                 {
                     model: Task,

--- a/backend/modules/goals/service.js
+++ b/backend/modules/goals/service.js
@@ -30,12 +30,9 @@ class GoalsService {
         if (!title || !title.trim()) {
             throw new ValidationError('Goal title is required');
         }
-        if (!area_id) {
-            throw new ValidationError('Goal must belong to an area');
-        }
         return goalsRepository.create({
             user_id: userId,
-            area_id,
+            area_id: area_id || null,
             title: title.trim(),
             why: why || null,
             horizon: horizon || 'season',

--- a/backend/modules/tasks/core/serializers.js
+++ b/backend/modules/tasks/core/serializers.js
@@ -109,6 +109,7 @@ async function serializeTask(
         uid: task.uid,
         project_uid: taskJson.Project?.uid || null,
         area_uid: taskJson.Area?.uid || null,
+        goal_uid: taskJson.Goal?.uid || null,
         recurring_parent_uid: recurringParentUid,
         due_date: processDueDateForResponse(taskJson.due_date, safeTimezone),
         defer_until: processDeferUntilForResponse(

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -43,6 +43,7 @@ const {
     validateParentTaskAccess,
     validateDeferUntilAndDueDate,
     validateAreaAccess,
+    validateGoalAccess,
 } = require('./utils/validation');
 const {
     buildTaskAttributes,
@@ -413,6 +414,7 @@ router.post('/task', async (req, res) => {
             project_uid,
             area_id,
             area_uid,
+            goal_id,
             parent_task_id,
             tags,
             Tags,
@@ -475,6 +477,16 @@ router.post('/task', async (req, res) => {
                 req.currentUser.id
             );
             if (validParentId) taskAttributes.parent_task_id = validParentId;
+        } catch (error) {
+            return res.status(400).json({ error: error.message });
+        }
+
+        try {
+            const validGoalId = await validateGoalAccess(
+                goal_id,
+                req.currentUser.id
+            );
+            if (validGoalId) taskAttributes.goal_id = validGoalId;
         } catch (error) {
             return res.status(400).json({ error: error.message });
         }
@@ -566,6 +578,7 @@ router.patch('/task/:uid', requireTaskWriteAccess, async (req, res) => {
             project_uid,
             area_id,
             area_uid,
+            goal_id,
             parent_task_id,
             tags,
             Tags,
@@ -710,6 +723,22 @@ router.patch('/task/:uid', requireTaskWriteAccess, async (req, res) => {
                 }
             } else {
                 taskAttributes.parent_task_id = null;
+            }
+        }
+
+        if (goal_id !== undefined) {
+            if (goal_id && goal_id.toString().trim()) {
+                try {
+                    const validGoalId = await validateGoalAccess(
+                        goal_id,
+                        req.currentUser.id
+                    );
+                    taskAttributes.goal_id = validGoalId;
+                } catch (error) {
+                    return res.status(400).json({ error: error.message });
+                }
+            } else {
+                taskAttributes.goal_id = null;
             }
         }
 

--- a/backend/modules/tasks/utils/constants.js
+++ b/backend/modules/tasks/utils/constants.js
@@ -1,4 +1,4 @@
-const { Tag, Project, Area, Task, Person } = require('../../../models');
+const { Tag, Project, Area, Task, Person, Goal } = require('../../../models');
 
 const TASK_INCLUDES = [
     {
@@ -20,6 +20,12 @@ const TASK_INCLUDES = [
         model: Person,
         as: 'AssignedTo',
         attributes: ['uid', 'name', 'color', 'relationship_type'],
+        required: false,
+    },
+    {
+        model: Goal,
+        as: 'Goal',
+        attributes: ['id', 'uid', 'title', 'status'],
         required: false,
     },
 ];

--- a/backend/modules/tasks/utils/validation.js
+++ b/backend/modules/tasks/utils/validation.js
@@ -1,4 +1,4 @@
-const { Project, Task, Area } = require('../../../models');
+const { Project, Task, Area, Goal } = require('../../../models');
 const permissionsService = require('../../../services/permissionsService');
 
 function isUid(value) {
@@ -159,9 +159,27 @@ async function validateAreaAccess(areaIdOrUid, userId) {
     return area.id;
 }
 
+async function validateGoalAccess(goalIdOrUid, userId) {
+    if (!goalIdOrUid || !goalIdOrUid.toString().trim()) {
+        return null;
+    }
+
+    const value = goalIdOrUid.toString().trim();
+    const where = isUid(value)
+        ? { uid: value, user_id: userId }
+        : { id: value, user_id: userId };
+    const goal = await Goal.findOne({ where });
+    if (!goal) {
+        throw new Error('Invalid goal.');
+    }
+
+    return goal.id;
+}
+
 module.exports = {
     validateProjectAccess,
     validateParentTaskAccess,
     validateDeferUntilAndDueDate,
     validateAreaAccess,
+    validateGoalAccess,
 };

--- a/docs/00-tasks-behavior.md
+++ b/docs/00-tasks-behavior.md
@@ -202,6 +202,19 @@ This document explains how tasks work in tududi from a user behavior perspective
     - Subtasks inherit parent task's project
     - Changing parent's project doesn't automatically update subtasks
 
+### Goal Assignment
+
+29. **Tasks can be directly assigned to a goal:**
+    - Optional `goal_id` field links the task to a specific goal
+    - Independent of any project — a task's goal and its project's goal are separate fields
+    - Set via the **Goal** card in the Task detail page sidebar (below the Area card)
+    - When a goal is deleted, `goal_id` is set to `null` on all tasks that referenced it
+
+30. **Goal assignment effects:**
+    - The task appears in the Goal detail page's Tasks section
+    - Useful for tracking work-toward-a-goal that doesn't fit inside a project
+    - No permission changes — goal access follows the task's normal permissions
+
 ---
 
 ## **Tags**

--- a/docs/07-areas.md
+++ b/docs/07-areas.md
@@ -745,10 +745,12 @@ Clicking an area card navigates to `/area/:uid-slug`, the Area detail page. This
 
 **Left column - Goals spine:**
 - Lists active goals, each with their linked project cards underneath
+- Goal titles are clickable links that navigate to the Goal detail page (`/goal/:uid-slug`)
+- "Add goal" button opens GoalModal (area pre-filled) to create a new goal
+- Deleting a goal opens a ConfirmDialog before proceeding
 - A "Maintenance" bucket for projects flagged as maintenance work
 - An "Unlinked" bucket for projects not yet assigned to a goal
 - A collapsed "Inactive goals" section
-- "Add goal" button to create goals inline
 - Warning banner if there are more than 5 active goals (scarcity nudge)
 
 **Right column - Tasks:**

--- a/docs/12-goals-system.md
+++ b/docs/12-goals-system.md
@@ -6,23 +6,25 @@ This document explains how goals work in tududi. For technical details see `/bac
 
 ## Overview
 
-**Goals** are outcome-level intentions that answer *why* a group of projects or tasks exists. They sit between Areas and Projects in the conceptual hierarchy, but are now first-class standalone entities with their own list page, detail page, and sidebar navigation — not embedded inside any single area.
+**Goals** are top-level outcome intentions that answer *why* a group of projects or tasks exists. They are the highest-level planning layer — above Areas — with their own list page, detail page, and sidebar navigation.
 
 **Hierarchy position:**
 ```
-Areas (life domains, optional)
-  └── Goals (season- or year-scale outcomes)
-        ├── Projects (specific initiatives)
-        │     └── Tasks (actionable items)
-        └── Tasks (directly assigned, without a project)
+Goals (season- or year-scale outcomes)   ← top level
+  ├── Projects (specific initiatives)
+  │     └── Tasks (actionable items)
+  └── Tasks (directly assigned, without a project)
+
+Areas (life domains, organizational containers)  ← parallel, not parent
+  └── Projects (can belong to an area AND a goal)
 ```
 
 **Key characteristics:**
-- Standalone entities — accessible from `/goals` and the sidebar
-- Area is optional (`area_id` is nullable); a goal can exist without belonging to any area
+- Top-level standalone entities — accessible from `/goals` and the sidebar
+- Not tied to any area; goals are independent of the Areas system
+- Projects can link to a goal regardless of which area they belong to
 - Have a time horizon: `season` or `year`
 - Have a status lifecycle: `active → achieved / paused / dropped`
-- Projects can be linked to a goal, flagged as maintenance, or left unlinked
 - Tasks can be assigned directly to a goal (in addition to the project→goal path)
 
 ---
@@ -36,7 +38,7 @@ Areas (life domains, optional)
 | `horizon` | enum | yes | `season` or `year`. Default: `season`. |
 | `target_date` | date | no | Optional deadline for the goal. |
 | `status` | enum | yes | `active`, `achieved`, `paused`, `dropped`. Default: `active`. |
-| `area_id` | integer | no | Optional parent area. Can be null. |
+| `area_id` | integer | no | Stored in DB but not exposed in UI. Goals are area-independent. |
 | `uid` | string | auto | URL-safe unique identifier. |
 
 ---

--- a/docs/12-goals-system.md
+++ b/docs/12-goals-system.md
@@ -1,27 +1,29 @@
 # Goals System - Behavior Rules
 
-This document explains how goals work in tududi. For technical details see `/backend/modules/goals/` and `/frontend/components/Area/AreaDetails.tsx`.
+This document explains how goals work in tududi. For technical details see `/backend/modules/goals/` and `/frontend/components/Goal/`.
 
 ---
 
 ## Overview
 
-**Goals** are outcome-level intentions that sit between Areas and Projects in the organizational hierarchy. They answer *why* a group of projects exists, give projects a destination to aim at, and make it easy to see whether your active work is moving toward something meaningful.
+**Goals** are outcome-level intentions that answer *why* a group of projects or tasks exists. They sit between Areas and Projects in the conceptual hierarchy, but are now first-class standalone entities with their own list page, detail page, and sidebar navigation — not embedded inside any single area.
 
 **Hierarchy position:**
 ```
-Areas (life domains)
+Areas (life domains, optional)
   └── Goals (season- or year-scale outcomes)
-        └── Projects (specific initiatives)
-              └── Tasks (actionable items)
+        ├── Projects (specific initiatives)
+        │     └── Tasks (actionable items)
+        └── Tasks (directly assigned, without a project)
 ```
 
 **Key characteristics:**
-- Belong to exactly one Area
+- Standalone entities — accessible from `/goals` and the sidebar
+- Area is optional (`area_id` is nullable); a goal can exist without belonging to any area
 - Have a time horizon: `season` or `year`
 - Have a status lifecycle: `active → achieved / paused / dropped`
 - Projects can be linked to a goal, flagged as maintenance, or left unlinked
-- Managed entirely from the Area detail page - no separate Goals page
+- Tasks can be assigned directly to a goal (in addition to the project→goal path)
 
 ---
 
@@ -30,11 +32,11 @@ Areas (life domains)
 | Field | Type | Required | Notes |
 |-------|------|----------|-------|
 | `title` | string | yes | The outcome statement. Max 255 chars. |
-| `why` | text | no | The motivation behind the goal. Displayed in italics under the title. |
+| `why` | text | no | The motivation behind the goal. Displayed in italics. |
 | `horizon` | enum | yes | `season` or `year`. Default: `season`. |
 | `target_date` | date | no | Optional deadline for the goal. |
 | `status` | enum | yes | `active`, `achieved`, `paused`, `dropped`. Default: `active`. |
-| `area_id` | integer | yes | The parent area. Cannot be changed after creation. |
+| `area_id` | integer | no | Optional parent area. Can be null. |
 | `uid` | string | auto | URL-safe unique identifier. |
 
 ---
@@ -50,33 +52,111 @@ active → dropped    (abandoned or no longer relevant)
 paused → active     (resuming)
 ```
 
-There is no enforced ordering - any status can move to any other.
+There is no enforced ordering — any status can transition to any other.
 
 ### Creating a goal
 
-1. Navigate to an Area detail page (`/area/:uid-slug`)
-2. Click **Add goal** next to the Goals heading
-3. Fill in the inline form:
-   - Title (required)
-   - Why (optional, displayed as context)
-   - Horizon (`season` / `year`)
-   - Status (defaults to `active`)
-   - Target date (optional)
-4. Click **Add goal** to save
+Goals can be created from multiple entry points:
+
+1. **Goals list page** (`/goals`): header button opens GoalModal
+2. **Sidebar**: click the **+** icon next to the Goals section heading
+3. **Area detail page**: click **Add goal** next to the Goals heading
+
+GoalModal fields:
+- Title (required)
+- Why (optional)
+- Horizon (`season` / `year`)
+- Status (defaults to `active`)
+- Target date (optional)
+- Area (optional — pick from dropdown or leave blank)
 
 ### Editing a goal
 
-Click the pencil icon on any goal row. The same inline form opens, pre-filled. Click **Update** to save.
+Click the pencil (edit) icon on any goal card on the Goals list page, or the edit button in the Goal detail page header. GoalModal opens pre-filled. Save to update.
+
+From the Area detail page: click the pencil icon on a goal row — same GoalModal opens.
 
 ### Deleting a goal
 
-Click the trash icon. A confirmation prompt warns that linked projects will become unlinked. The goal record is deleted; projects that referenced it have their `goal_id` set to `null` (they become "unlinked" projects in the Area view).
+Click the trash icon (Goals list page, Goal detail page, or Area detail page). A confirmation dialog warns that linked projects will become unlinked. The goal record is deleted; projects that referenced it have `goal_id` set to `null`.
 
 ---
 
 ## Scarcity Rule
 
-The Area detail page displays a warning banner when an area has **more than 5 active goals**. The message encourages the user to achieve or pause one before adding more. This is a soft nudge, not an enforced limit.
+The Area detail page displays a warning banner when an area has **more than 5 active goals**. This is a soft nudge, not an enforced limit.
+
+---
+
+## Goals List Page (`/goals`)
+
+A grid view of all the user's goals across all areas.
+
+**Layout:** Responsive grid (1 / 2 / 3 / 4 columns depending on screen size)
+
+**Each goal card shows:**
+- Title
+- Why text (truncated)
+- Status badge (color-coded)
+- Horizon badge
+- Area name (if set)
+- Project count and task count in a footer stats bar
+- Three-dot menu (hover) with Edit and Delete
+
+Clicking a card navigates to the Goal detail page.
+
+---
+
+## Goal Detail Page (`/goal/:uid-slug`)
+
+The goal detail page shows everything assigned to the goal, modelled after the Tag detail page.
+
+**URL format:** `/goal/{uid}-{title-slug}` — e.g., `/goal/abc123-launch-new-product`
+
+**Header banner:**
+- Goal title
+- Why text (italic, below title)
+- Status badge and horizon badge
+- Target date (if set)
+- Area name as a link to the area (if set)
+- Task and project counts
+- Edit (pencil) and Delete (trash) buttons
+
+**Two-column layout:**
+
+```
+┌─────────────────────┐  ┌─────────────────────────────┐
+│  Projects (1/3)     │  │  Tasks (2/3)                │
+│                     │  │                             │
+│  [project card]     │  │  [active tasks list]        │
+│  [project card]     │  │                             │
+│                     │  │  Completed (n)              │
+│                     │  │  [completed tasks list]     │
+└─────────────────────┘  └─────────────────────────────┘
+```
+
+**Projects section:**
+- Lists projects with `goal_id` pointing to this goal
+- Each project shows name, status, and a left-colored border
+- Click navigates to the project detail page
+
+**Tasks section:**
+- Lists tasks with `goal_id` pointing to this goal (direct assignment, not via project)
+- Active tasks shown first, completed tasks below in a "Completed (n)" subsection
+- Task rows show name, due date, and a check icon
+
+---
+
+## Sidebar Integration
+
+The Goals section appears in the left sidebar between Areas and Notes.
+
+- **Click the section label** → navigates to `/goals`
+- **Click the `+` icon** (hover to reveal) → opens GoalModal to create a new goal
+- **Click the chevron** → expands/collapses an inline list of active goals
+- **Each goal row** in the expanded list → navigates to that goal's detail page
+
+Only `status = active` goals are shown in the expandable list.
 
 ---
 
@@ -87,75 +167,59 @@ Each project in an area can be in one of three states relative to goals:
 | State | `goal_id` | `is_maintenance` | Meaning |
 |-------|-----------|------------------|---------|
 | Linked to goal | set | false | Project is working toward a specific goal |
-| Maintenance | null | true | Project keeps something running - not goal-directed |
+| Maintenance | null | true | Project keeps something running — not goal-directed |
 | Unlinked | null | false | Project not yet assigned to a goal or maintenance |
 
 ### Linking a project to a goal
 
-From the Area detail page, unlinked projects show a **link…** button. Clicking it opens an inline picker:
-1. Select a goal from the dropdown (only active goals shown)
-2. Click **Link** to save - or click **Maintenance** to mark it as maintenance instead
-3. The project moves out of the "Unlinked" bucket immediately
+**From the Area detail page**, unlinked projects show a **link…** button. Clicking it opens an inline picker to select a goal or mark as maintenance.
 
-From the Project modal (when editing a project):
+**From the Project modal** (when editing a project):
 1. Expand the **Goal** section (flag icon in toolbar)
-2. An area must already be selected - goals are fetched for that area
+2. An area must already be selected — goals are fetched for that area
 3. Choose from: No goal / Maintenance / active goals / inactive goals
-4. Save the project
 
 ### Unlinking
 
-Deleting the goal sets `goal_id` to `null` on all its projects. To manually unlink a project, open the project modal → Goal section → select **No goal**.
+Deleting the goal sets `goal_id = null` on all its projects (they become unlinked). To manually unlink, open the project modal → Goal section → select **No goal**.
 
 ---
 
-## Area Detail Page Layout
+## Task–Goal Relationship
 
-The Area detail page (`/area/:uid-slug`) is the primary interface for goals. It has a two-column layout:
+Tasks can be directly assigned to a goal, independent of any project.
 
-```
-┌─────────────────────────────────────┐
-│  Area header (name, description,    │
-│  stats: projects / tasks / goals)   │
-└─────────────────────────────────────┘
-┌─────────────────┐  ┌────────────────┐
-│  Goals column   │  │  Tasks column  │
-│  (1/3 width)    │  │  (2/3 width)   │
-│                 │  │                │
-│  [Add goal]     │  │  Active tasks  │
-│                 │  │  Completed     │
-│  ● Goal A       │  │  tasks         │
-│    PROJECTS     │  │                │
-│    ┌──────────┐ │  │                │
-│    │ Project 1│ │  │                │
-│    └──────────┘ │  │                │
-│                 │  │                │
-│  ● Goal B       │  │                │
-│    No projects  │  │                │
-│    linked       │  │                │
-│                 │  │                │
-│  🔧 Maintenance │  │                │
-│    PROJECTS     │  │                │
-│    ┌──────────┐ │  │                │
-│    │ Project 2│ │  │                │
-│    └──────────┘ │  │                │
-│                 │  │                │
-│  › Unlinked (1) │  │                │
-│                 │  │                │
-│  ▼ Inactive (2) │  │                │
-└─────────────────┘  └────────────────┘
-```
+### Assigning a task to a goal
 
-**Buckets in the Goals column (in order):**
-1. **Active goals** - each with its project cards underneath
-2. **Maintenance** - projects flagged `is_maintenance = true`
-3. **Unlinked** - projects with no goal and no maintenance flag
-4. **Inactive goals** - collapsed under a `<details>` element; shows `achieved`, `paused`, `dropped` goals
+From the **Task detail page** (`/task/:uid`): the right sidebar contains a **Goal** card (below the Area card). Click it to open a searchable dropdown of all goals. Select a goal to save.
 
-**Project cards** show:
-- A left-colored border using the project's color
-- A "PROJECTS" label above the card group
-- Project name (links to project detail)
+To remove: click the X button on the selected goal, or click the card and choose a different goal.
+
+### What this means
+
+- A task can carry its own `goal_id` that is separate from its project's `goal_id`.
+- The Goal detail page lists tasks that are directly assigned to the goal via this field.
+- There is no inherited goal_id from project → task; task and project goals are independent fields.
+
+---
+
+## Area Detail Page — Goals Section
+
+The Area detail page (`/area/:uid-slug`) retains a goals column that shows all goals belonging to that area.
+
+**Changed from the original implementation:**
+- "Add goal" button opens **GoalModal** (area pre-filled) instead of an inline form
+- Goal titles are now **clickable links** to `/goal/:uid-slug`
+- Deleting a goal uses a **ConfirmDialog** (not a browser `window.confirm`)
+- Goal row edit/delete buttons remain; clicking edit opens GoalModal
+
+**Buckets in the Goals column (unchanged):**
+1. **Active goals** — each with its linked project cards underneath
+2. **Maintenance** — projects flagged `is_maintenance = true`
+3. **Unlinked** — projects with no goal and no maintenance flag
+4. **Inactive goals** — collapsed under a `<details>` element
+
+For the full Area detail page layout, see [Areas](07-areas.md).
 
 ---
 
@@ -167,31 +231,32 @@ All endpoints require authentication. Responses are scoped to the current user.
 
 ```
 GET /api/goals
+GET /api/goals?area_uid=:uid
 GET /api/goals?area_id=:id
 ```
 
-Returns `{ goals: Goal[] }`. Pass `area_id` to filter to a single area.
+Returns `{ goals: Goal[] }`. Pass `area_uid` or `area_id` to filter to a single area.
 
-### Get goal
+### Get goal (with related tasks and projects)
 
 ```
 GET /api/goals/:uid
 ```
 
-Returns `{ goal: Goal }`.
+Returns `{ goal: Goal }`. The `goal` object includes `Tasks` and `Projects` arrays.
 
 ### Create goal
 
 ```
 POST /api/goals
-Body: { title, area_id, why?, horizon?, target_date?, status? }
+Body: { title, area_id?, why?, horizon?, target_date?, status? }
 ```
 
 Returns `{ goal: Goal, active_goals_count: number }`.
 
 **Validation:**
 - `title` required, non-empty
-- `area_id` required
+- `area_id` is optional (nullable)
 
 ### Update goal
 
@@ -208,7 +273,7 @@ Returns `{ goal: Goal, active_goals_count: number }`.
 DELETE /api/goals/:uid
 ```
 
-Returns 204. Projects referencing this goal have `goal_id` set to `null`.
+Returns 204. Projects referencing this goal have `goal_id` set to `null`. Tasks referencing this goal have `goal_id` set to `null`.
 
 ---
 
@@ -219,7 +284,7 @@ Returns 204. Projects referencing this goal have `goal_id` set to `null`.
 ```sql
 id          INTEGER  PRIMARY KEY AUTOINCREMENT
 uid         STRING   UNIQUE NOT NULL
-area_id     INTEGER  NOT NULL  → areas.id  CASCADE DELETE
+area_id     INTEGER  NULL  → areas.id  SET NULL on delete
 user_id     INTEGER  NOT NULL  → users.id  CASCADE DELETE
 title       STRING   NOT NULL
 why         TEXT
@@ -232,7 +297,9 @@ updated_at  DATETIME
 
 **Indexes:** `area_id`, `user_id`, `status`
 
-### Project columns added by this feature
+> Note: `area_id` changed from `NOT NULL` to nullable in migration `20260730000001-make-goals-area-id-nullable.js`.
+
+### Project columns added by the goals feature
 
 ```sql
 goal_id        INTEGER  → goals.id  SET NULL on delete
@@ -240,6 +307,14 @@ is_maintenance BOOLEAN  DEFAULT false
 ```
 
 **Index:** `projects.goal_id`
+
+### Task column added for direct goal assignment
+
+```sql
+goal_id  INTEGER  → goals.id  SET NULL on delete
+```
+
+**Index:** `tasks.goal_id` (migration `20260730000002-add-goal-id-to-tasks.js`)
 
 ---
 
@@ -249,6 +324,8 @@ is_maintenance BOOLEAN  DEFAULT false
 |-------|------|
 | Migration (goals table) | `/backend/migrations/20260624000001-create-goals.js` |
 | Migration (project columns) | `/backend/migrations/20260624000002-add-goal-columns-to-projects.js` |
+| Migration (nullable area_id) | `/backend/migrations/20260730000001-make-goals-area-id-nullable.js` |
+| Migration (task goal_id) | `/backend/migrations/20260730000002-add-goal-id-to-tasks.js` |
 | Sequelize model | `/backend/models/goal.js` |
 | Repository | `/backend/modules/goals/repository.js` |
 | Service | `/backend/modules/goals/service.js` |
@@ -257,8 +334,15 @@ is_maintenance BOOLEAN  DEFAULT false
 | MCP tools | `/backend/modules/mcp/tools/goalTools.js` |
 | Frontend entity | `/frontend/entities/Goal.ts` |
 | Frontend API client | `/frontend/utils/goalsService.ts` |
+| Goals Zustand store | `/frontend/store/useStore.ts` (`goalsStore` slice) |
+| Slug helper | `/frontend/utils/slugUtils.ts` (`createGoalUrl`) |
+| Goal modal (create/edit) | `/frontend/components/Goal/GoalModal.tsx` |
+| Goals list page | `/frontend/components/Goals.tsx` |
+| Goal detail page | `/frontend/components/Goal/GoalDetails.tsx` |
+| Sidebar section | `/frontend/components/Sidebar/SidebarGoals.tsx` |
+| Task goal card | `/frontend/components/Task/TaskDetails/TaskGoalCard.tsx` |
 | Goal dropdown component | `/frontend/components/Shared/GoalDropdown.tsx` |
-| Area detail page (primary UI) | `/frontend/components/Area/AreaDetails.tsx` |
+| Area detail page | `/frontend/components/Area/AreaDetails.tsx` |
 | Project modal (goal picker) | `/frontend/components/Project/ProjectModal.tsx` |
 
 ---
@@ -270,10 +354,10 @@ Goals are accessible via the MCP integration using five tools:
 | Tool | Description |
 |------|-------------|
 | `list_goals` | List goals, optionally filtered by `area_id` or `status` |
-| `get_goal` | Get a single goal by UID |
-| `create_goal` | Create a new goal (requires `title` and `area_id`) |
-| `update_goal` | Update title, why, horizon, target_date, or status |
-| `delete_goal` | Delete a goal (linked projects become unlinked) |
+| `get_goal` | Get a single goal by UID (includes linked tasks and projects) |
+| `create_goal` | Create a new goal (`title` required; `area_id` is optional) |
+| `update_goal` | Update title, why, horizon, target_date, area_id, or status |
+| `delete_goal` | Delete a goal (linked projects and tasks become unlinked) |
 
 See [MCP Integration](14-mcp-integration.md#goals-tools-5) for full parameter details.
 
@@ -281,14 +365,16 @@ See [MCP Integration](14-mcp-integration.md#goals-tools-5) for full parameter de
 
 ## Related Documentation
 
-- [Areas](07-areas.md) - Goals live inside areas; the Area detail page is the main goals UI
+- [Areas](07-areas.md) - Goals can optionally belong to areas; the Area detail page shows goals for that area
 - [Projects](06-projects.md) - Projects carry `goal_id` and `is_maintenance` fields
+- [Tasks Behavior](00-tasks-behavior.md) - Tasks carry their own `goal_id` for direct goal assignment
+- [Tags System](09-tags-system.md) - Goal detail page follows the same section layout as the Tag detail page
 - [Database & Migrations](database.md) - Migration workflow
 - [Backend Patterns](backend-patterns.md) - Module structure followed by the goals module
 - [MCP Integration](14-mcp-integration.md) - AI tool access to goals via Model Context Protocol
 
 ---
 
-**Document Version:** 1.0.0
-**Last Updated:** 2026-06-24
+**Document Version:** 2.0.0
+**Last Updated:** 2026-07-30
 **Audience:** Developers and AI assistants

--- a/docs/directory-structure.md
+++ b/docs/directory-structure.md
@@ -115,6 +115,11 @@
 │   │       └── validation.js
 │   │
 │   ├── areas/            # Area organization
+│   ├── goals/            # Goals management (standalone goals system)
+│   │   ├── routes.js
+│   │   ├── repository.js
+│   │   ├── service.js
+│   │   └── controller.js
 │   ├── notes/            # Notes management
 │   ├── tags/             # Tag system
 │   ├── users/            # User management
@@ -134,9 +139,10 @@
 │
 ├── models/               # Sequelize model definitions
 │   ├── index.js         # Model initialization & associations
-│   ├── task.js          # Task model (recurrence fields)
-│   ├── project.js       # Project model
+│   ├── task.js          # Task model (recurrence fields, goal_id)
+│   ├── project.js       # Project model (goal_id, is_maintenance)
 │   ├── area.js          # Area model
+│   ├── goal.js          # Goal model (standalone, area optional)
 │   ├── note.js          # Note model
 │   ├── tag.js           # Tag model
 │   ├── user.js          # User model (bcrypt password, settings)
@@ -274,11 +280,14 @@
 │   ├── Task/           # Task-related components
 │   │   ├── TasksToday.tsx
 │   │   ├── TaskDetails.tsx
-│   │   ├── TaskForm.tsx
 │   │   ├── TaskItem.tsx
 │   │   ├── TaskList.tsx
-│   │   ├── TaskFilters.tsx
-│   │   ├── SubtaskList.tsx
+│   │   ├── TaskDetails/         # Task detail sidebar cards
+│   │   │   ├── TaskProjectCard.tsx
+│   │   │   ├── TaskAreaCard.tsx
+│   │   │   ├── TaskGoalCard.tsx  # Goal picker card in task detail
+│   │   │   ├── TaskTagsCard.tsx
+│   │   │   └── ...
 │   │   └── ...
 │   │
 │   ├── Project/        # Project components
@@ -289,9 +298,15 @@
 │   │   └── ...
 │   │
 │   ├── Area/           # Area components
-│   │   ├── AreaDetails.tsx
-│   │   ├── AreaForm.tsx
+│   │   ├── AreaDetails.tsx  # Area detail + goals spine + project buckets
+│   │   ├── AreaModal.tsx
 │   │   └── ...
+│   │
+│   ├── Goal/           # Goal components (standalone goals system)
+│   │   ├── GoalDetails.tsx  # Goal detail page (projects + tasks)
+│   │   └── GoalModal.tsx    # Create/edit modal
+│   │
+│   ├── Goals.tsx       # Goals list page (grid, mirrors Areas.tsx)
 │   │
 │   ├── Note/           # Note components
 │   │   ├── NoteDetails.tsx
@@ -299,6 +314,13 @@
 │   │   └── ...
 │   │
 │   ├── Tag/            # Tag components
+│   │
+│   ├── Sidebar/        # Sidebar sub-components
+│   │   ├── SidebarAreas.tsx
+│   │   ├── SidebarGoals.tsx   # Goals section (expandable active goals list)
+│   │   ├── SidebarTags.tsx
+│   │   └── ...
+│   │
 │   ├── Habits/         # Recurring tasks UI
 │   ├── Inbox/          # Inbox management
 │   │
@@ -342,11 +364,10 @@
 │       └── Register.tsx
 │
 ├── store/              # Zustand state management
-│   └── useStore.ts    # Global store (28KB)
-│                       # - Task state & cache
-│                       # - Project state & cache
-│                       # - UI state (modals, filters, selections)
-│                       # - Cache management functions
+│   └── useStore.ts    # Global store
+│                       # - notesStore, areasStore, goalsStore
+│                       # - projectsStore, tagsStore, tasksStore
+│                       # - inboxStore, habitsStore, userSettingsStore
 │
 ├── contexts/           # React contexts
 │   ├── ModalContext.tsx          # Modal state management
@@ -366,6 +387,7 @@
 │   │   ├── notesService.ts
 │   │   ├── tagsService.ts
 │   │   ├── areasService.ts
+│   │   ├── goalsService.ts        # Goals API client (fetchGoals, fetchGoalByUid, createGoal, updateGoal, deleteGoal)
 │   │   ├── profileService.ts      # User profile API
 │   │   ├── apiKeysService.ts      # API token management
 │   │   ├── searchService.ts       # Search API client

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -17,6 +17,8 @@ import AreaDetails from './components/Area/AreaDetails';
 import Areas from './components/Areas';
 import TagDetails from './components/Tag/TagDetails';
 import Tags from './components/Tags';
+import GoalDetails from './components/Goal/GoalDetails';
+import Goals from './components/Goals';
 import Views from './components/Views';
 import ViewDetail from './components/ViewDetail';
 import Notes from './components/Notes';
@@ -299,6 +301,11 @@ const App: React.FC = () => {
                             <Route
                                 path="/tag/:uidSlug"
                                 element={<TagDetails />}
+                            />
+                            <Route path="/goals" element={<Goals />} />
+                            <Route
+                                path="/goal/:uidSlug"
+                                element={<GoalDetails />}
                             />
                             <Route path="/views" element={<Views />} />
                             <Route

--- a/frontend/Layout.tsx
+++ b/frontend/Layout.tsx
@@ -9,15 +9,18 @@ import ProjectModal from './components/Project/ProjectModal';
 import NoteModal from './components/Note/NoteModal';
 import AreaModal from './components/Area/AreaModal';
 import TagModal from './components/Tag/TagModal';
+import GoalModal from './components/Goal/GoalModal';
 import { Note } from './entities/Note';
 import { Area } from './entities/Area';
 import { Tag } from './entities/Tag';
+import { Goal } from './entities/Goal';
 import { Project } from './entities/Project';
 import { User } from './entities/User';
 import { useStore } from './store/useStore';
 import { createNote, updateNote } from './utils/notesService';
 import { createArea, updateArea } from './utils/areasService';
 import { createTag, updateTag } from './utils/tagsService';
+import { createGoal, updateGoal } from './utils/goalsService';
 import {
     fetchProjects,
     createProject,
@@ -56,10 +59,12 @@ const Layout: React.FC<LayoutProps> = ({
     const [isNoteModalOpen, setIsNoteModalOpen] = useState(false);
     const [isAreaModalOpen, setIsAreaModalOpen] = useState(false);
     const [isTagModalOpen, setIsTagModalOpen] = useState(false);
+    const [isGoalModalOpen, setIsGoalModalOpen] = useState(false);
 
     const [selectedNote, setSelectedNote] = useState<Note | null>(null);
     const [selectedArea, setSelectedArea] = useState<Area | null>(null);
     const [selectedTag, setSelectedTag] = useState<Tag | null>(null);
+    const [selectedGoal, setSelectedGoal] = useState<Goal | null>(null);
     const [keyboardShortcuts, setKeyboardShortcuts] = useState<KeyboardShortcutsConfig | null>(null);
 
     // Fetch keyboard shortcuts from profile
@@ -213,6 +218,38 @@ const Layout: React.FC<LayoutProps> = ({
     const closeTagModal = () => {
         setIsTagModalOpen(false);
         setSelectedTag(null);
+    };
+
+    const openGoalModal = (goal: Goal | null = null) => {
+        setSelectedGoal(goal);
+        setIsGoalModalOpen(true);
+    };
+
+    const closeGoalModal = () => {
+        setIsGoalModalOpen(false);
+        setSelectedGoal(null);
+    };
+
+    const handleSaveGoal = async (goalData: Partial<Goal>) => {
+        try {
+            if (goalData.uid || selectedGoal?.uid) {
+                const uid = (goalData.uid ?? selectedGoal?.uid)!;
+                const result = await updateGoal(uid, goalData);
+                const currentGoals = useStore.getState().goalsStore.goals;
+                useStore.getState().goalsStore.setGoals(
+                    currentGoals.map((g) => (g.uid === result.goal.uid ? result.goal : g))
+                );
+            } else {
+                const result = await createGoal(goalData as any);
+                const currentGoals = useStore.getState().goalsStore.goals;
+                useStore.getState().goalsStore.setGoals([...currentGoals, result.goal]);
+            }
+            closeGoalModal();
+        } catch (error: any) {
+            console.error('Error saving goal:', error);
+            if (isAuthError(error)) return;
+            throw error;
+        }
     };
 
     const handleSaveNote = async (noteData: Note) => {
@@ -383,6 +420,7 @@ const Layout: React.FC<LayoutProps> = ({
                     openNoteModal={openNoteModal}
                     openAreaModal={openAreaModal}
                     openTagModal={openTagModal}
+                    openGoalModal={openGoalModal}
                     openNewHabit={openNewHabit}
                     notes={notes}
                     areas={areas}
@@ -422,6 +460,7 @@ const Layout: React.FC<LayoutProps> = ({
                     openNoteModal={openNoteModal}
                     openAreaModal={openAreaModal}
                     openTagModal={openTagModal}
+                    openGoalModal={openGoalModal}
                     openNewHabit={openNewHabit}
                     notes={notes}
                     areas={areas}
@@ -461,6 +500,7 @@ const Layout: React.FC<LayoutProps> = ({
                     openNoteModal={openNoteModal}
                     openAreaModal={openAreaModal}
                     openTagModal={openTagModal}
+                    openGoalModal={openGoalModal}
                     openNewHabit={openNewHabit}
                     notes={notes}
                     areas={areas}
@@ -556,6 +596,15 @@ const Layout: React.FC<LayoutProps> = ({
                         onClose={closeTagModal}
                         onSave={handleSaveTag}
                         tag={selectedTag}
+                    />
+                )}
+
+                {isGoalModalOpen && (
+                    <GoalModal
+                        isOpen={isGoalModalOpen}
+                        onClose={closeGoalModal}
+                        onSave={handleSaveGoal}
+                        goal={selectedGoal}
                     />
                 )}
             </div>

--- a/frontend/Layout.tsx
+++ b/frontend/Layout.tsx
@@ -605,6 +605,7 @@ const Layout: React.FC<LayoutProps> = ({
                         onClose={closeGoalModal}
                         onSave={handleSaveGoal}
                         goal={selectedGoal}
+                        areas={areas}
                     />
                 )}
             </div>

--- a/frontend/Layout.tsx
+++ b/frontend/Layout.tsx
@@ -9,18 +9,15 @@ import ProjectModal from './components/Project/ProjectModal';
 import NoteModal from './components/Note/NoteModal';
 import AreaModal from './components/Area/AreaModal';
 import TagModal from './components/Tag/TagModal';
-import GoalModal from './components/Goal/GoalModal';
 import { Note } from './entities/Note';
 import { Area } from './entities/Area';
 import { Tag } from './entities/Tag';
-import { Goal } from './entities/Goal';
 import { Project } from './entities/Project';
 import { User } from './entities/User';
 import { useStore } from './store/useStore';
 import { createNote, updateNote } from './utils/notesService';
 import { createArea, updateArea } from './utils/areasService';
 import { createTag, updateTag } from './utils/tagsService';
-import { createGoal, updateGoal } from './utils/goalsService';
 import {
     fetchProjects,
     createProject,
@@ -59,12 +56,10 @@ const Layout: React.FC<LayoutProps> = ({
     const [isNoteModalOpen, setIsNoteModalOpen] = useState(false);
     const [isAreaModalOpen, setIsAreaModalOpen] = useState(false);
     const [isTagModalOpen, setIsTagModalOpen] = useState(false);
-    const [isGoalModalOpen, setIsGoalModalOpen] = useState(false);
 
     const [selectedNote, setSelectedNote] = useState<Note | null>(null);
     const [selectedArea, setSelectedArea] = useState<Area | null>(null);
     const [selectedTag, setSelectedTag] = useState<Tag | null>(null);
-    const [selectedGoal, setSelectedGoal] = useState<Goal | null>(null);
     const [keyboardShortcuts, setKeyboardShortcuts] = useState<KeyboardShortcutsConfig | null>(null);
 
     // Fetch keyboard shortcuts from profile
@@ -218,38 +213,6 @@ const Layout: React.FC<LayoutProps> = ({
     const closeTagModal = () => {
         setIsTagModalOpen(false);
         setSelectedTag(null);
-    };
-
-    const openGoalModal = (goal: Goal | null = null) => {
-        setSelectedGoal(goal);
-        setIsGoalModalOpen(true);
-    };
-
-    const closeGoalModal = () => {
-        setIsGoalModalOpen(false);
-        setSelectedGoal(null);
-    };
-
-    const handleSaveGoal = async (goalData: Partial<Goal>) => {
-        try {
-            if (goalData.uid || selectedGoal?.uid) {
-                const uid = (goalData.uid ?? selectedGoal?.uid)!;
-                const result = await updateGoal(uid, goalData);
-                const currentGoals = useStore.getState().goalsStore.goals;
-                useStore.getState().goalsStore.setGoals(
-                    currentGoals.map((g) => (g.uid === result.goal.uid ? result.goal : g))
-                );
-            } else {
-                const result = await createGoal(goalData as any);
-                const currentGoals = useStore.getState().goalsStore.goals;
-                useStore.getState().goalsStore.setGoals([...currentGoals, result.goal]);
-            }
-            closeGoalModal();
-        } catch (error: any) {
-            console.error('Error saving goal:', error);
-            if (isAuthError(error)) return;
-            throw error;
-        }
     };
 
     const handleSaveNote = async (noteData: Note) => {
@@ -420,7 +383,6 @@ const Layout: React.FC<LayoutProps> = ({
                     openNoteModal={openNoteModal}
                     openAreaModal={openAreaModal}
                     openTagModal={openTagModal}
-                    openGoalModal={openGoalModal}
                     openNewHabit={openNewHabit}
                     notes={notes}
                     areas={areas}
@@ -460,7 +422,6 @@ const Layout: React.FC<LayoutProps> = ({
                     openNoteModal={openNoteModal}
                     openAreaModal={openAreaModal}
                     openTagModal={openTagModal}
-                    openGoalModal={openGoalModal}
                     openNewHabit={openNewHabit}
                     notes={notes}
                     areas={areas}
@@ -500,7 +461,6 @@ const Layout: React.FC<LayoutProps> = ({
                     openNoteModal={openNoteModal}
                     openAreaModal={openAreaModal}
                     openTagModal={openTagModal}
-                    openGoalModal={openGoalModal}
                     openNewHabit={openNewHabit}
                     notes={notes}
                     areas={areas}
@@ -599,15 +559,6 @@ const Layout: React.FC<LayoutProps> = ({
                     />
                 )}
 
-                {isGoalModalOpen && (
-                    <GoalModal
-                        isOpen={isGoalModalOpen}
-                        onClose={closeGoalModal}
-                        onSave={handleSaveGoal}
-                        goal={selectedGoal}
-                        areas={areas}
-                    />
-                )}
             </div>
         </SidebarProvider>
     );

--- a/frontend/components/Area/AreaDetails.tsx
+++ b/frontend/components/Area/AreaDetails.tsx
@@ -22,7 +22,10 @@ import { updateArea } from '../../utils/areasService';
 import { fetchGoals, createGoal, updateGoal, deleteGoal } from '../../utils/goalsService';
 import { updateProject } from '../../utils/projectsService';
 import AreaModal from './AreaModal';
+import GoalModal from '../Goal/GoalModal';
+import ConfirmDialog from '../Shared/ConfirmDialog';
 import TaskList from '../Task/TaskList';
+import { createGoalUrl } from '../../utils/slugUtils';
 
 const HORIZON_LABELS: Record<GoalHorizon, string> = {
     season: 'season',
@@ -35,22 +38,6 @@ const STATUS_LABELS: Record<GoalStatus, string> = {
     paused: 'paused',
     dropped: 'dropped',
 };
-
-interface GoalFormState {
-    title: string;
-    why: string;
-    horizon: GoalHorizon;
-    target_date: string;
-    status: GoalStatus;
-}
-
-const emptyGoalForm = (): GoalFormState => ({
-    title: '',
-    why: '',
-    horizon: 'season',
-    target_date: '',
-    status: 'active',
-});
 
 const AreaDetails: React.FC = () => {
     const { t } = useTranslation();
@@ -70,10 +57,9 @@ const AreaDetails: React.FC = () => {
 
     const [goals, setGoals] = useState<Goal[]>([]);
     const [loadingGoals, setLoadingGoals] = useState(false);
-
-    const [goalForm, setGoalForm] = useState<GoalFormState | null>(null);
-    const [editingGoalUid, setEditingGoalUid] = useState<string | null>(null);
-    const [savingGoal, setSavingGoal] = useState(false);
+    const [isGoalModalOpen, setIsGoalModalOpen] = useState(false);
+    const [editingGoal, setEditingGoal] = useState<Goal | null>(null);
+    const [goalToDelete, setGoalToDelete] = useState<Goal | null>(null);
 
     const areaUid = uidSlug?.split('-')[0] || '';
 
@@ -181,62 +167,37 @@ const AreaDetails: React.FC = () => {
     };
 
     const openNewGoalForm = () => {
-        setEditingGoalUid(null);
-        setGoalForm(emptyGoalForm());
+        setEditingGoal(null);
+        setIsGoalModalOpen(true);
     };
 
     const openEditGoalForm = (goal: Goal) => {
-        setEditingGoalUid(goal.uid || null);
-        setGoalForm({
-            title: goal.title,
-            why: goal.why || '',
-            horizon: goal.horizon,
-            target_date: goal.target_date || '',
-            status: goal.status,
-        });
+        setEditingGoal(goal);
+        setIsGoalModalOpen(true);
     };
 
-    const cancelGoalForm = () => {
-        setGoalForm(null);
-        setEditingGoalUid(null);
+    const handleGoalModalClose = () => {
+        setIsGoalModalOpen(false);
+        setEditingGoal(null);
     };
 
-    const saveGoal = async () => {
-        if (!goalForm || !area?.id) return;
-        if (!goalForm.title.trim()) return;
-        setSavingGoal(true);
-        try {
-            if (editingGoalUid) {
-                const { goal } = await updateGoal(editingGoalUid, {
-                    title: goalForm.title.trim(),
-                    why: goalForm.why || null,
-                    horizon: goalForm.horizon,
-                    target_date: goalForm.target_date || null,
-                    status: goalForm.status,
-                });
-                setGoals((prev) => prev.map((g) => (g.uid === editingGoalUid ? goal : g)));
-            } else {
-                const { goal } = await createGoal({
-                    area_id: area.id!,
-                    title: goalForm.title.trim(),
-                    why: goalForm.why || null,
-                    horizon: goalForm.horizon,
-                    target_date: goalForm.target_date || null,
-                    status: goalForm.status,
-                });
-                setGoals((prev) => [...prev, goal]);
-            }
-            cancelGoalForm();
-        } finally {
-            setSavingGoal(false);
+    const handleGoalSave = async (data: Partial<Goal>) => {
+        if (!area?.id) return;
+        if (editingGoal?.uid) {
+            const { goal } = await updateGoal(editingGoal.uid, data);
+            setGoals((prev) => prev.map((g) => (g.uid === editingGoal.uid ? goal : g)));
+        } else {
+            const { goal } = await createGoal({ ...data, area_id: area.id } as any);
+            setGoals((prev) => [...prev, goal]);
         }
+        handleGoalModalClose();
     };
 
-    const handleDeleteGoal = async (goal: Goal) => {
-        if (!goal.uid) return;
-        if (!window.confirm(`Drop goal "${goal.title}"? Projects under it will become unlinked.`)) return;
-        await deleteGoal(goal.uid);
-        setGoals((prev) => prev.filter((g) => g.uid !== goal.uid));
+    const handleDeleteGoal = async () => {
+        if (!goalToDelete?.uid) return;
+        await deleteGoal(goalToDelete.uid);
+        setGoals((prev) => prev.filter((g) => g.uid !== goalToDelete.uid));
+        setGoalToDelete(null);
     };
 
     const patchProjectInStore = (uid: string, patch: Partial<Project>) => {
@@ -417,73 +378,12 @@ const AreaDetails: React.FC = () => {
                         </button>
                     </div>
 
-                    {/* Inline goal form */}
-                    {goalForm && (
-                        <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-white dark:bg-gray-900 space-y-3">
-                            <input
-                                autoFocus
-                                type="text"
-                                placeholder={t('areas.goalTitlePlaceholder')}
-                                value={goalForm.title}
-                                onChange={(e) => setGoalForm((f) => f ? { ...f, title: e.target.value } : f)}
-                                className="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-md py-1.5 px-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
-                            />
-                            <input
-                                type="text"
-                                placeholder={t('areas.goalWhyPlaceholder')}
-                                value={goalForm.why}
-                                onChange={(e) => setGoalForm((f) => f ? { ...f, why: e.target.value } : f)}
-                                className="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-md py-1.5 px-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
-                            />
-                            <div className="flex gap-2">
-                                <select
-                                    value={goalForm.horizon}
-                                    onChange={(e) => setGoalForm((f) => f ? { ...f, horizon: e.target.value as GoalHorizon } : f)}
-                                    className="flex-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md py-1.5 px-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-                                >
-                                    <option value="season">{t('areas.horizonSeason')}</option>
-                                    <option value="year">{t('areas.horizonYear')}</option>
-                                </select>
-                                <select
-                                    value={goalForm.status}
-                                    onChange={(e) => setGoalForm((f) => f ? { ...f, status: e.target.value as GoalStatus } : f)}
-                                    className="flex-1 text-sm border border-gray-300 dark:border-gray-600 rounded-md py-1.5 px-2 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-                                >
-                                    {(Object.keys(STATUS_LABELS) as GoalStatus[]).map((s) => (
-                                        <option key={s} value={s}>{STATUS_LABELS[s]}</option>
-                                    ))}
-                                </select>
-                            </div>
-                            <input
-                                type="date"
-                                value={goalForm.target_date}
-                                onChange={(e) => setGoalForm((f) => f ? { ...f, target_date: e.target.value } : f)}
-                                className="w-full text-sm border border-gray-300 dark:border-gray-600 rounded-md py-1.5 px-3 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
-                            />
-                            <div className="flex gap-2 justify-end">
-                                <button
-                                    onClick={cancelGoalForm}
-                                    className="text-xs text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 px-3 py-1"
-                                >
-                                    Cancel
-                                </button>
-                                <button
-                                    onClick={saveGoal}
-                                    disabled={savingGoal || !goalForm.title.trim()}
-                                    className="text-xs bg-blue-600 text-white px-3 py-1 rounded-md hover:bg-blue-700 disabled:opacity-50"
-                                >
-                                    {savingGoal ? 'Saving…' : editingGoalUid ? 'Update' : 'Add goal'}
-                                </button>
-                            </div>
-                        </div>
-                    )}
-
                     {loadingGoals ? (
                         <p className="text-sm text-gray-400 dark:text-gray-500">Loading goals…</p>
                     ) : (
                         <div className="space-y-4">
                             {/* Empty state: only when there are no goals AND no projects at all */}
-                            {goals.length === 0 && areaProjects.length === 0 && !goalForm && (
+                            {goals.length === 0 && areaProjects.length === 0 && (
                                 <p className="text-sm text-gray-400 dark:text-gray-500">
                                     No goals yet. Add a goal to group projects by outcome.
                                 </p>
@@ -498,7 +398,7 @@ const AreaDetails: React.FC = () => {
                                     areaColor={area.color}
                                     getProjectLink={getProjectLink}
                                     onEdit={() => openEditGoalForm(goal)}
-                                    onDelete={() => handleDeleteGoal(goal)}
+                                    onDelete={() => setGoalToDelete(goal)}
                                 />
                             ))}
 
@@ -548,7 +448,7 @@ const AreaDetails: React.FC = () => {
                                                 areaColor={area.color}
                                                 getProjectLink={getProjectLink}
                                                 onEdit={() => openEditGoalForm(goal)}
-                                                onDelete={() => handleDeleteGoal(goal)}
+                                                onDelete={() => setGoalToDelete(goal)}
                                                 dimmed
                                             />
                                         ))}
@@ -639,6 +539,25 @@ const AreaDetails: React.FC = () => {
                     onClose={() => setIsEditModalOpen(false)}
                 />
             )}
+
+            {isGoalModalOpen && (
+                <GoalModal
+                    isOpen={isGoalModalOpen}
+                    onClose={handleGoalModalClose}
+                    onSave={handleGoalSave}
+                    goal={editingGoal}
+                    defaultAreaId={area?.id}
+                />
+            )}
+
+            {goalToDelete && (
+                <ConfirmDialog
+                    title={t('modals.deleteGoal.title', 'Delete Goal')}
+                    message={`${t('modals.deleteGoal.message', 'Are you sure you want to delete')} "${goalToDelete.title}"? Projects under it will become unlinked.`}
+                    onConfirm={handleDeleteGoal}
+                    onCancel={() => setGoalToDelete(null)}
+                />
+            )}
         </div>
     );
 };
@@ -660,14 +579,21 @@ const GoalBucket: React.FC<GoalBucketProps> = ({
 }) => {
     const { t } = useTranslation();
     const dotColor = areaColor || '#6b7280';
+    const goalUrl = goal.uid ? createGoalUrl({ uid: goal.uid, title: goal.title }) : null;
     return (
         <div className={dimmed ? 'opacity-60' : ''}>
             <div className="flex items-start justify-between gap-2 mb-1.5">
                 <div className="flex items-center gap-2 min-w-0">
                     <FlagIcon className="h-4 w-4 flex-shrink-0" style={{ color: dotColor }} />
-                    <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">
-                        {goal.title}
-                    </span>
+                    {goalUrl ? (
+                        <Link to={goalUrl} className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate hover:text-blue-600 dark:hover:text-blue-400">
+                            {goal.title}
+                        </Link>
+                    ) : (
+                        <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">
+                            {goal.title}
+                        </span>
+                    )}
                     <span className="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0">
                         {HORIZON_LABELS[goal.horizon]}
                         {goal.status !== 'active' && ` · ${STATUS_LABELS[goal.status]}`}

--- a/frontend/components/Area/AreaDetails.tsx
+++ b/frontend/components/Area/AreaDetails.tsx
@@ -3,40 +3,26 @@ import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
     PencilIcon,
-    PlusIcon,
-    PencilSquareIcon,
-    TrashIcon,
     FlagIcon,
-    WrenchScrewdriverIcon,
-    ChevronRightIcon,
-    ExclamationTriangleIcon,
-    InformationCircleIcon,
+    XMarkIcon,
 } from '@heroicons/react/24/outline';
 import { useStore } from '../../store/useStore';
 import { Area } from '../../entities/Area';
+import { Goal } from '../../entities/Goal';
 import { Project } from '../../entities/Project';
-import { Goal, GoalStatus, GoalHorizon } from '../../entities/Goal';
 import { Task } from '../../entities/Task';
 import { fetchTasks } from '../../utils/tasksService';
 import { updateArea } from '../../utils/areasService';
-import { fetchGoals, createGoal, updateGoal, deleteGoal } from '../../utils/goalsService';
-import { updateProject } from '../../utils/projectsService';
+import { updateGoal } from '../../utils/goalsService';
 import AreaModal from './AreaModal';
-import GoalModal from '../Goal/GoalModal';
-import ConfirmDialog from '../Shared/ConfirmDialog';
 import TaskList from '../Task/TaskList';
 import { createGoalUrl } from '../../utils/slugUtils';
 
-const HORIZON_LABELS: Record<GoalHorizon, string> = {
-    season: 'season',
-    year: 'year',
-};
-
-const STATUS_LABELS: Record<GoalStatus, string> = {
-    active: 'active',
-    achieved: 'achieved',
-    paused: 'paused',
-    dropped: 'dropped',
+const STATUS_COLORS: Record<string, string> = {
+    active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+    achieved: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+    paused: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+    dropped: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
 };
 
 const AreaDetails: React.FC = () => {
@@ -47,6 +33,7 @@ const AreaDetails: React.FC = () => {
     const areasStore = useStore((state: any) => state.areasStore);
     const projectsStore = useStore((state: any) => state.projectsStore);
     const tasksStore = useStore((state: any) => state.tasksStore);
+    const goalsStore = useStore((state: any) => state.goalsStore);
 
     const [area, setArea] = useState<Area | null>(null);
     const [isLoading, setIsLoading] = useState(true);
@@ -54,12 +41,6 @@ const AreaDetails: React.FC = () => {
     const [areaTasks, setAreaTasks] = useState<Task[]>([]);
     const [loadingTasks, setLoadingTasks] = useState(false);
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
-
-    const [goals, setGoals] = useState<Goal[]>([]);
-    const [loadingGoals, setLoadingGoals] = useState(false);
-    const [isGoalModalOpen, setIsGoalModalOpen] = useState(false);
-    const [editingGoal, setEditingGoal] = useState<Goal | null>(null);
-    const [goalToDelete, setGoalToDelete] = useState<Goal | null>(null);
 
     const areaUid = uidSlug?.split('-')[0] || '';
 
@@ -74,6 +55,12 @@ const AreaDetails: React.FC = () => {
             projectsStore.loadProjects();
         }
     }, [projectsStore]);
+
+    useEffect(() => {
+        if (!goalsStore.hasLoaded && !goalsStore.isLoading) {
+            goalsStore.loadGoals();
+        }
+    }, [goalsStore]);
 
     useEffect(() => {
         if (!areaUid) {
@@ -105,34 +92,29 @@ const AreaDetails: React.FC = () => {
     }, [area?.uid]);
 
     useEffect(() => {
-        if (area?.uid) {
-            loadAreaTasks();
-        }
+        if (area?.uid) loadAreaTasks();
     }, [area?.uid, loadAreaTasks]);
-
-    const loadGoals = useCallback(async () => {
-        if (!area?.uid) return;
-        setLoadingGoals(true);
-        try {
-            const data = await fetchGoals(area.uid);
-            setGoals(data);
-        } catch {
-            setGoals([]);
-        } finally {
-            setLoadingGoals(false);
-        }
-    }, [area?.uid]);
-
-    useEffect(() => {
-        if (area?.uid) {
-            loadGoals();
-        }
-    }, [area?.uid, loadGoals]);
 
     const areaProjects = projectsStore.projects.filter((p: Project) => {
         const projectArea = p.area || (p as any).Area;
         return projectArea?.uid === areaUid;
     });
+
+    const areaGoals: Goal[] = goalsStore.goals.filter(
+        (g: Goal) => g.Area?.uid === areaUid || (area && g.area_id === (area as any).id)
+    );
+
+    const handleRemoveGoalFromArea = async (goal: Goal) => {
+        if (!goal.uid) return;
+        try {
+            const result = await updateGoal(goal.uid, { area_id: null });
+            goalsStore.setGoals(
+                goalsStore.goals.map((g: Goal) => g.uid === result.goal.uid ? result.goal : g)
+            );
+        } catch {
+            // silently ignore
+        }
+    };
 
     const handleTaskUpdate = async (updatedTask: Task) => {
         setAreaTasks((prev) => prev.map((t) => (t.uid === updatedTask.uid ? updatedTask : t)));
@@ -158,107 +140,6 @@ const AreaDetails: React.FC = () => {
         navigate(`/area/${result.uid}-${slug}`, { replace: true });
     };
 
-    const getProjectLink = (project: Project) => {
-        if (project.uid) {
-            const slug = project.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
-            return `/project/${project.uid}-${slug}`;
-        }
-        return `/project/${project.id}`;
-    };
-
-    const openNewGoalForm = () => {
-        setEditingGoal(null);
-        setIsGoalModalOpen(true);
-    };
-
-    const openEditGoalForm = (goal: Goal) => {
-        setEditingGoal(goal);
-        setIsGoalModalOpen(true);
-    };
-
-    const handleGoalModalClose = () => {
-        setIsGoalModalOpen(false);
-        setEditingGoal(null);
-    };
-
-    const handleGoalSave = async (data: Partial<Goal>) => {
-        if (!area?.id) return;
-        if (editingGoal?.uid) {
-            const { goal } = await updateGoal(editingGoal.uid, data);
-            setGoals((prev) => prev.map((g) => (g.uid === editingGoal.uid ? goal : g)));
-        } else {
-            const { goal } = await createGoal({ ...data, area_id: area.id } as any);
-            setGoals((prev) => [...prev, goal]);
-        }
-        handleGoalModalClose();
-    };
-
-    const handleDeleteGoal = async () => {
-        if (!goalToDelete?.uid) return;
-        await deleteGoal(goalToDelete.uid);
-        setGoals((prev) => prev.filter((g) => g.uid !== goalToDelete.uid));
-        setGoalToDelete(null);
-    };
-
-    const patchProjectInStore = (uid: string, patch: Partial<Project>) => {
-        projectsStore.setProjects(
-            projectsStore.projects.map((p: Project) =>
-                p.uid === uid ? { ...p, ...patch } : p
-            )
-        );
-    };
-
-    const handleLinkToGoal = async (project: Project, goal: Goal) => {
-        if (!project.uid || !goal.id) return;
-        try {
-            const saved = await updateProject(project.uid, { goal_id: goal.id, is_maintenance: false });
-            const savedGoalId = saved.goal_id ?? (saved as any).Goal?.id ?? null;
-            patchProjectInStore(project.uid, {
-                goal_id: savedGoalId,
-                is_maintenance: saved.is_maintenance ?? false,
-            });
-        } catch (err) {
-            console.error('[handleLinkToGoal] error:', err);
-        }
-    };
-
-    const handleMarkMaintenance = async (project: Project) => {
-        if (!project.uid) return;
-        try {
-            const saved = await updateProject(project.uid, { goal_id: null, is_maintenance: true });
-            patchProjectInStore(project.uid, {
-                goal_id: saved.goal_id ?? null,
-                is_maintenance: saved.is_maintenance ?? true,
-            });
-        } catch (err) {
-            console.error('Failed to mark project as maintenance:', err);
-        }
-    };
-
-    const handleUnmarkMaintenance = async (project: Project) => {
-        if (!project.uid) return;
-        try {
-            const saved = await updateProject(project.uid, { is_maintenance: false, goal_id: null });
-            patchProjectInStore(project.uid, {
-                is_maintenance: saved.is_maintenance ?? false,
-                goal_id: saved.goal_id ?? null,
-            });
-        } catch (err) {
-            console.error('Failed to unmark project as maintenance:', err);
-        }
-    };
-
-    const handleDropProject = async (project: Project) => {
-        if (!project.uid) return;
-        if (!window.confirm(`Remove "${project.name}" from this area?`)) return;
-        try {
-            await updateProject(project.uid, { area_id: null });
-            patchProjectInStore(project.uid, { area_id: null, goal_id: null, is_maintenance: false });
-        } catch (err) {
-            console.error('Failed to remove project from area:', err);
-        }
-    };
-
     if (isLoading) {
         return (
             <div className="flex items-center justify-center h-64 text-gray-500 dark:text-gray-400">
@@ -280,27 +161,6 @@ const AreaDetails: React.FC = () => {
     );
     const completedTasks = areaTasks.filter((t) => t.status === 'done' || t.status === 2);
 
-    const projectsByGoal = new Map<number, Project[]>();
-    const maintenanceProjects: Project[] = [];
-    const unlinkedProjects: Project[] = [];
-
-    areaProjects.forEach((p: Project) => {
-        const goalId = (p as any).goal_id ?? p.goal_id;
-        const isMaintenance = (p as any).is_maintenance ?? p.is_maintenance;
-        if (goalId) {
-            const list = projectsByGoal.get(goalId) || [];
-            list.push(p);
-            projectsByGoal.set(goalId, list);
-        } else if (isMaintenance) {
-            maintenanceProjects.push(p);
-        } else {
-            unlinkedProjects.push(p);
-        }
-    });
-
-    const activeGoals = goals.filter((g) => g.status === 'active');
-    const tooManyGoals = activeGoals.length > 5;
-
     return (
         <div className="w-full px-2 sm:px-4 lg:px-6 pt-4 pb-8">
             {/* Area Header */}
@@ -316,11 +176,9 @@ const AreaDetails: React.FC = () => {
                             }`}>
                                 Area
                             </p>
-                            <h1
-                                className={`text-3xl font-light uppercase tracking-wide ${
-                                    area.color ? 'text-white' : 'text-gray-900 dark:text-gray-100'
-                                }`}
-                            >
+                            <h1 className={`text-3xl font-light uppercase tracking-wide ${
+                                area.color ? 'text-white' : 'text-gray-900 dark:text-gray-100'
+                            }`}>
                                 {area.name}
                             </h1>
                             {area.description && (
@@ -330,10 +188,8 @@ const AreaDetails: React.FC = () => {
                             )}
                             <div className={`mt-3 flex gap-4 text-xs ${area.color ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'}`}>
                                 <span>{areaProjects.length} {t('areas.projects', 'projects')}</span>
+                                <span>{areaGoals.length} {t('areas.goals', 'goals')}</span>
                                 <span>{activeTasks.length} {t('areas.tasks', 'tasks')}</span>
-                                {goals.length > 0 && (
-                                    <span>{activeGoals.length} active {activeGoals.length === 1 ? 'goal' : 'goals'}</span>
-                                )}
                             </div>
                         </div>
                         <button
@@ -351,177 +207,92 @@ const AreaDetails: React.FC = () => {
                 </div>
             </div>
 
-            {/* Scarcity guard */}
-            {tooManyGoals && (
-                <div className="mb-6 flex items-center gap-3 px-4 py-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-700 rounded-lg text-sm text-amber-700 dark:text-amber-400">
-                    <ExclamationTriangleIcon className="h-4 w-4 flex-shrink-0" />
-                    <span>{activeGoals.length} active goals. Goals work best at 3-5. Achieve or pause one?</span>
-                </div>
-            )}
+            {/* Goals section */}
+            <div className="mb-10">
+                <h2 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4">
+                    {t('goals.title', 'Goals')} ({areaGoals.length})
+                </h2>
 
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-                {/* Goals spine + projects */}
-                <div className="lg:col-span-1 space-y-6">
-                    <div className="flex items-center justify-between mb-1">
-                        <h2 className="text-lg font-light text-gray-700 dark:text-gray-300">Goals</h2>
-                        <button
-                            onClick={openNewGoalForm}
-                            className="flex items-center gap-1 text-xs text-blue-600 dark:text-blue-400 hover:underline"
-                        >
-                            <PlusIcon className="h-3.5 w-3.5" /> Add goal
-                        </button>
-                    </div>
-
-                    {loadingGoals ? (
-                        <p className="text-sm text-gray-400 dark:text-gray-500">Loading goals…</p>
-                    ) : (
-                        <div className="space-y-4">
-                            {goals.length === 0 && areaProjects.length === 0 && (
-                                <p className="text-sm text-gray-400 dark:text-gray-500">
-                                    No goals yet. Add a goal to group projects by outcome.
-                                </p>
-                            )}
-
-                            {/* Active goals */}
-                            {goals.filter((g) => g.status === 'active').map((goal) => (
-                                <GoalBucket
-                                    key={goal.uid || goal.id}
-                                    goal={goal}
-                                    projects={projectsByGoal.get(goal.id!) || []}
-                                    areaColor={area.color}
-                                    getProjectLink={getProjectLink}
-                                    onEdit={() => openEditGoalForm(goal)}
-                                    onDelete={() => setGoalToDelete(goal)}
-                                />
-                            ))}
-
-                            {/* Maintenance bucket */}
-                            {maintenanceProjects.length > 0 && (
-                                <div>
-                                    <div className="flex items-center gap-2 mb-2">
-                                        <WrenchScrewdriverIcon className="h-4 w-4 text-gray-400" />
-                                        <span className="text-sm font-medium text-gray-600 dark:text-gray-400">Maintenance</span>
-                                        <span className="relative group/tip">
-                                            <InformationCircleIcon className="h-3.5 w-3.5 text-gray-300 dark:text-gray-600 cursor-help" />
-                                            <span className="pointer-events-none absolute left-5 top-0 z-10 w-52 rounded-md bg-gray-800 px-2.5 py-1.5 text-xs text-white opacity-0 group-hover/tip:opacity-100 transition-opacity shadow-lg">
-                                                Maintenance projects keep things running. They&apos;re ongoing work without a specific goal or end date.
+                {areaGoals.length === 0 ? (
+                    <p className="text-sm text-gray-400 dark:text-gray-500">
+                        {t('goals.noGoalsInArea', 'No goals linked to this area.')}
+                    </p>
+                ) : (
+                    <div className="flex flex-col gap-2">
+                        {areaGoals.map((goal) => {
+                            const goalUrl = goal.uid ? createGoalUrl({ uid: goal.uid, title: goal.title }) : '/goals';
+                            return (
+                                <div key={goal.uid} className="flex items-center gap-2 group">
+                                    <Link
+                                        to={goalUrl}
+                                        className="flex-1 flex items-center gap-3 px-3 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 hover:bg-white dark:hover:bg-gray-800 transition-colors"
+                                    >
+                                        <FlagIcon className="h-4 w-4 text-blue-500 flex-shrink-0" />
+                                        <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate flex-1">
+                                            {goal.title}
+                                        </span>
+                                        {goal.why && (
+                                            <span className="text-xs text-gray-400 dark:text-gray-500 truncate hidden sm:block max-w-xs">
+                                                {goal.why}
                                             </span>
+                                        )}
+                                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium flex-shrink-0 ${STATUS_COLORS[goal.status] ?? ''}`}>
+                                            {t(`goals.status.${goal.status}`, goal.status)}
                                         </span>
-                                    </div>
-                                    <div className="ml-6">
-                                        <p className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1.5">
-                                            Projects
-                                        </p>
-                                        <div className="space-y-2">
-                                            {maintenanceProjects.map((p) => (
-                                                <MaintenanceProjectRow
-                                                    key={p.uid || p.id}
-                                                    project={p}
-                                                    getLink={getProjectLink}
-                                                    onUnmark={handleUnmarkMaintenance}
-                                                />
-                                            ))}
-                                        </div>
-                                    </div>
+                                    </Link>
+                                    <button
+                                        onClick={() => handleRemoveGoalFromArea(goal)}
+                                        className="opacity-0 group-hover:opacity-100 transition-opacity p-1.5 text-gray-400 hover:text-red-500 dark:text-gray-500 dark:hover:text-red-400 rounded"
+                                        title={t('goals.removeFromArea', 'Remove from area')}
+                                    >
+                                        <XMarkIcon className="h-4 w-4" />
+                                    </button>
                                 </div>
-                            )}
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
 
-                            {/* Inactive goals */}
-                            {goals.filter((g) => g.status !== 'active').length > 0 && (
-                                <details className="mt-2">
-                                    <summary className="text-xs text-gray-400 dark:text-gray-500 cursor-pointer select-none">
-                                        Inactive goals ({goals.filter((g) => g.status !== 'active').length})
-                                    </summary>
-                                    <div className="mt-2 space-y-3">
-                                        {goals.filter((g) => g.status !== 'active').map((goal) => (
-                                            <GoalBucket
-                                                key={goal.uid || goal.id}
-                                                goal={goal}
-                                                projects={projectsByGoal.get(goal.id!) || []}
-                                                areaColor={area.color}
-                                                getProjectLink={getProjectLink}
-                                                onEdit={() => openEditGoalForm(goal)}
-                                                onDelete={() => setGoalToDelete(goal)}
-                                                dimmed
-                                            />
-                                        ))}
-                                    </div>
-                                </details>
-                            )}
-
-                            {/* Unlinked bucket */}
-                            {unlinkedProjects.length > 0 && (
-                                <div>
-                                    <div className="flex items-center gap-2 mb-2">
-                                        <ChevronRightIcon className="h-4 w-4 text-gray-300 dark:text-gray-600" />
-                                        <span className="text-sm text-gray-400 dark:text-gray-500">
-                                            Unlinked ({unlinkedProjects.length})
-                                        </span>
-                                    </div>
-                                    <div className="ml-6">
-                                        <p className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1.5">
-                                            Projects
-                                        </p>
-                                        <div className="space-y-2">
-                                            {unlinkedProjects.map((p) => (
-                                                <UnlinkedProjectRow
-                                                    key={p.uid || p.id}
-                                                    project={p}
-                                                    goals={goals.filter((g) => g.status === 'active')}
-                                                    getLink={getProjectLink}
-                                                    onLinkToGoal={handleLinkToGoal}
-                                                    onMarkMaintenance={handleMarkMaintenance}
-                                                    onDrop={handleDropProject}
-                                                />
-                                            ))}
-                                        </div>
-                                    </div>
-                                </div>
-                            )}
-                        </div>
-                    )}
-                </div>
-
-                {/* Tasks column */}
-                <div className="lg:col-span-2">
-                    <h2 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4">
-                        {t('areas.tasksInArea', 'Tasks')}
-                    </h2>
-                    {loadingTasks ? (
-                        <div className="text-sm text-gray-400 dark:text-gray-500">
-                            {t('loading.tasks', 'Loading tasks…')}
-                        </div>
-                    ) : activeTasks.length === 0 && completedTasks.length === 0 ? (
-                        <p className="text-sm text-gray-400 dark:text-gray-500">
-                            {t('areas.noTasks', 'No tasks directly in this area')}
-                        </p>
-                    ) : (
-                        <div className="space-y-6">
-                            {activeTasks.length > 0 && (
+            {/* Tasks */}
+            <div>
+                <h2 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4">
+                    {t('areas.tasksInArea', 'Tasks')}
+                </h2>
+                {loadingTasks ? (
+                    <div className="text-sm text-gray-400 dark:text-gray-500">
+                        {t('loading.tasks', 'Loading tasks…')}
+                    </div>
+                ) : activeTasks.length === 0 && completedTasks.length === 0 ? (
+                    <p className="text-sm text-gray-400 dark:text-gray-500">
+                        {t('areas.noTasks', 'No tasks directly in this area')}
+                    </p>
+                ) : (
+                    <div className="space-y-6">
+                        {activeTasks.length > 0 && (
+                            <TaskList
+                                tasks={activeTasks}
+                                projects={projectsStore.projects}
+                                onTaskUpdate={handleTaskUpdate}
+                                onTaskDelete={handleTaskDelete}
+                            />
+                        )}
+                        {completedTasks.length > 0 && (
+                            <div>
+                                <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">
+                                    {t('tasks.completed', 'Completed')} ({completedTasks.length})
+                                </h3>
                                 <TaskList
-                                    tasks={activeTasks}
+                                    tasks={completedTasks}
                                     projects={projectsStore.projects}
                                     onTaskUpdate={handleTaskUpdate}
                                     onTaskDelete={handleTaskDelete}
+                                    showCompletedTasks={true}
                                 />
-                            )}
-                            {completedTasks.length > 0 && (
-                                <div>
-                                    <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">
-                                        {t('tasks.completed', 'Completed')} ({completedTasks.length})
-                                    </h3>
-                                    <TaskList
-                                        tasks={completedTasks}
-                                        projects={projectsStore.projects}
-                                        onTaskUpdate={handleTaskUpdate}
-                                        onTaskDelete={handleTaskDelete}
-                                        showCompletedTasks={true}
-                                    />
-                                </div>
-                            )}
-                        </div>
-                    )}
-                </div>
+                            </div>
+                        )}
+                    </div>
+                )}
             </div>
 
             {isEditModalOpen && (
@@ -531,217 +302,6 @@ const AreaDetails: React.FC = () => {
                     onSave={handleAreaSave}
                     onClose={() => setIsEditModalOpen(false)}
                 />
-            )}
-
-            {isGoalModalOpen && (
-                <GoalModal
-                    isOpen={isGoalModalOpen}
-                    onClose={handleGoalModalClose}
-                    onSave={handleGoalSave}
-                    goal={editingGoal}
-                    areas={areasStore.areas}
-                    defaultAreaId={area?.id}
-                />
-            )}
-
-            {goalToDelete && (
-                <ConfirmDialog
-                    title={t('modals.deleteGoal.title', 'Delete Goal')}
-                    message={`${t('modals.deleteGoal.message', 'Are you sure you want to delete')} "${goalToDelete.title}"? Projects under it will become unlinked.`}
-                    onConfirm={handleDeleteGoal}
-                    onCancel={() => setGoalToDelete(null)}
-                />
-            )}
-        </div>
-    );
-};
-
-/* ── Sub-components ─────────────────────────────────────────────── */
-
-interface GoalBucketProps {
-    goal: Goal;
-    projects: Project[];
-    areaColor?: string | null;
-    getProjectLink: (p: Project) => string;
-    onEdit: () => void;
-    onDelete: () => void;
-    dimmed?: boolean;
-}
-
-const GoalBucket: React.FC<GoalBucketProps> = ({
-    goal, projects, areaColor, getProjectLink, onEdit, onDelete, dimmed,
-}) => {
-    const { t } = useTranslation();
-    const dotColor = areaColor || '#6b7280';
-    const goalUrl = goal.uid ? createGoalUrl({ uid: goal.uid, title: goal.title }) : null;
-    return (
-        <div className={dimmed ? 'opacity-60' : ''}>
-            <div className="flex items-start justify-between gap-2 mb-1.5">
-                <div className="flex items-center gap-2 min-w-0">
-                    <FlagIcon className="h-4 w-4 flex-shrink-0" style={{ color: dotColor }} />
-                    {goalUrl ? (
-                        <Link to={goalUrl} className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate hover:text-blue-600 dark:hover:text-blue-400">
-                            {goal.title}
-                        </Link>
-                    ) : (
-                        <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">
-                            {goal.title}
-                        </span>
-                    )}
-                    <span className="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0">
-                        {HORIZON_LABELS[goal.horizon]}
-                        {goal.status !== 'active' && ` · ${STATUS_LABELS[goal.status]}`}
-                    </span>
-                </div>
-                <div className="flex items-center gap-1 flex-shrink-0">
-                    <button onClick={onEdit} className="p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300" title={t('areas.editGoal')}>
-                        <PencilSquareIcon className="h-3.5 w-3.5" />
-                    </button>
-                    <button onClick={onDelete} className="p-1 text-gray-400 hover:text-red-500" title={t('areas.deleteGoal')}>
-                        <TrashIcon className="h-3.5 w-3.5" />
-                    </button>
-                </div>
-            </div>
-            {goal.why && (
-                <p className="text-xs text-gray-400 dark:text-gray-500 ml-6 mb-1.5 italic">{goal.why}</p>
-            )}
-            {projects.length > 0 ? (
-                <div className="ml-6">
-                    <p className="text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500 mb-1.5">
-                        Projects
-                    </p>
-                    <div className="space-y-2">
-                        {projects.map((p) => (
-                            <ProjectChip key={p.uid || p.id} project={p} getLink={getProjectLink} />
-                        ))}
-                    </div>
-                </div>
-            ) : (
-                <p className="text-xs text-gray-300 dark:text-gray-600 ml-6 italic">No projects linked</p>
-            )}
-        </div>
-    );
-};
-
-interface MaintenanceProjectRowProps {
-    project: Project;
-    getLink: (p: Project) => string;
-    onUnmark: (p: Project) => void;
-}
-
-const MaintenanceProjectRow: React.FC<MaintenanceProjectRowProps> = ({ project, getLink, onUnmark }) => {
-    const { t } = useTranslation();
-    const cardColor = (project as any).color || '#6b7280';
-    return (
-        <div
-            className="flex items-center gap-3 px-3 py-3 rounded-md bg-white dark:bg-gray-900 shadow-sm border-l-4 group"
-            style={{ borderLeftColor: cardColor }}
-        >
-            <Link
-                to={getLink(project)}
-                className="min-w-0 flex-1 text-sm font-medium text-gray-800 dark:text-gray-200 truncate hover:text-gray-900 dark:hover:text-gray-100"
-            >
-                {project.name}
-            </Link>
-            <button
-                onClick={() => onUnmark(project)}
-                className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0"
-                title={t('areas.moveBackToUnlinked')}
-            >
-                unlink
-            </button>
-        </div>
-    );
-};
-
-interface ProjectChipProps {
-    project: Project;
-    getLink: (p: Project) => string;
-}
-
-const ProjectChip: React.FC<ProjectChipProps> = ({ project, getLink }) => {
-    const cardColor = (project as any).color || '#6b7280';
-    return (
-        <Link
-            to={getLink(project)}
-            className="flex items-center gap-3 px-3 py-3 rounded-md bg-white dark:bg-gray-900 shadow-sm hover:shadow-md transition-shadow border-l-4"
-            style={{ borderLeftColor: cardColor }}
-        >
-            <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate">
-                {project.name}
-            </span>
-        </Link>
-    );
-};
-
-interface UnlinkedProjectRowProps {
-    project: Project;
-    goals: Goal[];
-    getLink: (p: Project) => string;
-    onLinkToGoal: (p: Project, goal: Goal) => void;
-    onMarkMaintenance: (p: Project) => void;
-    onDrop: (p: Project) => void;
-}
-
-const UnlinkedProjectRow: React.FC<UnlinkedProjectRowProps> = ({
-    project, goals, getLink, onLinkToGoal, onMarkMaintenance, onDrop,
-}) => {
-    const [open, setOpen] = useState(false);
-
-    const cardColor = (project as any).color || '#9ca3af';
-    return (
-        <div
-            className="bg-white dark:bg-gray-900 rounded-md shadow-sm px-3 py-3 border-l-4"
-            style={{ borderLeftColor: cardColor }}
-        >
-            <div className="flex items-start justify-between gap-2">
-                <Link
-                    to={getLink(project)}
-                    className="min-w-0 flex-1 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 truncate"
-                >
-                    {project.name}
-                </Link>
-                <button
-                    onClick={() => setOpen((o) => !o)}
-                    className="text-xs text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 flex-shrink-0 mt-0.5"
-                >
-                    {open ? 'cancel' : 'link…'}
-                </button>
-            </div>
-            {open && (
-                <div className="mt-2 space-y-1.5">
-                    {goals.length > 0 ? (
-                        <div className="flex flex-wrap gap-1.5">
-                            {goals.map((g) => (
-                                <button
-                                    key={g.uid}
-                                    onClick={() => onLinkToGoal(project, g)}
-                                    className="text-xs bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-700 px-2 py-1 rounded hover:bg-blue-100 dark:hover:bg-blue-800/40"
-                                >
-                                    {g.title}
-                                </button>
-                            ))}
-                        </div>
-                    ) : (
-                        <p className="text-xs text-gray-400 dark:text-gray-500">
-                            No active goals yet. Add one above to link this project.
-                        </p>
-                    )}
-                    <div className="flex gap-2 pt-1">
-                        <button
-                            onClick={() => onMarkMaintenance(project)}
-                            className="text-xs text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-gray-600 px-2 py-1 rounded hover:bg-gray-50 dark:hover:bg-gray-800"
-                        >
-                            Maintenance
-                        </button>
-                        <button
-                            onClick={() => onDrop(project)}
-                            className="text-xs text-red-500 dark:text-red-400 border border-red-200 dark:border-red-700 px-2 py-1 rounded hover:bg-red-50 dark:hover:bg-red-900/20"
-                        >
-                            Drop
-                        </button>
-                    </div>
-                </div>
             )}
         </div>
     );

--- a/frontend/components/Area/AreaDetails.tsx
+++ b/frontend/components/Area/AreaDetails.tsx
@@ -209,14 +209,9 @@ const AreaDetails: React.FC = () => {
     };
 
     const handleLinkToGoal = async (project: Project, goal: Goal) => {
-        console.log('[handleLinkToGoal]', { projectUid: project.uid, goalId: goal.id, goalUid: goal.uid });
-        if (!project.uid || !goal.id) {
-            console.warn('[handleLinkToGoal] early return – missing uid or goal.id', { projectUid: project.uid, goalId: goal.id });
-            return;
-        }
+        if (!project.uid || !goal.id) return;
         try {
             const saved = await updateProject(project.uid, { goal_id: goal.id, is_maintenance: false });
-            console.log('[handleLinkToGoal] server response goal_id:', saved.goal_id);
             const savedGoalId = saved.goal_id ?? (saved as any).Goal?.id ?? null;
             patchProjectInStore(project.uid, {
                 goal_id: savedGoalId,
@@ -285,7 +280,6 @@ const AreaDetails: React.FC = () => {
     );
     const completedTasks = areaTasks.filter((t) => t.status === 'done' || t.status === 2);
 
-    // Bucket projects into: under a goal / maintenance / unlinked
     const projectsByGoal = new Map<number, Project[]>();
     const maintenanceProjects: Project[] = [];
     const unlinkedProjects: Project[] = [];
@@ -382,7 +376,6 @@ const AreaDetails: React.FC = () => {
                         <p className="text-sm text-gray-400 dark:text-gray-500">Loading goals…</p>
                     ) : (
                         <div className="space-y-4">
-                            {/* Empty state: only when there are no goals AND no projects at all */}
                             {goals.length === 0 && areaProjects.length === 0 && (
                                 <p className="text-sm text-gray-400 dark:text-gray-500">
                                     No goals yet. Add a goal to group projects by outcome.
@@ -470,17 +463,17 @@ const AreaDetails: React.FC = () => {
                                             Projects
                                         </p>
                                         <div className="space-y-2">
-                                        {unlinkedProjects.map((p) => (
-                                            <UnlinkedProjectRow
-                                                key={p.uid || p.id}
-                                                project={p}
-                                                goals={goals.filter((g) => g.status === 'active')}
-                                                getLink={getProjectLink}
-                                                onLinkToGoal={handleLinkToGoal}
-                                                onMarkMaintenance={handleMarkMaintenance}
-                                                onDrop={handleDropProject}
-                                            />
-                                        ))}
+                                            {unlinkedProjects.map((p) => (
+                                                <UnlinkedProjectRow
+                                                    key={p.uid || p.id}
+                                                    project={p}
+                                                    goals={goals.filter((g) => g.status === 'active')}
+                                                    getLink={getProjectLink}
+                                                    onLinkToGoal={handleLinkToGoal}
+                                                    onMarkMaintenance={handleMarkMaintenance}
+                                                    onDrop={handleDropProject}
+                                                />
+                                            ))}
                                         </div>
                                     </div>
                                 </div>
@@ -546,6 +539,7 @@ const AreaDetails: React.FC = () => {
                     onClose={handleGoalModalClose}
                     onSave={handleGoalSave}
                     goal={editingGoal}
+                    areas={areasStore.areas}
                     defaultAreaId={area?.id}
                 />
             )}
@@ -724,25 +718,25 @@ const UnlinkedProjectRow: React.FC<UnlinkedProjectRowProps> = ({
                                     onClick={() => onLinkToGoal(project, g)}
                                     className="text-xs bg-blue-50 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-700 px-2 py-1 rounded hover:bg-blue-100 dark:hover:bg-blue-800/40"
                                 >
-                                    → {g.title}
+                                    {g.title}
                                 </button>
                             ))}
                         </div>
                     ) : (
-                        <p className="text-xs text-gray-400 dark:text-gray-500 italic">
+                        <p className="text-xs text-gray-400 dark:text-gray-500">
                             No active goals yet. Add one above to link this project.
                         </p>
                     )}
-                    <div className="flex flex-wrap gap-1.5">
+                    <div className="flex gap-2 pt-1">
                         <button
                             onClick={() => onMarkMaintenance(project)}
-                            className="text-xs border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-400 px-2 py-1 rounded hover:bg-gray-50 dark:hover:bg-gray-800"
+                            className="text-xs text-gray-500 dark:text-gray-400 border border-gray-200 dark:border-gray-600 px-2 py-1 rounded hover:bg-gray-50 dark:hover:bg-gray-800"
                         >
                             Maintenance
                         </button>
                         <button
                             onClick={() => onDrop(project)}
-                            className="text-xs text-red-400 hover:text-red-600 px-1 py-1"
+                            className="text-xs text-red-500 dark:text-red-400 border border-red-200 dark:border-red-700 px-2 py-1 rounded hover:bg-red-50 dark:hover:bg-red-900/20"
                         >
                             Drop
                         </button>

--- a/frontend/components/Area/AreaModal.tsx
+++ b/frontend/components/Area/AreaModal.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Area } from '../../entities/Area';
+import { Goal } from '../../entities/Goal';
 import { useToast } from '../Shared/ToastContext';
 import { useTranslation } from 'react-i18next';
 import DiscardChangesDialog from '../Shared/DiscardChangesDialog';
-import { TrashIcon } from '@heroicons/react/24/outline';
+import { TrashIcon, ChevronDownIcon, FlagIcon, CheckIcon } from '@heroicons/react/24/outline';
 import ColorPicker from '../Shared/ColorPicker';
+import { useStore } from '../../store/useStore';
+import { updateGoal } from '../../utils/goalsService';
 
 interface AreaModalProps {
     isOpen: boolean;
@@ -36,8 +39,26 @@ const AreaModal: React.FC<AreaModalProps> = ({
     const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
     const [isClosing, setIsClosing] = useState(false);
     const [showDiscardDialog, setShowDiscardDialog] = useState(false);
+    const [isGoalDropdownOpen, setIsGoalDropdownOpen] = useState(false);
+    const [selectedGoalUids, setSelectedGoalUids] = useState<string[]>([]);
+    const [initialGoalUids, setInitialGoalUids] = useState<string[]>([]);
+    const goalDropdownRef = useRef<HTMLDivElement>(null);
 
     const { showSuccessToast, showErrorToast } = useToast();
+
+    const allGoals: Goal[] = useStore((state: any) => state.goalsStore.goals);
+    const goalsLoaded = useStore((state: any) => state.goalsStore.hasLoaded);
+    const loadGoals = useStore((state: any) => state.goalsStore.loadGoals);
+    const setGoals = useStore((state: any) => state.goalsStore.setGoals);
+
+    useEffect(() => {
+        if (!goalsLoaded) loadGoals();
+    }, [goalsLoaded, loadGoals]);
+
+    // Available goals: already linked to this area, or unlinked
+    const availableGoals = allGoals.filter(
+        (g) => !g.area_id || (area && g.Area?.uid === area.uid)
+    );
 
     useEffect(() => {
         if (isOpen) {
@@ -50,45 +71,34 @@ const AreaModal: React.FC<AreaModalProps> = ({
             });
             setError(null);
 
-            // Auto-focus on the name input when modal opens
-            setTimeout(() => {
-                nameInputRef.current?.focus();
-            }, 100);
+            const linked = allGoals
+                .filter((g) => area && g.Area?.uid === area.uid)
+                .map((g) => g.uid!)
+                .filter(Boolean);
+            setSelectedGoalUids(linked);
+            setInitialGoalUids(linked);
+
+            setTimeout(() => nameInputRef.current?.focus(), 100);
         }
     }, [isOpen, area]);
 
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
             if (showDiscardDialog) return;
-            if (
-                modalRef.current &&
-                !modalRef.current.contains(event.target as Node)
-            ) {
+            if (modalRef.current && !modalRef.current.contains(event.target as Node)) {
                 handleClose();
             }
         };
-
-        if (isOpen) {
-            document.addEventListener('mousedown', handleClickOutside);
-        }
-        return () => {
-            document.removeEventListener('mousedown', handleClickOutside);
-        };
+        if (isOpen) document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
     }, [isOpen, showDiscardDialog]);
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
             if (event.key === 'Escape') {
-                // Don't show discard dialog if already showing
-                if (showDiscardDialog) {
-                    // Let the dialog handle its own Escape
-                    return;
-                }
-
+                if (showDiscardDialog) return;
                 event.preventDefault();
                 event.stopPropagation();
-
-                // Check for unsaved changes using ref to get current value
                 if (hasUnsavedChangesRef.current()) {
                     setShowDiscardDialog(true);
                 } else {
@@ -96,45 +106,61 @@ const AreaModal: React.FC<AreaModalProps> = ({
                 }
             }
         };
-
-        if (isOpen) {
-            document.addEventListener('keydown', handleKeyDown);
-        }
-        return () => {
-            document.removeEventListener('keydown', handleKeyDown);
-        };
+        if (isOpen) document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
     }, [isOpen, showDiscardDialog]);
 
-    const handleChange = (
-        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
-    ) => {
+    useEffect(() => {
+        if (!isGoalDropdownOpen) return;
+        const handleOutside = (e: MouseEvent) => {
+            if (goalDropdownRef.current && !goalDropdownRef.current.contains(e.target as Node)) {
+                setIsGoalDropdownOpen(false);
+            }
+        };
+        setTimeout(() => document.addEventListener('mousedown', handleOutside), 50);
+        return () => document.removeEventListener('mousedown', handleOutside);
+    }, [isGoalDropdownOpen]);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target;
-        setFormData((prev) => ({
-            ...prev,
-            [name]: value,
-        }));
+        setFormData((prev) => ({ ...prev, [name]: value }));
+    };
+
+    const toggleGoal = (uid: string) => {
+        setSelectedGoalUids((prev) =>
+            prev.includes(uid) ? prev.filter((u) => u !== uid) : [...prev, uid]
+        );
     };
 
     const handleSubmit = async (e?: React.FormEvent) => {
-        if (e) {
-            e.preventDefault();
-        }
-
+        if (e) e.preventDefault();
         if (!formData.name.trim()) {
             setError(t('errors.areaNameRequired'));
             return;
         }
-
         setIsSubmitting(true);
         setError(null);
-
         try {
             await onSave(formData);
-            showSuccessToast(
-                formData.uid
-                    ? t('success.areaUpdated')
-                    : t('success.areaCreated')
-            );
+
+            // Sync goal area assignments for existing areas
+            if (area?.id) {
+                const added = selectedGoalUids.filter((u) => !initialGoalUids.includes(u));
+                const removed = initialGoalUids.filter((u) => !selectedGoalUids.includes(u));
+
+                const updates = await Promise.all([
+                    ...added.map((uid) => updateGoal(uid, { area_id: area.id })),
+                    ...removed.map((uid) => updateGoal(uid, { area_id: null })),
+                ]);
+
+                if (updates.length > 0) {
+                    const updatedMap: Record<string, Goal> = {};
+                    updates.forEach((r) => { updatedMap[r.goal.uid!] = r.goal; });
+                    setGoals(allGoals.map((g) => updatedMap[g.uid!] ?? g));
+                }
+            }
+
+            showSuccessToast(formData.uid ? t('success.areaUpdated') : t('success.areaCreated'));
             handleClose();
         } catch (err) {
             setError((err as Error).message);
@@ -144,29 +170,20 @@ const AreaModal: React.FC<AreaModalProps> = ({
         }
     };
 
-    // Check if there are unsaved changes
     const hasUnsavedChanges = () => {
         if (!area) {
-            // New area - check if any field has been filled
-            return (
-                formData.name.trim() !== '' ||
-                formData.description?.trim() !== ''
-            );
+            return formData.name.trim() !== '' || (formData.description?.trim() ?? '') !== '';
         }
-
-        // Existing area - compare with original
         return (
             formData.name !== area.name ||
             formData.description !== area.description ||
-            formData.color !== area.color
+            formData.color !== area.color ||
+            selectedGoalUids.join(',') !== initialGoalUids.join(',')
         );
     };
 
-    // Use ref to store hasUnsavedChanges so it's always current in the event handler
     const hasUnsavedChangesRef = useRef(hasUnsavedChanges);
-    useEffect(() => {
-        hasUnsavedChangesRef.current = hasUnsavedChanges;
-    });
+    useEffect(() => { hasUnsavedChangesRef.current = hasUnsavedChanges; });
 
     const handleClose = () => {
         setIsClosing(true);
@@ -174,36 +191,26 @@ const AreaModal: React.FC<AreaModalProps> = ({
             onClose();
             setIsClosing(false);
             setShowDiscardDialog(false);
+            setIsGoalDropdownOpen(false);
         }, 300);
-    };
-
-    const handleDiscardChanges = () => {
-        setShowDiscardDialog(false);
-        handleClose();
-    };
-
-    const handleCancelDiscard = () => {
-        setShowDiscardDialog(false);
     };
 
     const handleDeleteArea = async () => {
         if (formData.uid && onDelete) {
             try {
                 await onDelete(formData.uid);
-                showSuccessToast(
-                    t('success.areaDeleted', 'Area deleted successfully!')
-                );
+                showSuccessToast(t('success.areaDeleted', 'Area deleted successfully!'));
                 handleClose();
             } catch (err) {
                 setError((err as Error).message);
-                showErrorToast(
-                    t('errors.failedToDeleteArea', 'Failed to delete area.')
-                );
+                showErrorToast(t('errors.failedToDeleteArea', 'Failed to delete area.'));
             }
         }
     };
 
     if (!isOpen) return null;
+
+    const selectedGoals = availableGoals.filter((g) => selectedGoalUids.includes(g.uid!));
 
     return (
         <>
@@ -220,21 +227,15 @@ const AreaModal: React.FC<AreaModalProps> = ({
                         } h-full sm:h-auto sm:my-4`}
                     >
                         <div className="flex flex-col h-full sm:min-h-[400px] sm:max-h-[90vh]">
-                            {/* Main Form Section */}
                             <div className="flex-1 flex flex-col transition-all duration-300 bg-white dark:bg-gray-800 sm:rounded-lg">
                                 <div className="flex-1 relative">
                                     <div
                                         className="absolute inset-0 overflow-y-auto overflow-x-hidden"
-                                        style={{
-                                            WebkitOverflowScrolling: 'touch',
-                                        }}
+                                        style={{ WebkitOverflowScrolling: 'touch' }}
                                     >
-                                        <form
-                                            className="h-full"
-                                            onSubmit={handleSubmit}
-                                        >
+                                        <form className="h-full" onSubmit={handleSubmit}>
                                             <fieldset className="h-full flex flex-col">
-                                                {/* Area Title Section - Always Visible */}
+                                                {/* Name */}
                                                 <div className="border-b border-gray-200 dark:border-gray-700 pb-4 mb-4 px-4 pt-4 sm:rounded-t-lg">
                                                     <input
                                                         ref={nameInputRef}
@@ -245,72 +246,113 @@ const AreaModal: React.FC<AreaModalProps> = ({
                                                         onChange={handleChange}
                                                         required
                                                         className="block w-full text-xl font-semibold bg-transparent text-black dark:text-white border-none focus:outline-none shadow-sm py-2"
-                                                        placeholder={t(
-                                                            'forms.areaNamePlaceholder'
-                                                        )}
+                                                        placeholder={t('forms.areaNamePlaceholder')}
                                                         data-testid="area-name-input"
                                                     />
                                                 </div>
 
-                                                {/* Description Section - Always Visible */}
-                                                <div className="flex-1 pb-4 sm:px-4">
+                                                {/* Description */}
+                                                <div className="pb-4 px-4">
                                                     <textarea
                                                         id="areaDescription"
                                                         name="description"
-                                                        value={
-                                                            formData.description
-                                                        }
+                                                        value={formData.description}
                                                         onChange={handleChange}
-                                                        className="block w-full h-full sm:border sm:border-gray-300 sm:dark:border-gray-600 sm:rounded-md shadow-sm py-2 px-3 sm:py-3 sm:px-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 sm:focus:ring-2 sm:focus:ring-blue-500 transition duration-150 ease-in-out resize-none"
-                                                        placeholder={t(
-                                                            'forms.areaDescriptionPlaceholder'
-                                                        )}
-                                                        style={{
-                                                            minHeight: '150px',
-                                                        }}
+                                                        className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 resize-none"
+                                                        placeholder={t('forms.areaDescriptionPlaceholder')}
+                                                        rows={3}
                                                     />
                                                 </div>
 
-                                                {/* Color Section */}
+                                                {/* Color */}
                                                 <div className="border-t border-gray-200 dark:border-gray-700 pt-4 pb-4 px-4">
-                                                    <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+                                                    <h3 className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-3 uppercase tracking-wider">
                                                         {t('forms.color', 'Color')}
                                                     </h3>
                                                     <ColorPicker
                                                         value={formData.color || ''}
                                                         onChange={(color) =>
-                                                            setFormData((prev) => ({
-                                                                ...prev,
-                                                                color: color || '',
-                                                            }))
+                                                            setFormData((prev) => ({ ...prev, color: color || '' }))
                                                         }
                                                     />
                                                 </div>
 
-                                                {/* Error Message */}
-                                                {error && (
-                                                    <div className="text-red-500 px-4 mb-4">
-                                                        {error}
+                                                {/* Goals — only shown when editing an existing area */}
+                                                {area?.id && (
+                                                    <div className="border-t border-gray-200 dark:border-gray-700 pt-4 pb-4 px-4">
+                                                        <h3 className="text-xs font-medium text-gray-500 dark:text-gray-400 mb-3 uppercase tracking-wider">
+                                                            {t('goals.title', 'Goals')}
+                                                        </h3>
+
+                                                        <div className="relative" ref={goalDropdownRef}>
+                                                            <button
+                                                                type="button"
+                                                                onClick={() => setIsGoalDropdownOpen((v) => !v)}
+                                                                className="w-full flex items-center justify-between gap-2 border border-gray-300 dark:border-gray-600 rounded-md px-3 py-2 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 hover:border-gray-400 dark:hover:border-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors"
+                                                            >
+                                                                <span className="truncate text-left">
+                                                                    {selectedGoals.length === 0
+                                                                        ? t('goals.noGoalsSelected', 'No goals selected')
+                                                                        : selectedGoals.map((g) => g.title).join(', ')}
+                                                                </span>
+                                                                <ChevronDownIcon className={`h-4 w-4 flex-shrink-0 text-gray-400 transition-transform ${isGoalDropdownOpen ? 'rotate-180' : ''}`} />
+                                                            </button>
+
+                                                            {isGoalDropdownOpen && (
+                                                                <div className="absolute left-0 right-0 top-full mt-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-600 rounded-md shadow-lg z-50 max-h-52 overflow-y-auto">
+                                                                    {availableGoals.length === 0 ? (
+                                                                        <p className="px-3 py-2.5 text-sm text-gray-400 dark:text-gray-500">
+                                                                            {t('goals.noAvailableGoals', 'No available goals')}
+                                                                        </p>
+                                                                    ) : (
+                                                                        availableGoals.map((goal) => {
+                                                                            const checked = selectedGoalUids.includes(goal.uid!);
+                                                                            return (
+                                                                                <button
+                                                                                    key={goal.uid}
+                                                                                    type="button"
+                                                                                    onClick={() => toggleGoal(goal.uid!)}
+                                                                                    className="w-full flex items-center gap-3 px-3 py-2.5 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors text-left"
+                                                                                >
+                                                                                    <div className={`flex-shrink-0 w-4 h-4 rounded border flex items-center justify-center ${
+                                                                                        checked
+                                                                                            ? 'bg-blue-600 border-blue-600'
+                                                                                            : 'border-gray-300 dark:border-gray-500'
+                                                                                    }`}>
+                                                                                        {checked && <CheckIcon className="h-3 w-3 text-white" />}
+                                                                                    </div>
+                                                                                    <FlagIcon className="h-4 w-4 text-blue-500 flex-shrink-0" />
+                                                                                    <div className="min-w-0 flex-1">
+                                                                                        <p className="text-sm text-gray-800 dark:text-gray-200 truncate">{goal.title}</p>
+                                                                                        <p className="text-xs text-gray-400 dark:text-gray-500">{t(`goals.horizon.${goal.horizon}`, goal.horizon)} · {t(`goals.status.${goal.status}`, goal.status)}</p>
+                                                                                    </div>
+                                                                                </button>
+                                                                            );
+                                                                        })
+                                                                    )}
+                                                                </div>
+                                                            )}
+                                                        </div>
                                                     </div>
+                                                )}
+
+                                                {error && (
+                                                    <div className="text-red-500 px-4 mb-4 text-sm">{error}</div>
                                                 )}
                                             </fieldset>
                                         </form>
                                     </div>
                                 </div>
 
-                                {/* Action Buttons - Below border with custom layout */}
+                                {/* Footer */}
                                 <div className="flex-shrink-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 px-3 py-2 flex items-center justify-between sm:rounded-b-lg">
-                                    {/* Left side: Delete and Cancel */}
                                     <div className="flex items-center space-x-3">
                                         {area && area.uid && onDelete && (
                                             <button
                                                 type="button"
                                                 onClick={handleDeleteArea}
                                                 className="p-2 border border-red-300 dark:border-red-600 text-red-600 dark:text-red-400 rounded-md hover:bg-red-50 dark:hover:bg-red-900/20 focus:outline-none transition duration-150 ease-in-out"
-                                                title={t(
-                                                    'common.delete',
-                                                    'Delete'
-                                                )}
+                                                title={t('common.delete', 'Delete')}
                                             >
                                                 <TrashIcon className="h-4 w-4" />
                                             </button>
@@ -323,16 +365,12 @@ const AreaModal: React.FC<AreaModalProps> = ({
                                             {t('common.cancel')}
                                         </button>
                                     </div>
-
-                                    {/* Right side: Save */}
                                     <button
                                         type="button"
                                         onClick={() => handleSubmit()}
                                         disabled={isSubmitting}
                                         className={`px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 focus:outline-none transition duration-150 ease-in-out text-sm ${
-                                            isSubmitting
-                                                ? 'opacity-50 cursor-not-allowed'
-                                                : ''
+                                            isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
                                         }`}
                                         data-testid="area-save-button"
                                     >
@@ -350,8 +388,8 @@ const AreaModal: React.FC<AreaModalProps> = ({
             </div>
             {showDiscardDialog && (
                 <DiscardChangesDialog
-                    onDiscard={handleDiscardChanges}
-                    onCancel={handleCancelDiscard}
+                    onDiscard={() => { setShowDiscardDialog(false); handleClose(); }}
+                    onCancel={() => setShowDiscardDialog(false)}
                 />
             )}
         </>

--- a/frontend/components/Goal/GoalDetails.tsx
+++ b/frontend/components/Goal/GoalDetails.tsx
@@ -1,63 +1,140 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, useLocation, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
     PencilSquareIcon,
     TrashIcon,
     FlagIcon,
-    FolderIcon,
-    CheckCircleIcon,
+    XMarkIcon,
 } from '@heroicons/react/24/outline';
-import { Goal } from '../../entities/Goal';
+import { Goal, GoalHorizon, GoalStatus } from '../../entities/Goal';
 import { Task } from '../../entities/Task';
 import { Project } from '../../entities/Project';
-import { fetchGoalByUid, updateGoal, deleteGoal } from '../../utils/goalsService';
+import { fetchGoalByUid, createGoal, updateGoal, deleteGoal } from '../../utils/goalsService';
 import { extractUidFromSlug, createProjectUrl } from '../../utils/slugUtils';
 import ConfirmDialog from '../Shared/ConfirmDialog';
-import GoalModal from './GoalModal';
+import TaskList from '../Task/TaskList';
 import { useStore } from '../../store/useStore';
 import { useToast } from '../Shared/ToastContext';
 
-const STATUS_COLORS: Record<string, string> = {
-    active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-    achieved: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-    paused: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
-    dropped: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
-};
-
 const TASK_STATUS_DONE = [2, 3, 'done', 'archived'];
+
+const defaultFormData = (): Partial<Goal> => ({
+    title: '',
+    why: '',
+    horizon: 'season' as GoalHorizon,
+    status: 'active' as GoalStatus,
+    target_date: '',
+    area_id: null,
+});
 
 const GoalDetails: React.FC = () => {
     const { t } = useTranslation();
     const { uidSlug } = useParams<{ uidSlug: string }>();
     const navigate = useNavigate();
+    const location = useLocation();
     const { showSuccessToast, showErrorToast } = useToast();
 
+    const isNew = uidSlug === 'new';
+    const prefilledAreaId = isNew ? ((location.state as any)?.area_id ?? null) : null;
+
     const [goal, setGoal] = useState<Goal | null>(null);
-    const [loading, setLoading] = useState(true);
+    const [loading, setLoading] = useState(!isNew);
     const [error, setError] = useState<string | null>(null);
-    const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+    const [isEditing, setIsEditing] = useState(isNew);
     const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
+    const [formData, setFormData] = useState<Partial<Goal>>({ ...defaultFormData(), area_id: prefilledAreaId });
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [formError, setFormError] = useState<string | null>(null);
 
     const loadGoals = useStore((state: any) => state.goalsStore.loadGoals);
+    const areas = useStore((state: any) => state.areasStore.areas);
+    const projects: Project[] = useStore((state: any) => state.projectsStore.projects);
 
     useEffect(() => {
+        if (isNew) return;
+
         const uid = extractUidFromSlug(uidSlug ?? '');
         if (!uid) { setError(t('goals.notFound', 'Goal not found')); setLoading(false); return; }
 
         fetchGoalByUid(uid)
-            .then((data) => setGoal(data))
+            .then((data) => {
+                setGoal(data);
+                setFormData({
+                    title: data.title,
+                    why: data.why ?? '',
+                    horizon: data.horizon,
+                    status: data.status,
+                    target_date: data.target_date ?? '',
+                    area_id: data.area_id ?? null,
+                });
+            })
             .catch((err) => setError(err?.message || t('goals.notFound', 'Goal not found')))
             .finally(() => setLoading(false));
-    }, [uidSlug, t]);
+    }, [uidSlug, t, isNew]);
 
-    const handleSaveGoal = async (data: Partial<Goal>) => {
-        if (!goal?.uid) return;
-        const result = await updateGoal(goal.uid, data);
-        setGoal((prev) => prev ? { ...prev, ...result.goal } : result.goal);
-        loadGoals(true);
-        showSuccessToast(t('success.goalUpdated', 'Goal updated!'));
-        setIsEditModalOpen(false);
+    const handleChange = (
+        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+    ) => {
+        const { name, value } = e.target;
+        setFormData((prev) => ({
+            ...prev,
+            [name]: name === 'area_id' ? (value ? parseInt(value, 10) : null) : value,
+        }));
+    };
+
+    const handleSubmit = async () => {
+        if (!formData.title?.trim()) {
+            setFormError(t('errors.goalTitleRequired', 'Goal title is required'));
+            return;
+        }
+        setIsSubmitting(true);
+        setFormError(null);
+        try {
+            const payload = {
+                ...formData,
+                target_date: formData.target_date || null,
+                area_id: formData.area_id || null,
+            };
+            if (isNew) {
+                const result = await createGoal(payload as any);
+                const current = useStore.getState().goalsStore.goals;
+                useStore.getState().goalsStore.setGoals([...current, result.goal]);
+                showSuccessToast(t('success.goalCreated', 'Goal created!'));
+                const { createGoalUrl } = await import('../../utils/slugUtils');
+                navigate(createGoalUrl({ uid: result.goal.uid!, title: result.goal.title }), { replace: true });
+            } else {
+                const result = await updateGoal(goal!.uid!, payload);
+                setGoal((prev) => prev ? { ...prev, ...result.goal } : result.goal);
+                setIsEditing(false);
+                loadGoals(true);
+                showSuccessToast(t('success.goalUpdated', 'Goal updated!'));
+            }
+        } catch (err) {
+            setFormError((err as Error).message);
+            showErrorToast(t('errors.failedToSaveGoal', 'Failed to save goal.'));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const handleCancelEdit = () => {
+        if (isNew) {
+            navigate('/goals');
+            return;
+        }
+        setIsEditing(false);
+        setFormError(null);
+        if (goal) {
+            setFormData({
+                title: goal.title,
+                why: goal.why ?? '',
+                horizon: goal.horizon,
+                status: goal.status,
+                target_date: goal.target_date ?? '',
+                area_id: goal.area_id ?? null,
+            });
+        }
     };
 
     const handleDeleteGoal = async () => {
@@ -73,164 +150,339 @@ const GoalDetails: React.FC = () => {
         setIsConfirmDeleteOpen(false);
     };
 
+    const handleTaskUpdate = async (updatedTask: Task) => {
+        setGoal((prev) => {
+            if (!prev) return prev;
+            return {
+                ...prev,
+                Tasks: (prev.Tasks ?? []).map((t: any) =>
+                    (t.uid ?? t.id) === (updatedTask.uid ?? updatedTask.id) ? updatedTask : t
+                ),
+            };
+        });
+    };
+
+    const handleTaskDelete = (taskUid: string) => {
+        setGoal((prev) => {
+            if (!prev) return prev;
+            return {
+                ...prev,
+                Tasks: (prev.Tasks ?? []).filter((t: any) => t.uid !== taskUid),
+            };
+        });
+    };
+
     if (loading) {
         return (
-            <div className="flex items-center justify-center h-screen">
-                <div className="text-xl font-semibold text-gray-700 dark:text-gray-200">
-                    {t('common.loading', 'Loading...')}
-                </div>
+            <div className="flex items-center justify-center h-64 text-gray-500 dark:text-gray-400">
+                {t('common.loading', 'Loading...')}
             </div>
         );
     }
 
-    if (error || !goal) {
+    if (error || (!isNew && !goal)) {
         return <div className="text-red-500 p-4">{error ?? t('goals.notFound', 'Goal not found')}</div>;
     }
 
-    const tasks: Task[] = (goal.Tasks ?? []) as Task[];
-    const projects: Project[] = (goal.Projects ?? []) as Project[];
+    const tasks: Task[] = (goal?.Tasks ?? []) as Task[];
+    const goalProjects: Project[] = (goal?.Projects ?? []) as Project[];
     const activeTasks = tasks.filter((t) => !TASK_STATUS_DONE.includes(t.status as any));
     const completedTasks = tasks.filter((t) => TASK_STATUS_DONE.includes(t.status as any));
+
+    const areaColor = goal?.Area?.color;
+    const hasColor = !!areaColor;
+    const showForm = isEditing || isNew;
 
     return (
         <div className="w-full px-2 sm:px-4 lg:px-6 pt-4 pb-8">
             {/* Header banner */}
-            <div className="bg-gray-50 dark:bg-gray-900 rounded-xl mb-8 overflow-hidden">
-                <div className="p-6">
-                    <div className="flex items-start justify-between gap-4">
-                        <div className="min-w-0 flex-1">
+            <div
+                className="rounded-xl mb-8 overflow-hidden"
+                style={hasColor && !showForm ? { backgroundColor: areaColor } : undefined}
+            >
+                <div className={`p-6 ${(!hasColor || showForm) ? 'bg-gray-50 dark:bg-gray-900 rounded-xl' : ''}`}>
+                    {showForm ? (
+                        /* Edit / Create form inline */
+                        <div className="flex flex-col gap-4">
                             <div className="flex items-center gap-2 mb-1">
                                 <FlagIcon className="h-4 w-4 text-blue-500" />
                                 <p className="text-xs font-medium uppercase tracking-widest text-gray-400 dark:text-gray-500">
-                                    {t('goals.singular', 'Goal')}
+                                    {isNew ? t('goals.newGoal', 'New Goal') : t('goals.editGoal', 'Edit Goal')}
                                 </p>
                             </div>
-                            <h1 className="text-3xl font-light text-gray-900 dark:text-gray-100">
-                                {goal.title}
-                            </h1>
-                            {goal.why && (
-                                <p className="mt-2 text-sm text-gray-500 dark:text-gray-400 italic">
-                                    {goal.why}
-                                </p>
+
+                            <input
+                                autoFocus
+                                type="text"
+                                name="title"
+                                value={formData.title ?? ''}
+                                onChange={handleChange}
+                                className="w-full text-3xl font-light bg-transparent text-gray-900 dark:text-gray-100 border-b border-gray-300 dark:border-gray-600 focus:outline-none focus:border-blue-500 pb-1"
+                                placeholder={t('forms.goalTitlePlaceholder', 'Goal title')}
+                            />
+
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
+                                    {t('forms.goalWhy', 'Why')}
+                                </label>
+                                <textarea
+                                    name="why"
+                                    value={formData.why ?? ''}
+                                    onChange={handleChange}
+                                    rows={3}
+                                    className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 resize-none"
+                                    placeholder={t('forms.goalWhyPlaceholder', 'What will achieving this enable?')}
+                                />
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-3">
+                                <div>
+                                    <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
+                                        {t('forms.goalHorizon', 'Horizon')}
+                                    </label>
+                                    <select
+                                        name="horizon"
+                                        value={formData.horizon ?? 'season'}
+                                        onChange={handleChange}
+                                        className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                                    >
+                                        <option value="season">{t('goals.horizon.season', 'Season')}</option>
+                                        <option value="year">{t('goals.horizon.year', 'Year')}</option>
+                                    </select>
+                                </div>
+                                <div>
+                                    <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
+                                        {t('forms.goalStatus', 'Status')}
+                                    </label>
+                                    <select
+                                        name="status"
+                                        value={formData.status ?? 'active'}
+                                        onChange={handleChange}
+                                        className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                                    >
+                                        <option value="active">{t('goals.status.active', 'Active')}</option>
+                                        <option value="achieved">{t('goals.status.achieved', 'Achieved')}</option>
+                                        <option value="paused">{t('goals.status.paused', 'Paused')}</option>
+                                        <option value="dropped">{t('goals.status.dropped', 'Dropped')}</option>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
+                                    {t('forms.goalTargetDate', 'Target Date')}
+                                </label>
+                                <input
+                                    type="date"
+                                    name="target_date"
+                                    value={formData.target_date ?? ''}
+                                    onChange={handleChange}
+                                    className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                                />
+                            </div>
+
+                            <div>
+                                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
+                                    {t('forms.goalArea', 'Area')} ({t('common.optional', 'optional')})
+                                </label>
+                                <select
+                                    name="area_id"
+                                    value={formData.area_id ?? ''}
+                                    onChange={handleChange}
+                                    className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                                >
+                                    <option value="">{t('forms.noArea', 'No area')}</option>
+                                    {areas.map((area: any) => (
+                                        <option key={area.id} value={area.id}>
+                                            {area.name}
+                                        </option>
+                                    ))}
+                                </select>
+                            </div>
+
+                            {formError && (
+                                <div className="text-red-500 text-sm">{formError}</div>
                             )}
-                            <div className="mt-3 flex flex-wrap items-center gap-2">
-                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[goal.status] ?? ''}`}>
-                                    {t(`goals.status.${goal.status}`, goal.status)}
-                                </span>
-                                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-                                    {t(`goals.horizon.${goal.horizon}`, goal.horizon)}
-                                </span>
-                                {goal.target_date && (
-                                    <span className="text-xs text-gray-400 dark:text-gray-500">
-                                        {t('goals.targetDate', 'Target')}: {new Date(goal.target_date).toLocaleDateString()}
-                                    </span>
+
+                            <div className="flex items-center gap-3 pt-2">
+                                <button
+                                    onClick={handleSubmit}
+                                    disabled={isSubmitting}
+                                    className={`px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 text-sm ${isSubmitting ? 'opacity-50 cursor-not-allowed' : ''}`}
+                                >
+                                    {isSubmitting
+                                        ? t('modals.submitting', 'Saving...')
+                                        : isNew
+                                            ? t('modals.createGoal', 'Create Goal')
+                                            : t('modals.updateGoal', 'Update Goal')}
+                                </button>
+                                <button
+                                    onClick={handleCancelEdit}
+                                    className="flex items-center gap-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+                                >
+                                    <XMarkIcon className="h-4 w-4" />
+                                    {t('common.cancel', 'Cancel')}
+                                </button>
+                            </div>
+                        </div>
+                    ) : (
+                        /* View mode */
+                        <div className="flex items-start justify-between gap-4">
+                            <div className="min-w-0 flex-1">
+                                {/* Breadcrumb: Area → Goal */}
+                                <div className="flex items-center gap-1.5 mb-3">
+                                    {goal!.Area ? (
+                                        <>
+                                            <Link
+                                                to={`/area/${goal!.Area.uid}-${goal!.Area.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`}
+                                                className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium transition-opacity hover:opacity-80 ${
+                                                    hasColor ? 'bg-white/20 text-white' : ''
+                                                }`}
+                                                style={!hasColor && goal!.Area.color ? { backgroundColor: goal!.Area.color + '33', color: goal!.Area.color } : {}}
+                                            >
+                                                {!hasColor && !goal!.Area.color && (
+                                                    <span className="w-2 h-2 rounded-full bg-gray-400 dark:bg-gray-500" />
+                                                )}
+                                                {goal!.Area.name}
+                                            </Link>
+                                            <span className={`text-xs ${hasColor ? 'text-white/40' : 'text-gray-300 dark:text-gray-600'}`}>/</span>
+                                        </>
+                                    ) : null}
+                                    <div className="flex items-center gap-1.5">
+                                        <FlagIcon className={`h-3.5 w-3.5 ${hasColor ? 'text-white/70' : 'text-blue-500'}`} />
+                                        <p className={`text-xs font-medium uppercase tracking-widest ${hasColor ? 'text-white/60' : 'text-gray-400 dark:text-gray-500'}`}>
+                                            {t('goals.singular', 'Goal')}
+                                        </p>
+                                    </div>
+                                </div>
+
+                                <h1 className={`text-3xl font-light ${hasColor ? 'text-white' : 'text-gray-900 dark:text-gray-100'}`}>
+                                    {goal!.title}
+                                </h1>
+                                {goal!.why && (
+                                    <p className={`mt-2 text-sm italic ${hasColor ? 'text-white/80' : 'text-gray-500 dark:text-gray-400'}`}>
+                                        {goal!.why}
+                                    </p>
+                                )}
+                                <div className={`mt-3 flex gap-4 text-xs ${hasColor ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'}`}>
+                                    <span>{t(`goals.status.${goal!.status}`, goal!.status)}</span>
+                                    <span>{t(`goals.horizon.${goal!.horizon}`, goal!.horizon)}</span>
+                                    {goal!.target_date && (
+                                        <span>{t('goals.targetDate', 'Target')}: {new Date(goal!.target_date).toLocaleDateString()}</span>
+                                    )}
+                                </div>
+                                <div className={`mt-3 flex gap-4 text-xs ${hasColor ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'}`}>
+                                    <span>{tasks.length} {t('tasks.title', 'tasks')}</span>
+                                    <span>{goalProjects.length} {t('projects.title', 'projects')}</span>
+                                </div>
+                            </div>
+                            <div className="flex items-center gap-1 flex-shrink-0">
+                                <button
+                                    onClick={() => setIsEditing(true)}
+                                    className={`p-2 rounded-lg transition-colors ${
+                                        hasColor
+                                            ? 'text-white/80 hover:text-white hover:bg-white/10'
+                                            : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
+                                    }`}
+                                    title={t('common.edit', 'Edit')}
+                                >
+                                    <PencilSquareIcon className="h-5 w-5" />
+                                </button>
+                                <button
+                                    onClick={() => setIsConfirmDeleteOpen(true)}
+                                    className={`p-2 rounded-lg transition-colors ${
+                                        hasColor
+                                            ? 'text-white/80 hover:text-white hover:bg-white/10'
+                                            : 'text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-800'
+                                    }`}
+                                    title={t('common.delete', 'Delete')}
+                                >
+                                    <TrashIcon className="h-5 w-5" />
+                                </button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {/* Projects + Tasks sections (only in view mode) */}
+            {!isNew && !isEditing && goal && (
+                <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+                    {/* Projects section */}
+                    <div>
+                        <h3 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4">
+                            {t('projects.title', 'Projects')} ({goalProjects.length})
+                        </h3>
+                        {goalProjects.length === 0 ? (
+                            <p className="text-sm text-gray-400 dark:text-gray-500">
+                                {t('goals.noProjects', 'No projects linked to this goal.')}
+                            </p>
+                        ) : (
+                            <div className="flex flex-col gap-2">
+                                {goalProjects.map((project) => (
+                                    <Link
+                                        key={project.uid ?? project.id}
+                                        to={project.uid ? createProjectUrl({ uid: project.uid, name: project.name }) : '/projects'}
+                                        className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 hover:bg-white dark:hover:bg-gray-800 transition-colors group border-l-4"
+                                        style={{ borderLeftColor: (project as any).color || '#6366f1' }}
+                                    >
+                                        <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate flex-1 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
+                                            {project.name}
+                                        </span>
+                                        {project.status && (
+                                            <span className="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0">
+                                                {project.status.replace('_', ' ')}
+                                            </span>
+                                        )}
+                                    </Link>
+                                ))}
+                            </div>
+                        )}
+                    </div>
+
+                    {/* Tasks section */}
+                    <div className="lg:col-span-2">
+                        <h3 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4">
+                            {t('tasks.title', 'Tasks')} ({tasks.length})
+                        </h3>
+                        {tasks.length === 0 ? (
+                            <p className="text-sm text-gray-400 dark:text-gray-500">
+                                {t('goals.noTasks', 'No tasks assigned to this goal.')}
+                            </p>
+                        ) : (
+                            <div className="space-y-6">
+                                {activeTasks.length > 0 && (
+                                    <TaskList
+                                        tasks={activeTasks}
+                                        projects={projects}
+                                        onTaskUpdate={handleTaskUpdate}
+                                        onTaskDelete={handleTaskDelete}
+                                    />
+                                )}
+                                {completedTasks.length > 0 && (
+                                    <div>
+                                        <h4 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">
+                                            {t('tasks.completed', 'Completed')} ({completedTasks.length})
+                                        </h4>
+                                        <TaskList
+                                            tasks={completedTasks}
+                                            projects={projects}
+                                            onTaskUpdate={handleTaskUpdate}
+                                            onTaskDelete={handleTaskDelete}
+                                            showCompletedTasks={true}
+                                        />
+                                    </div>
                                 )}
                             </div>
-                            <div className="mt-3 flex gap-4 text-xs text-gray-500 dark:text-gray-400">
-                                <span>{tasks.length} {t('tasks.title', 'tasks')}</span>
-                                <span>{projects.length} {t('projects.title', 'projects')}</span>
-                            </div>
-                        </div>
-                        <div className="flex items-center gap-1 flex-shrink-0">
-                            <button
-                                onClick={() => setIsEditModalOpen(true)}
-                                className="p-2 rounded-lg text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-                                title={t('common.edit', 'Edit')}
-                            >
-                                <PencilSquareIcon className="h-5 w-5" />
-                            </button>
-                            <button
-                                onClick={() => setIsConfirmDeleteOpen(true)}
-                                className="p-2 rounded-lg text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-                                title={t('common.delete', 'Delete')}
-                            >
-                                <TrashIcon className="h-5 w-5" />
-                            </button>
-                        </div>
+                        )}
                     </div>
                 </div>
-            </div>
-
-            <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
-                {/* Projects section */}
-                <div>
-                    <h3 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4 flex items-center gap-2">
-                        <FolderIcon className="h-5 w-5" />
-                        {t('projects.title', 'Projects')} ({projects.length})
-                    </h3>
-                    {projects.length === 0 ? (
-                        <p className="text-sm text-gray-400 dark:text-gray-500">
-                            {t('goals.noProjects', 'No projects linked to this goal.')}
-                        </p>
-                    ) : (
-                        <div className="flex flex-col gap-2">
-                            {projects.map((project) => (
-                                <Link
-                                    key={project.uid ?? project.id}
-                                    to={project.uid ? createProjectUrl({ uid: project.uid, name: project.name }) : '/projects'}
-                                    className="flex items-center gap-3 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
-                                >
-                                    <span
-                                        className="w-1 h-8 rounded-full flex-shrink-0"
-                                        style={{ backgroundColor: (project as any).color ?? '#6366f1' }}
-                                    />
-                                    <span className="text-sm text-gray-800 dark:text-gray-200 truncate">
-                                        {project.name}
-                                    </span>
-                                    {project.status && (
-                                        <span className="ml-auto text-xs text-gray-400 dark:text-gray-500 flex-shrink-0">
-                                            {project.status}
-                                        </span>
-                                    )}
-                                </Link>
-                            ))}
-                        </div>
-                    )}
-                </div>
-
-                {/* Tasks section */}
-                <div className="lg:col-span-2">
-                    <h3 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4 flex items-center gap-2">
-                        <CheckCircleIcon className="h-5 w-5" />
-                        {t('tasks.title', 'Tasks')} ({tasks.length})
-                    </h3>
-                    {tasks.length === 0 ? (
-                        <p className="text-sm text-gray-400 dark:text-gray-500">
-                            {t('goals.noTasks', 'No tasks assigned to this goal.')}
-                        </p>
-                    ) : (
-                        <div className="flex flex-col gap-1">
-                            {activeTasks.map((task) => (
-                                <TaskRow key={task.uid ?? task.id} task={task} />
-                            ))}
-                            {completedTasks.length > 0 && (
-                                <>
-                                    <div className="mt-4 mb-2 text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wider">
-                                        {t('tasks.completed', 'Completed')} ({completedTasks.length})
-                                    </div>
-                                    {completedTasks.map((task) => (
-                                        <TaskRow key={task.uid ?? task.id} task={task} done />
-                                    ))}
-                                </>
-                            )}
-                        </div>
-                    )}
-                </div>
-            </div>
-
-            {isEditModalOpen && (
-                <GoalModal
-                    isOpen={isEditModalOpen}
-                    onClose={() => setIsEditModalOpen(false)}
-                    onSave={handleSaveGoal}
-                    goal={goal}
-                />
             )}
 
             {isConfirmDeleteOpen && (
                 <ConfirmDialog
                     title={t('modals.deleteGoal.title', 'Delete Goal')}
-                    message={`${t('modals.deleteGoal.message', 'Are you sure you want to delete')} "${goal.title}"?`}
+                    message={`${t('modals.deleteGoal.message', 'Are you sure you want to delete')} "${goal?.title}"?`}
                     onConfirm={handleDeleteGoal}
                     onCancel={() => setIsConfirmDeleteOpen(false)}
                 />
@@ -238,22 +490,5 @@ const GoalDetails: React.FC = () => {
         </div>
     );
 };
-
-const TaskRow: React.FC<{ task: Task; done?: boolean }> = ({
-    task,
-    done = false,
-}) => (
-    <div className={`flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${done ? 'opacity-50' : ''}`}>
-        <CheckCircleIcon className={`h-4 w-4 flex-shrink-0 ${done ? 'text-green-500' : 'text-gray-300 dark:text-gray-600'}`} />
-        <span className={`text-sm flex-1 ${done ? 'line-through text-gray-400 dark:text-gray-500' : 'text-gray-800 dark:text-gray-200'}`}>
-            {task.name}
-        </span>
-        {task.due_date && !done && (
-            <span className="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0">
-                {new Date(task.due_date).toLocaleDateString()}
-            </span>
-        )}
-    </div>
-);
 
 export default GoalDetails;

--- a/frontend/components/Goal/GoalDetails.tsx
+++ b/frontend/components/Goal/GoalDetails.tsx
@@ -1,0 +1,268 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+    PencilSquareIcon,
+    TrashIcon,
+    FlagIcon,
+    FolderIcon,
+    CheckCircleIcon,
+} from '@heroicons/react/24/outline';
+import { Goal } from '../../entities/Goal';
+import { Task } from '../../entities/Task';
+import { Project } from '../../entities/Project';
+import { fetchGoalByUid, updateGoal, deleteGoal } from '../../utils/goalsService';
+import { extractUidFromSlug, createProjectUrl } from '../../utils/slugUtils';
+import ConfirmDialog from '../Shared/ConfirmDialog';
+import GoalModal from './GoalModal';
+import { useStore } from '../../store/useStore';
+import { useToast } from '../Shared/ToastContext';
+
+const STATUS_COLORS: Record<string, string> = {
+    active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+    achieved: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+    paused: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+    dropped: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+};
+
+const TASK_STATUS_DONE = [2, 3, 'done', 'archived'];
+
+const GoalDetails: React.FC = () => {
+    const { t } = useTranslation();
+    const { uidSlug } = useParams<{ uidSlug: string }>();
+    const navigate = useNavigate();
+    const { showSuccessToast, showErrorToast } = useToast();
+
+    const [goal, setGoal] = useState<Goal | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+    const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+    const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
+
+    const loadGoals = useStore((state: any) => state.goalsStore.loadGoals);
+
+    useEffect(() => {
+        const uid = extractUidFromSlug(uidSlug ?? '');
+        if (!uid) { setError(t('goals.notFound', 'Goal not found')); setLoading(false); return; }
+
+        fetchGoalByUid(uid)
+            .then((data) => setGoal(data))
+            .catch(() => setError(t('goals.notFound', 'Goal not found')))
+            .finally(() => setLoading(false));
+    }, [uidSlug, t]);
+
+    const handleSaveGoal = async (data: Partial<Goal>) => {
+        if (!goal?.uid) return;
+        const result = await updateGoal(goal.uid, data);
+        setGoal((prev) => prev ? { ...prev, ...result.goal } : result.goal);
+        loadGoals(true);
+        showSuccessToast(t('success.goalUpdated', 'Goal updated!'));
+        setIsEditModalOpen(false);
+    };
+
+    const handleDeleteGoal = async () => {
+        if (!goal?.uid) return;
+        try {
+            await deleteGoal(goal.uid);
+            loadGoals(true);
+            showSuccessToast(t('success.goalDeleted', 'Goal deleted!'));
+            navigate('/goals');
+        } catch {
+            showErrorToast(t('errors.failedToDeleteGoal', 'Failed to delete goal.'));
+        }
+        setIsConfirmDeleteOpen(false);
+    };
+
+    if (loading) {
+        return (
+            <div className="flex items-center justify-center h-screen">
+                <div className="text-xl font-semibold text-gray-700 dark:text-gray-200">
+                    {t('common.loading', 'Loading...')}
+                </div>
+            </div>
+        );
+    }
+
+    if (error || !goal) {
+        return <div className="text-red-500 p-4">{error ?? t('goals.notFound', 'Goal not found')}</div>;
+    }
+
+    const tasks: Task[] = (goal.Tasks ?? []) as Task[];
+    const projects: Project[] = (goal.Projects ?? []) as Project[];
+    const activeTasks = tasks.filter((t) => !TASK_STATUS_DONE.includes(t.status as any));
+    const completedTasks = tasks.filter((t) => TASK_STATUS_DONE.includes(t.status as any));
+
+    return (
+        <div className="w-full px-2 sm:px-4 lg:px-6 pt-4 pb-8">
+            {/* Header banner */}
+            <div className="bg-gray-50 dark:bg-gray-900 rounded-xl mb-8 overflow-hidden">
+                <div className="p-6">
+                    <div className="flex items-start justify-between gap-4">
+                        <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2 mb-1">
+                                <FlagIcon className="h-4 w-4 text-blue-500" />
+                                <p className="text-xs font-medium uppercase tracking-widest text-gray-400 dark:text-gray-500">
+                                    {t('goals.singular', 'Goal')}
+                                </p>
+                            </div>
+                            <h1 className="text-3xl font-light text-gray-900 dark:text-gray-100">
+                                {goal.title}
+                            </h1>
+                            {goal.why && (
+                                <p className="mt-2 text-sm text-gray-500 dark:text-gray-400 italic">
+                                    {goal.why}
+                                </p>
+                            )}
+                            <div className="mt-3 flex flex-wrap items-center gap-2">
+                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[goal.status] ?? ''}`}>
+                                    {t(`goals.status.${goal.status}`, goal.status)}
+                                </span>
+                                <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                                    {t(`goals.horizon.${goal.horizon}`, goal.horizon)}
+                                </span>
+                                {goal.target_date && (
+                                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                                        {t('goals.targetDate', 'Target')}: {new Date(goal.target_date).toLocaleDateString()}
+                                    </span>
+                                )}
+                                {goal.Area && (
+                                    <Link
+                                        to={`/area/${goal.Area.uid}-${(goal.Area.name ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`}
+                                        className="text-xs text-blue-500 hover:text-blue-600 dark:text-blue-400"
+                                        onClick={(e) => e.stopPropagation()}
+                                    >
+                                        {goal.Area.name}
+                                    </Link>
+                                )}
+                            </div>
+                            <div className="mt-3 flex gap-4 text-xs text-gray-500 dark:text-gray-400">
+                                <span>{tasks.length} {t('tasks.title', 'tasks')}</span>
+                                <span>{projects.length} {t('projects.title', 'projects')}</span>
+                            </div>
+                        </div>
+                        <div className="flex items-center gap-1 flex-shrink-0">
+                            <button
+                                onClick={() => setIsEditModalOpen(true)}
+                                className="p-2 rounded-lg text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                                title={t('common.edit', 'Edit')}
+                            >
+                                <PencilSquareIcon className="h-5 w-5" />
+                            </button>
+                            <button
+                                onClick={() => setIsConfirmDeleteOpen(true)}
+                                className="p-2 rounded-lg text-gray-500 hover:text-red-600 dark:text-gray-400 dark:hover:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                                title={t('common.delete', 'Delete')}
+                            >
+                                <TrashIcon className="h-5 w-5" />
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+                {/* Projects section */}
+                <div>
+                    <h3 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4 flex items-center gap-2">
+                        <FolderIcon className="h-5 w-5" />
+                        {t('projects.title', 'Projects')} ({projects.length})
+                    </h3>
+                    {projects.length === 0 ? (
+                        <p className="text-sm text-gray-400 dark:text-gray-500">
+                            {t('goals.noProjects', 'No projects linked to this goal.')}
+                        </p>
+                    ) : (
+                        <div className="flex flex-col gap-2">
+                            {projects.map((project) => (
+                                <Link
+                                    key={project.uid ?? project.id}
+                                    to={project.uid ? createProjectUrl({ uid: project.uid, name: project.name }) : '/projects'}
+                                    className="flex items-center gap-3 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                                >
+                                    <span
+                                        className="w-1 h-8 rounded-full flex-shrink-0"
+                                        style={{ backgroundColor: (project as any).color ?? '#6366f1' }}
+                                    />
+                                    <span className="text-sm text-gray-800 dark:text-gray-200 truncate">
+                                        {project.name}
+                                    </span>
+                                    {project.status && (
+                                        <span className="ml-auto text-xs text-gray-400 dark:text-gray-500 flex-shrink-0">
+                                            {project.status}
+                                        </span>
+                                    )}
+                                </Link>
+                            ))}
+                        </div>
+                    )}
+                </div>
+
+                {/* Tasks section */}
+                <div className="lg:col-span-2">
+                    <h3 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4 flex items-center gap-2">
+                        <CheckCircleIcon className="h-5 w-5" />
+                        {t('tasks.title', 'Tasks')} ({tasks.length})
+                    </h3>
+                    {tasks.length === 0 ? (
+                        <p className="text-sm text-gray-400 dark:text-gray-500">
+                            {t('goals.noTasks', 'No tasks assigned to this goal.')}
+                        </p>
+                    ) : (
+                        <div className="flex flex-col gap-1">
+                            {activeTasks.map((task) => (
+                                <TaskRow key={task.uid ?? task.id} task={task} />
+                            ))}
+                            {completedTasks.length > 0 && (
+                                <>
+                                    <div className="mt-4 mb-2 text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wider">
+                                        {t('tasks.completed', 'Completed')} ({completedTasks.length})
+                                    </div>
+                                    {completedTasks.map((task) => (
+                                        <TaskRow key={task.uid ?? task.id} task={task} done />
+                                    ))}
+                                </>
+                            )}
+                        </div>
+                    )}
+                </div>
+            </div>
+
+            {isEditModalOpen && (
+                <GoalModal
+                    isOpen={isEditModalOpen}
+                    onClose={() => setIsEditModalOpen(false)}
+                    onSave={handleSaveGoal}
+                    goal={goal}
+                />
+            )}
+
+            {isConfirmDeleteOpen && (
+                <ConfirmDialog
+                    title={t('modals.deleteGoal.title', 'Delete Goal')}
+                    message={`${t('modals.deleteGoal.message', 'Are you sure you want to delete')} "${goal.title}"?`}
+                    onConfirm={handleDeleteGoal}
+                    onCancel={() => setIsConfirmDeleteOpen(false)}
+                />
+            )}
+        </div>
+    );
+};
+
+const TaskRow: React.FC<{ task: Task; done?: boolean }> = ({
+    task,
+    done = false,
+}) => (
+    <div className={`flex items-center gap-3 px-3 py-2 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors ${done ? 'opacity-50' : ''}`}>
+        <CheckCircleIcon className={`h-4 w-4 flex-shrink-0 ${done ? 'text-green-500' : 'text-gray-300 dark:text-gray-600'}`} />
+        <span className={`text-sm flex-1 ${done ? 'line-through text-gray-400 dark:text-gray-500' : 'text-gray-800 dark:text-gray-200'}`}>
+            {task.name}
+        </span>
+        {task.due_date && !done && (
+            <span className="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0">
+                {new Date(task.due_date).toLocaleDateString()}
+            </span>
+        )}
+    </div>
+);
+
+export default GoalDetails;

--- a/frontend/components/Goal/GoalDetails.tsx
+++ b/frontend/components/Goal/GoalDetails.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams, Link, useNavigate } from 'react-router-dom';
+import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
     PencilSquareIcon,
@@ -47,7 +47,7 @@ const GoalDetails: React.FC = () => {
 
         fetchGoalByUid(uid)
             .then((data) => setGoal(data))
-            .catch(() => setError(t('goals.notFound', 'Goal not found')))
+            .catch((err) => setError(err?.message || t('goals.notFound', 'Goal not found')))
             .finally(() => setLoading(false));
     }, [uidSlug, t]);
 
@@ -124,15 +124,6 @@ const GoalDetails: React.FC = () => {
                                     <span className="text-xs text-gray-400 dark:text-gray-500">
                                         {t('goals.targetDate', 'Target')}: {new Date(goal.target_date).toLocaleDateString()}
                                     </span>
-                                )}
-                                {goal.Area && (
-                                    <Link
-                                        to={`/area/${goal.Area.uid}-${(goal.Area.name ?? '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`}
-                                        className="text-xs text-blue-500 hover:text-blue-600 dark:text-blue-400"
-                                        onClick={(e) => e.stopPropagation()}
-                                    >
-                                        {goal.Area.name}
-                                    </Link>
                                 )}
                             </div>
                             <div className="mt-3 flex gap-4 text-xs text-gray-500 dark:text-gray-400">

--- a/frontend/components/Goal/GoalModal.tsx
+++ b/frontend/components/Goal/GoalModal.tsx
@@ -1,0 +1,358 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { TrashIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from 'react-i18next';
+import { Goal, GoalHorizon, GoalStatus } from '../../entities/Goal';
+import { useToast } from '../Shared/ToastContext';
+import DiscardChangesDialog from '../Shared/DiscardChangesDialog';
+import { useStore } from '../../store/useStore';
+
+interface GoalModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onSave: (data: Partial<Goal>) => Promise<void>;
+    onDelete?: (uid: string) => Promise<void>;
+    goal?: Goal | null;
+    defaultAreaId?: number | null;
+}
+
+const GoalModal: React.FC<GoalModalProps> = ({
+    isOpen,
+    onClose,
+    onSave,
+    onDelete,
+    goal,
+    defaultAreaId,
+}) => {
+    const { t } = useTranslation();
+    const { showSuccessToast, showErrorToast } = useToast();
+    const titleInputRef = useRef<HTMLInputElement>(null);
+    const modalRef = useRef<HTMLDivElement>(null);
+    const hasUnsavedChangesRef = useRef<() => boolean>(() => false);
+
+    const areas = useStore((state: any) => state.areasStore.areas);
+    const loadAreas = useStore((state: any) => state.areasStore.loadAreas);
+    const areasLoaded = useStore((state: any) => state.areasStore.hasLoaded);
+
+    const emptyForm = (): Partial<Goal> => ({
+        title: '',
+        why: '',
+        horizon: 'season' as GoalHorizon,
+        status: 'active' as GoalStatus,
+        target_date: '',
+        area_id: defaultAreaId ?? null,
+    });
+
+    const [formData, setFormData] = useState<Partial<Goal>>(emptyForm());
+    const [error, setError] = useState<string | null>(null);
+    const [isSubmitting, setIsSubmitting] = useState(false);
+    const [isClosing, setIsClosing] = useState(false);
+    const [showDiscardDialog, setShowDiscardDialog] = useState(false);
+
+    useEffect(() => {
+        if (!areasLoaded) loadAreas();
+    }, [areasLoaded, loadAreas]);
+
+    useEffect(() => {
+        if (isOpen) {
+            setFormData(
+                goal
+                    ? {
+                          title: goal.title,
+                          why: goal.why ?? '',
+                          horizon: goal.horizon,
+                          status: goal.status,
+                          target_date: goal.target_date ?? '',
+                          area_id: goal.area_id ?? null,
+                      }
+                    : emptyForm()
+            );
+            setError(null);
+            setTimeout(() => titleInputRef.current?.focus(), 100);
+        }
+    }, [isOpen, goal]);
+
+    useEffect(() => {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (showDiscardDialog) return;
+            if (modalRef.current && !modalRef.current.contains(e.target as Node)) {
+                handleClose();
+            }
+        };
+        if (isOpen) document.addEventListener('mousedown', handleClickOutside);
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [isOpen, showDiscardDialog]);
+
+    useEffect(() => {
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') {
+                if (showDiscardDialog) return;
+                e.preventDefault();
+                if (hasUnsavedChangesRef.current()) {
+                    setShowDiscardDialog(true);
+                } else {
+                    handleClose();
+                }
+            }
+        };
+        if (isOpen) document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [isOpen, showDiscardDialog]);
+
+    const hasUnsavedChanges = () => {
+        if (!goal) return (formData.title?.trim() ?? '') !== '';
+        return (
+            formData.title !== goal.title ||
+            formData.why !== (goal.why ?? '') ||
+            formData.horizon !== goal.horizon ||
+            formData.status !== goal.status ||
+            formData.target_date !== (goal.target_date ?? '') ||
+            formData.area_id !== (goal.area_id ?? null)
+        );
+    };
+
+    useEffect(() => {
+        hasUnsavedChangesRef.current = hasUnsavedChanges;
+    });
+
+    const handleClose = () => {
+        setIsClosing(true);
+        setTimeout(() => {
+            onClose();
+            setIsClosing(false);
+            setShowDiscardDialog(false);
+        }, 300);
+    };
+
+    const handleChange = (
+        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+    ) => {
+        const { name, value } = e.target;
+        setFormData((prev) => ({
+            ...prev,
+            [name]: name === 'area_id' ? (value ? parseInt(value) : null) : value,
+        }));
+    };
+
+    const handleSubmit = async (e?: React.FormEvent) => {
+        if (e) e.preventDefault();
+        if (!formData.title?.trim()) {
+            setError(t('errors.goalTitleRequired', 'Goal title is required'));
+            return;
+        }
+        setIsSubmitting(true);
+        setError(null);
+        try {
+            await onSave({
+                ...formData,
+                target_date: formData.target_date || null,
+                area_id: formData.area_id || null,
+            });
+            showSuccessToast(
+                goal
+                    ? t('success.goalUpdated', 'Goal updated!')
+                    : t('success.goalCreated', 'Goal created!')
+            );
+            handleClose();
+        } catch (err) {
+            setError((err as Error).message);
+            showErrorToast(t('errors.failedToSaveGoal', 'Failed to save goal.'));
+        } finally {
+            setIsSubmitting(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        if (!goal?.uid || !onDelete) return;
+        try {
+            await onDelete(goal.uid);
+            showSuccessToast(t('success.goalDeleted', 'Goal deleted!'));
+            handleClose();
+        } catch {
+            showErrorToast(t('errors.failedToDeleteGoal', 'Failed to delete goal.'));
+        }
+    };
+
+    if (!isOpen) return null;
+
+    return (
+        <>
+            <div
+                className={`fixed top-16 left-0 right-0 bottom-0 bg-gray-900 bg-opacity-80 z-40 transition-opacity duration-300 overflow-hidden sm:overflow-y-auto ${
+                    isClosing ? 'opacity-0' : 'opacity-100'
+                }`}
+            >
+                <div className="h-full flex items-center justify-center sm:px-4 sm:py-4">
+                    <div
+                        ref={modalRef}
+                        className={`bg-white dark:bg-gray-800 border-0 sm:border sm:border-gray-200 sm:dark:border-gray-700 sm:rounded-lg sm:shadow-2xl w-full sm:max-w-md transform transition-transform duration-300 ${
+                            isClosing ? 'scale-95' : 'scale-100'
+                        } h-full sm:h-auto sm:my-4`}
+                    >
+                        <div className="flex flex-col h-full sm:min-h-[400px] sm:max-h-[90vh]">
+                            <div className="flex-1 flex flex-col bg-white dark:bg-gray-800 sm:rounded-lg">
+                                <div className="flex-1 relative">
+                                    <div
+                                        className="absolute inset-0 overflow-y-auto overflow-x-hidden"
+                                        style={{ WebkitOverflowScrolling: 'touch' }}
+                                    >
+                                        <form className="h-full" onSubmit={handleSubmit}>
+                                            <fieldset className="h-full flex flex-col">
+                                                {/* Title */}
+                                                <div className="border-b border-gray-200 dark:border-gray-700 pb-4 mb-4 px-4 pt-4 sm:rounded-t-lg">
+                                                    <input
+                                                        ref={titleInputRef}
+                                                        type="text"
+                                                        name="title"
+                                                        value={formData.title ?? ''}
+                                                        onChange={handleChange}
+                                                        required
+                                                        className="block w-full text-xl font-semibold bg-transparent text-black dark:text-white border-none focus:outline-none shadow-sm py-2"
+                                                        placeholder={t('forms.goalTitlePlaceholder', 'Goal title')}
+                                                    />
+                                                </div>
+
+                                                <div className="flex flex-col gap-4 px-4 pb-4">
+                                                    {/* Why */}
+                                                    <div>
+                                                        <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
+                                                            {t('forms.goalWhy', 'Why')}
+                                                        </label>
+                                                        <textarea
+                                                            name="why"
+                                                            value={formData.why ?? ''}
+                                                            onChange={handleChange}
+                                                            rows={3}
+                                                            className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 resize-none"
+                                                            placeholder={t('forms.goalWhyPlaceholder', 'What will achieving this enable?')}
+                                                        />
+                                                    </div>
+
+                                                    {/* Horizon + Status row */}
+                                                    <div className="grid grid-cols-2 gap-3">
+                                                        <div>
+                                                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
+                                                                {t('forms.goalHorizon', 'Horizon')}
+                                                            </label>
+                                                            <select
+                                                                name="horizon"
+                                                                value={formData.horizon ?? 'season'}
+                                                                onChange={handleChange}
+                                                                className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                                                            >
+                                                                <option value="season">{t('goals.horizon.season', 'Season')}</option>
+                                                                <option value="year">{t('goals.horizon.year', 'Year')}</option>
+                                                            </select>
+                                                        </div>
+                                                        <div>
+                                                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
+                                                                {t('forms.goalStatus', 'Status')}
+                                                            </label>
+                                                            <select
+                                                                name="status"
+                                                                value={formData.status ?? 'active'}
+                                                                onChange={handleChange}
+                                                                className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                                                            >
+                                                                <option value="active">{t('goals.status.active', 'Active')}</option>
+                                                                <option value="achieved">{t('goals.status.achieved', 'Achieved')}</option>
+                                                                <option value="paused">{t('goals.status.paused', 'Paused')}</option>
+                                                                <option value="dropped">{t('goals.status.dropped', 'Dropped')}</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+
+                                                    {/* Target date */}
+                                                    <div>
+                                                        <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
+                                                            {t('forms.goalTargetDate', 'Target Date')}
+                                                        </label>
+                                                        <input
+                                                            type="date"
+                                                            name="target_date"
+                                                            value={formData.target_date ?? ''}
+                                                            onChange={handleChange}
+                                                            className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                                                        />
+                                                    </div>
+
+                                                    {/* Area (optional) */}
+                                                    <div>
+                                                        <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
+                                                            {t('forms.goalArea', 'Area')} ({t('common.optional', 'optional')})
+                                                        </label>
+                                                        <select
+                                                            name="area_id"
+                                                            value={formData.area_id ?? ''}
+                                                            onChange={handleChange}
+                                                            className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                                                        >
+                                                            <option value="">{t('forms.noArea', 'No area')}</option>
+                                                            {areas.map((area: any) => (
+                                                                <option key={area.id} value={area.id}>
+                                                                    {area.name}
+                                                                </option>
+                                                            ))}
+                                                        </select>
+                                                    </div>
+                                                </div>
+
+                                                {error && (
+                                                    <div className="text-red-500 px-4 mb-4 text-sm">{error}</div>
+                                                )}
+                                            </fieldset>
+                                        </form>
+                                    </div>
+                                </div>
+
+                                {/* Footer */}
+                                <div className="flex-shrink-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 px-3 py-2 flex items-center justify-between sm:rounded-b-lg">
+                                    <div className="flex items-center space-x-3">
+                                        {goal?.uid && onDelete && (
+                                            <button
+                                                type="button"
+                                                onClick={handleDelete}
+                                                className="p-2 border border-red-300 dark:border-red-600 text-red-600 dark:text-red-400 rounded-md hover:bg-red-50 dark:hover:bg-red-900/20 focus:outline-none transition duration-150"
+                                                title={t('common.delete', 'Delete')}
+                                            >
+                                                <TrashIcon className="h-4 w-4" />
+                                            </button>
+                                        )}
+                                        <button
+                                            type="button"
+                                            onClick={handleClose}
+                                            className="text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 focus:outline-none text-sm"
+                                        >
+                                            {t('common.cancel')}
+                                        </button>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        onClick={() => handleSubmit()}
+                                        disabled={isSubmitting}
+                                        className={`px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600 focus:outline-none text-sm ${
+                                            isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
+                                        }`}
+                                    >
+                                        {isSubmitting
+                                            ? t('modals.submitting')
+                                            : goal?.uid
+                                              ? t('modals.updateGoal', 'Update Goal')
+                                              : t('modals.createGoal', 'Create Goal')}
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            {showDiscardDialog && (
+                <DiscardChangesDialog
+                    onDiscard={() => { setShowDiscardDialog(false); handleClose(); }}
+                    onCancel={() => setShowDiscardDialog(false)}
+                />
+            )}
+        </>
+    );
+};
+
+export default GoalModal;

--- a/frontend/components/Goal/GoalModal.tsx
+++ b/frontend/components/Goal/GoalModal.tsx
@@ -2,9 +2,9 @@ import React, { useState, useEffect, useRef } from 'react';
 import { TrashIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import { Goal, GoalHorizon, GoalStatus } from '../../entities/Goal';
+import { Area } from '../../entities/Area';
 import { useToast } from '../Shared/ToastContext';
 import DiscardChangesDialog from '../Shared/DiscardChangesDialog';
-import { useStore } from '../../store/useStore';
 
 interface GoalModalProps {
     isOpen: boolean;
@@ -12,6 +12,7 @@ interface GoalModalProps {
     onSave: (data: Partial<Goal>) => Promise<void>;
     onDelete?: (uid: string) => Promise<void>;
     goal?: Goal | null;
+    areas?: Area[];
     defaultAreaId?: number | null;
 }
 
@@ -21,6 +22,7 @@ const GoalModal: React.FC<GoalModalProps> = ({
     onSave,
     onDelete,
     goal,
+    areas = [],
     defaultAreaId,
 }) => {
     const { t } = useTranslation();
@@ -29,11 +31,7 @@ const GoalModal: React.FC<GoalModalProps> = ({
     const modalRef = useRef<HTMLDivElement>(null);
     const hasUnsavedChangesRef = useRef<() => boolean>(() => false);
 
-    const areas = useStore((state: any) => state.areasStore.areas);
-    const loadAreas = useStore((state: any) => state.areasStore.loadAreas);
-    const areasLoaded = useStore((state: any) => state.areasStore.hasLoaded);
-
-    const emptyForm = (): Partial<Goal> => ({
+    const getDefaultForm = (): Partial<Goal> => ({
         title: '',
         why: '',
         horizon: 'season' as GoalHorizon,
@@ -42,15 +40,11 @@ const GoalModal: React.FC<GoalModalProps> = ({
         area_id: defaultAreaId ?? null,
     });
 
-    const [formData, setFormData] = useState<Partial<Goal>>(emptyForm());
+    const [formData, setFormData] = useState<Partial<Goal>>(getDefaultForm());
     const [error, setError] = useState<string | null>(null);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [isClosing, setIsClosing] = useState(false);
     const [showDiscardDialog, setShowDiscardDialog] = useState(false);
-
-    useEffect(() => {
-        if (!areasLoaded) loadAreas();
-    }, [areasLoaded, loadAreas]);
 
     useEffect(() => {
         if (isOpen) {
@@ -64,7 +58,7 @@ const GoalModal: React.FC<GoalModalProps> = ({
                           target_date: goal.target_date ?? '',
                           area_id: goal.area_id ?? null,
                       }
-                    : emptyForm()
+                    : getDefaultForm()
             );
             setError(null);
             setTimeout(() => titleInputRef.current?.focus(), 100);
@@ -129,7 +123,7 @@ const GoalModal: React.FC<GoalModalProps> = ({
         const { name, value } = e.target;
         setFormData((prev) => ({
             ...prev,
-            [name]: name === 'area_id' ? (value ? parseInt(value) : null) : value,
+            [name]: name === 'area_id' ? (value ? parseInt(value, 10) : null) : value,
         }));
     };
 
@@ -275,25 +269,27 @@ const GoalModal: React.FC<GoalModalProps> = ({
                                                         />
                                                     </div>
 
-                                                    {/* Area (optional) */}
-                                                    <div>
-                                                        <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
-                                                            {t('forms.goalArea', 'Area')} ({t('common.optional', 'optional')})
-                                                        </label>
-                                                        <select
-                                                            name="area_id"
-                                                            value={formData.area_id ?? ''}
-                                                            onChange={handleChange}
-                                                            className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
-                                                        >
-                                                            <option value="">{t('forms.noArea', 'No area')}</option>
-                                                            {areas.map((area: any) => (
-                                                                <option key={area.id} value={area.id}>
-                                                                    {area.name}
-                                                                </option>
-                                                            ))}
-                                                        </select>
-                                                    </div>
+                                                    {/* Area (optional, only shown if areas list provided) */}
+                                                    {areas.length > 0 && (
+                                                        <div>
+                                                            <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
+                                                                {t('forms.goalArea', 'Area')} ({t('common.optional', 'optional')})
+                                                            </label>
+                                                            <select
+                                                                name="area_id"
+                                                                value={formData.area_id ?? ''}
+                                                                onChange={handleChange}
+                                                                className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+                                                            >
+                                                                <option value="">{t('forms.noArea', 'No area')}</option>
+                                                                {areas.map((area) => (
+                                                                    <option key={area.id} value={area.id}>
+                                                                        {area.name}
+                                                                    </option>
+                                                                ))}
+                                                            </select>
+                                                        </div>
+                                                    )}
                                                 </div>
 
                                                 {error && (

--- a/frontend/components/Goals.tsx
+++ b/frontend/components/Goals.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
     EllipsisVerticalIcon,
@@ -8,10 +8,10 @@ import {
     CheckCircleIcon,
 } from '@heroicons/react/24/outline';
 import ConfirmDialog from './Shared/ConfirmDialog';
-import GoalModal from './Goal/GoalModal';
 import { useStore } from '../store/useStore';
-import { createGoal, updateGoal, deleteGoal } from '../utils/goalsService';
+import { deleteGoal } from '../utils/goalsService';
 import { Goal } from '../entities/Goal';
+import { Area } from '../entities/Area';
 import { createGoalUrl } from '../utils/slugUtils';
 
 const STATUS_COLORS: Record<string, string> = {
@@ -23,6 +23,7 @@ const STATUS_COLORS: Record<string, string> = {
 
 const Goals: React.FC = () => {
     const { t } = useTranslation();
+    const navigate = useNavigate();
 
     const {
         goals,
@@ -31,8 +32,11 @@ const Goals: React.FC = () => {
         loadGoals,
     } = useStore((state: any) => state.goalsStore);
 
-    const [isGoalModalOpen, setIsGoalModalOpen] = useState(false);
-    const [selectedGoal, setSelectedGoal] = useState<Goal | null>(null);
+    const areas: Area[] = useStore((state: any) => state.areasStore.areas);
+    const areasLoaded = useStore((state: any) => state.areasStore.hasLoaded);
+    const loadAreas = useStore((state: any) => state.areasStore.loadAreas);
+
+    const [selectedAreaUid, setSelectedAreaUid] = useState<string | null>(null);
     const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
     const [goalToDelete, setGoalToDelete] = useState<Goal | null>(null);
     const [dropdownOpen, setDropdownOpen] = useState<string | null>(null);
@@ -42,6 +46,10 @@ const Goals: React.FC = () => {
     useEffect(() => {
         if (!hasLoaded && !loading) loadGoals();
     }, [hasLoaded, loading, loadGoals]);
+
+    useEffect(() => {
+        if (!areasLoaded) loadAreas();
+    }, [areasLoaded, loadAreas]);
 
     useEffect(() => {
         const handleClickOutside = (e: MouseEvent) => {
@@ -57,22 +65,6 @@ const Goals: React.FC = () => {
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, [dropdownOpen]);
 
-    const handleSaveGoal = async (data: Partial<Goal>) => {
-        if (selectedGoal?.uid) {
-            const result = await updateGoal(selectedGoal.uid, data);
-            const current = useStore.getState().goalsStore.goals;
-            useStore.getState().goalsStore.setGoals(
-                current.map((g: Goal) => (g.uid === result.goal.uid ? result.goal : g))
-            );
-        } else {
-            const result = await createGoal(data as any);
-            const current = useStore.getState().goalsStore.goals;
-            useStore.getState().goalsStore.setGoals([...current, result.goal]);
-        }
-        setIsGoalModalOpen(false);
-        setSelectedGoal(null);
-    };
-
     const handleDeleteGoal = async () => {
         if (!goalToDelete?.uid) return;
         await deleteGoal(goalToDelete.uid);
@@ -82,29 +74,81 @@ const Goals: React.FC = () => {
         setGoalToDelete(null);
     };
 
-    const openEdit = (goal: Goal) => { setSelectedGoal(goal); setIsGoalModalOpen(true); };
     const openConfirmDelete = (goal: Goal) => { setGoalToDelete(goal); setIsConfirmDialogOpen(true); };
+
+    // Derive areas that actually have goals
+    const areasWithGoals = areas.filter((a) =>
+        goals.some((g: Goal) => g.area_id === a.id || (g.Area && g.Area.uid === a.uid))
+    );
+
+    const filteredGoals = selectedAreaUid
+        ? goals.filter((g: Goal) => g.Area?.uid === selectedAreaUid)
+        : goals;
 
     return (
         <div className="w-full px-2 sm:px-4 lg:px-6 pt-4 pb-8">
             <div className="w-full">
-                <div className="flex items-center mb-8">
+                <div className="flex items-center mb-6">
                     <h2 className="text-2xl font-light">{t('goals.title', 'Goals')}</h2>
                 </div>
 
-                {goals.length === 0 ? (
-                    <p className="text-gray-700 dark:text-gray-300">
+                {/* Area filter tabs */}
+                {areasWithGoals.length > 0 && (
+                    <div className="flex flex-wrap gap-2 mb-6">
+                        <button
+                            onClick={() => setSelectedAreaUid(null)}
+                            className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                                selectedAreaUid === null
+                                    ? 'bg-gray-800 text-white dark:bg-gray-200 dark:text-gray-900'
+                                    : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+                            }`}
+                        >
+                            {t('common.all', 'All')}
+                        </button>
+                        {areasWithGoals.map((area) => (
+                            <button
+                                key={area.uid}
+                                onClick={() => setSelectedAreaUid(area.uid === selectedAreaUid ? null : area.uid!)}
+                                className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                                    selectedAreaUid === area.uid
+                                        ? 'text-white'
+                                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600'
+                                }`}
+                                style={
+                                    selectedAreaUid === area.uid && area.color
+                                        ? { backgroundColor: area.color }
+                                        : selectedAreaUid === area.uid
+                                        ? { backgroundColor: '#374151' }
+                                        : {}
+                                }
+                            >
+                                {area.name}
+                            </button>
+                        ))}
+                    </div>
+                )}
+
+                {filteredGoals.length === 0 ? (
+                    <p className="text-gray-500 dark:text-gray-400">
                         {t('goals.noGoalsFound', 'No goals yet.')}
                     </p>
                 ) : (
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
-                        {goals.map((goal: Goal) => {
+                        {filteredGoals.map((goal: Goal) => {
                             const goalUrl = goal.uid ? createGoalUrl({ uid: goal.uid, title: goal.title }) : '/goals';
+                            const areaColor = goal.Area?.color;
+                            const hasColor = !!areaColor;
+
                             return (
                                 <Link
                                     key={goal.uid}
                                     to={goalUrl}
-                                    className={`rounded-xl shadow-sm relative flex flex-col group hover:shadow-md transition-shadow cursor-pointer bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 ${dropdownOpen === goal.uid ? 'z-50' : ''}`}
+                                    className={`rounded-xl shadow-sm relative flex flex-col group hover:shadow-md transition-shadow cursor-pointer ${
+                                        !hasColor
+                                            ? 'bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600'
+                                            : ''
+                                    } ${dropdownOpen === goal.uid ? 'z-50' : ''}`}
+                                    style={hasColor ? { backgroundColor: areaColor } : {}}
                                 >
                                     {/* Three-dot menu */}
                                     <div className="absolute top-2 right-2 z-10" ref={dropdownRef}>
@@ -116,14 +160,23 @@ const Goals: React.FC = () => {
                                                 if (next) justOpenedRef.current = true;
                                                 setDropdownOpen(next);
                                             }}
-                                            className="focus:outline-none opacity-0 group-hover:opacity-100 transition-opacity duration-200 p-1 rounded text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600"
+                                            className={`focus:outline-none opacity-0 group-hover:opacity-100 transition-opacity duration-200 p-1 rounded ${
+                                                hasColor
+                                                    ? 'text-white/60 hover:text-white hover:bg-white/20'
+                                                    : 'text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600'
+                                            }`}
                                         >
                                             <EllipsisVerticalIcon className="h-4 w-4" />
                                         </button>
                                         {dropdownOpen === goal.uid && (
                                             <div className="absolute right-0 top-full mt-1 w-28 bg-white dark:bg-gray-700 shadow-lg rounded-md z-[60]">
                                                 <button
-                                                    onClick={(e) => { e.preventDefault(); e.stopPropagation(); openEdit(goal); setDropdownOpen(null); }}
+                                                    onClick={(e) => {
+                                                        e.preventDefault();
+                                                        e.stopPropagation();
+                                                        setDropdownOpen(null);
+                                                        navigate(goalUrl);
+                                                    }}
                                                     className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left rounded-t-md"
                                                 >
                                                     {t('common.edit', 'Edit')}
@@ -139,35 +192,53 @@ const Goals: React.FC = () => {
                                     </div>
 
                                     {/* Card content */}
-                                    <div className="px-5 pt-6 pb-4 flex-1 flex flex-col">
-                                        <div className="flex items-start gap-2 mb-2">
-                                            <FlagIcon className="h-5 w-5 text-blue-500 flex-shrink-0 mt-0.5" />
-                                            <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-100 line-clamp-2">
+                                    <div className="px-5 pt-6 pb-4 flex-1 flex items-center justify-center text-center">
+                                        <div>
+                                            <div className="flex items-center justify-center gap-2 mb-2">
+                                                <FlagIcon className={`h-4 w-4 flex-shrink-0 ${hasColor ? 'text-white/70' : 'text-blue-500'}`} />
+                                            </div>
+                                            <h3 className={`text-sm font-semibold tracking-wide line-clamp-2 ${
+                                                hasColor ? 'text-white' : 'text-gray-800 dark:text-gray-100'
+                                            }`}>
                                                 {goal.title}
                                             </h3>
+                                            {goal.why && (
+                                                <p className={`text-xs mt-2 line-clamp-2 leading-relaxed ${
+                                                    hasColor ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'
+                                                }`}>
+                                                    {goal.why}
+                                                </p>
+                                            )}
+                                            <div className="flex flex-wrap justify-center gap-1 mt-3">
+                                                <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                                                    hasColor
+                                                        ? 'bg-white/20 text-white'
+                                                        : STATUS_COLORS[goal.status] ?? ''
+                                                }`}>
+                                                    {t(`goals.status.${goal.status}`, goal.status)}
+                                                </span>
+                                                <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
+                                                    hasColor
+                                                        ? 'bg-white/15 text-white/80'
+                                                        : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+                                                }`}>
+                                                    {t(`goals.horizon.${goal.horizon}`, goal.horizon)}
+                                                </span>
+                                            </div>
+                                            {goal.Area && (
+                                                <p className={`text-xs mt-2 ${hasColor ? 'text-white/55' : 'text-gray-400 dark:text-gray-500'}`}>
+                                                    {goal.Area.name}
+                                                </p>
+                                            )}
                                         </div>
-                                        {goal.why && (
-                                            <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 mb-3">
-                                                {goal.why}
-                                            </p>
-                                        )}
-                                        <div className="flex flex-wrap gap-1 mt-auto">
-                                            <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${STATUS_COLORS[goal.status] ?? ''}`}>
-                                                {t(`goals.status.${goal.status}`, goal.status)}
-                                            </span>
-                                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
-                                                {t(`goals.horizon.${goal.horizon}`, goal.horizon)}
-                                            </span>
-                                        </div>
-                                        {goal.Area && (
-                                            <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
-                                                {goal.Area.name}
-                                            </p>
-                                        )}
                                     </div>
 
                                     {/* Stats footer */}
-                                    <div className="rounded-b-xl flex items-stretch divide-x bg-gray-50 dark:bg-gray-800 border-t border-gray-100 dark:border-gray-600 divide-gray-200 dark:divide-gray-600">
+                                    <div className={`rounded-b-xl flex items-stretch divide-x ${
+                                        hasColor
+                                            ? 'bg-black/20 divide-white/10'
+                                            : 'bg-gray-50 dark:bg-gray-800 border-t border-gray-100 dark:border-gray-600 divide-gray-200 dark:divide-gray-600'
+                                    }`}>
                                         {[
                                             {
                                                 icon: <FolderIcon className="h-3.5 w-3.5" />,
@@ -181,10 +252,14 @@ const Goals: React.FC = () => {
                                             },
                                         ].map(({ icon, count, label }) => (
                                             <div key={label} className="flex-1 flex flex-col items-center py-3 gap-1">
-                                                <span className="text-base font-semibold leading-none text-gray-700 dark:text-gray-200">
+                                                <span className={`text-base font-semibold leading-none ${
+                                                    hasColor ? 'text-white' : 'text-gray-700 dark:text-gray-200'
+                                                }`}>
                                                     {count}
                                                 </span>
-                                                <span className="flex items-center gap-1 text-[10px] leading-none text-gray-400 dark:text-gray-500">
+                                                <span className={`flex items-center gap-1 text-[10px] leading-none ${
+                                                    hasColor ? 'text-white/55' : 'text-gray-400 dark:text-gray-500'
+                                                }`}>
                                                     {icon}
                                                     {label}
                                                 </span>
@@ -197,16 +272,6 @@ const Goals: React.FC = () => {
                     </div>
                 )}
             </div>
-
-            {isGoalModalOpen && (
-                <GoalModal
-                    isOpen={isGoalModalOpen}
-                    onClose={() => { setIsGoalModalOpen(false); setSelectedGoal(null); }}
-                    onSave={handleSaveGoal}
-                    onDelete={async (uid) => { await deleteGoal(uid); loadGoals(true); setIsGoalModalOpen(false); setSelectedGoal(null); }}
-                    goal={selectedGoal}
-                />
-            )}
 
             {isConfirmDialogOpen && goalToDelete && (
                 <ConfirmDialog

--- a/frontend/components/Goals.tsx
+++ b/frontend/components/Goals.tsx
@@ -1,0 +1,223 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+    EllipsisVerticalIcon,
+    FlagIcon,
+    FolderIcon,
+    CheckCircleIcon,
+} from '@heroicons/react/24/outline';
+import ConfirmDialog from './Shared/ConfirmDialog';
+import GoalModal from './Goal/GoalModal';
+import { useStore } from '../store/useStore';
+import { createGoal, updateGoal, deleteGoal } from '../utils/goalsService';
+import { Goal } from '../entities/Goal';
+import { createGoalUrl } from '../utils/slugUtils';
+
+const STATUS_COLORS: Record<string, string> = {
+    active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+    achieved: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+    paused: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
+    dropped: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
+};
+
+const Goals: React.FC = () => {
+    const { t } = useTranslation();
+
+    const {
+        goals,
+        isLoading: loading,
+        hasLoaded,
+        loadGoals,
+    } = useStore((state: any) => state.goalsStore);
+
+    const [isGoalModalOpen, setIsGoalModalOpen] = useState(false);
+    const [selectedGoal, setSelectedGoal] = useState<Goal | null>(null);
+    const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
+    const [goalToDelete, setGoalToDelete] = useState<Goal | null>(null);
+    const [dropdownOpen, setDropdownOpen] = useState<string | null>(null);
+    const justOpenedRef = useRef(false);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
+    useEffect(() => {
+        if (!hasLoaded && !loading) loadGoals();
+    }, [hasLoaded, loading, loadGoals]);
+
+    useEffect(() => {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (justOpenedRef.current) { justOpenedRef.current = false; return; }
+            if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+                setDropdownOpen(null);
+            }
+        };
+        if (dropdownOpen !== null) {
+            const id = setTimeout(() => document.addEventListener('mousedown', handleClickOutside), 100);
+            return () => { clearTimeout(id); document.removeEventListener('mousedown', handleClickOutside); };
+        }
+        return () => document.removeEventListener('mousedown', handleClickOutside);
+    }, [dropdownOpen]);
+
+    const handleSaveGoal = async (data: Partial<Goal>) => {
+        if (selectedGoal?.uid) {
+            const result = await updateGoal(selectedGoal.uid, data);
+            const current = useStore.getState().goalsStore.goals;
+            useStore.getState().goalsStore.setGoals(
+                current.map((g: Goal) => (g.uid === result.goal.uid ? result.goal : g))
+            );
+        } else {
+            const result = await createGoal(data as any);
+            const current = useStore.getState().goalsStore.goals;
+            useStore.getState().goalsStore.setGoals([...current, result.goal]);
+        }
+        setIsGoalModalOpen(false);
+        setSelectedGoal(null);
+    };
+
+    const handleDeleteGoal = async () => {
+        if (!goalToDelete?.uid) return;
+        await deleteGoal(goalToDelete.uid);
+        const current = useStore.getState().goalsStore.goals;
+        useStore.getState().goalsStore.setGoals(current.filter((g: Goal) => g.uid !== goalToDelete.uid));
+        setIsConfirmDialogOpen(false);
+        setGoalToDelete(null);
+    };
+
+    const openEdit = (goal: Goal) => { setSelectedGoal(goal); setIsGoalModalOpen(true); };
+    const openConfirmDelete = (goal: Goal) => { setGoalToDelete(goal); setIsConfirmDialogOpen(true); };
+
+    return (
+        <div className="w-full px-2 sm:px-4 lg:px-6 pt-4 pb-8">
+            <div className="w-full">
+                <div className="flex items-center mb-8">
+                    <h2 className="text-2xl font-light">{t('goals.title', 'Goals')}</h2>
+                </div>
+
+                {goals.length === 0 ? (
+                    <p className="text-gray-700 dark:text-gray-300">
+                        {t('goals.noGoalsFound', 'No goals yet.')}
+                    </p>
+                ) : (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+                        {goals.map((goal: Goal) => {
+                            const goalUrl = goal.uid ? createGoalUrl({ uid: goal.uid, title: goal.title }) : '/goals';
+                            return (
+                                <Link
+                                    key={goal.uid}
+                                    to={goalUrl}
+                                    className={`rounded-xl shadow-sm relative flex flex-col group hover:shadow-md transition-shadow cursor-pointer bg-white dark:bg-gray-700 border border-gray-200 dark:border-gray-600 ${dropdownOpen === goal.uid ? 'z-50' : ''}`}
+                                >
+                                    {/* Three-dot menu */}
+                                    <div className="absolute top-2 right-2 z-10" ref={dropdownRef}>
+                                        <button
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                e.stopPropagation();
+                                                const next = dropdownOpen === goal.uid ? null : goal.uid!;
+                                                if (next) justOpenedRef.current = true;
+                                                setDropdownOpen(next);
+                                            }}
+                                            className="focus:outline-none opacity-0 group-hover:opacity-100 transition-opacity duration-200 p-1 rounded text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600"
+                                        >
+                                            <EllipsisVerticalIcon className="h-4 w-4" />
+                                        </button>
+                                        {dropdownOpen === goal.uid && (
+                                            <div className="absolute right-0 top-full mt-1 w-28 bg-white dark:bg-gray-700 shadow-lg rounded-md z-[60]">
+                                                <button
+                                                    onClick={(e) => { e.preventDefault(); e.stopPropagation(); openEdit(goal); setDropdownOpen(null); }}
+                                                    className="block px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left rounded-t-md"
+                                                >
+                                                    {t('common.edit', 'Edit')}
+                                                </button>
+                                                <button
+                                                    onClick={(e) => { e.preventDefault(); e.stopPropagation(); openConfirmDelete(goal); setDropdownOpen(null); }}
+                                                    className="block px-4 py-2 text-sm text-red-500 dark:text-red-300 hover:bg-gray-100 dark:hover:bg-gray-600 w-full text-left rounded-b-md"
+                                                >
+                                                    {t('common.delete', 'Delete')}
+                                                </button>
+                                            </div>
+                                        )}
+                                    </div>
+
+                                    {/* Card content */}
+                                    <div className="px-5 pt-6 pb-4 flex-1 flex flex-col">
+                                        <div className="flex items-start gap-2 mb-2">
+                                            <FlagIcon className="h-5 w-5 text-blue-500 flex-shrink-0 mt-0.5" />
+                                            <h3 className="text-sm font-semibold text-gray-800 dark:text-gray-100 line-clamp-2">
+                                                {goal.title}
+                                            </h3>
+                                        </div>
+                                        {goal.why && (
+                                            <p className="text-xs text-gray-500 dark:text-gray-400 line-clamp-2 mb-3">
+                                                {goal.why}
+                                            </p>
+                                        )}
+                                        <div className="flex flex-wrap gap-1 mt-auto">
+                                            <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${STATUS_COLORS[goal.status] ?? ''}`}>
+                                                {t(`goals.status.${goal.status}`, goal.status)}
+                                            </span>
+                                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400">
+                                                {t(`goals.horizon.${goal.horizon}`, goal.horizon)}
+                                            </span>
+                                        </div>
+                                        {goal.Area && (
+                                            <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
+                                                {goal.Area.name}
+                                            </p>
+                                        )}
+                                    </div>
+
+                                    {/* Stats footer */}
+                                    <div className="rounded-b-xl flex items-stretch divide-x bg-gray-50 dark:bg-gray-800 border-t border-gray-100 dark:border-gray-600 divide-gray-200 dark:divide-gray-600">
+                                        {[
+                                            {
+                                                icon: <FolderIcon className="h-3.5 w-3.5" />,
+                                                count: (goal as any).projects_count ?? (goal.Projects?.length ?? 0),
+                                                label: t('goals.stats.projects', 'projects'),
+                                            },
+                                            {
+                                                icon: <CheckCircleIcon className="h-3.5 w-3.5" />,
+                                                count: (goal as any).tasks_count ?? (goal.Tasks?.length ?? 0),
+                                                label: t('goals.stats.tasks', 'tasks'),
+                                            },
+                                        ].map(({ icon, count, label }) => (
+                                            <div key={label} className="flex-1 flex flex-col items-center py-3 gap-1">
+                                                <span className="text-base font-semibold leading-none text-gray-700 dark:text-gray-200">
+                                                    {count}
+                                                </span>
+                                                <span className="flex items-center gap-1 text-[10px] leading-none text-gray-400 dark:text-gray-500">
+                                                    {icon}
+                                                    {label}
+                                                </span>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </Link>
+                            );
+                        })}
+                    </div>
+                )}
+            </div>
+
+            {isGoalModalOpen && (
+                <GoalModal
+                    isOpen={isGoalModalOpen}
+                    onClose={() => { setIsGoalModalOpen(false); setSelectedGoal(null); }}
+                    onSave={handleSaveGoal}
+                    onDelete={async (uid) => { await deleteGoal(uid); loadGoals(true); setIsGoalModalOpen(false); setSelectedGoal(null); }}
+                    goal={selectedGoal}
+                />
+            )}
+
+            {isConfirmDialogOpen && goalToDelete && (
+                <ConfirmDialog
+                    title={t('modals.deleteGoal.title', 'Delete Goal')}
+                    message={`${t('modals.deleteGoal.message', 'Are you sure you want to delete the goal')} "${goalToDelete.title}"?`}
+                    onConfirm={handleDeleteGoal}
+                    onCancel={() => { setIsConfirmDialogOpen(false); setGoalToDelete(null); }}
+                />
+            )}
+        </div>
+    );
+};
+
+export default Goals;

--- a/frontend/components/Project/ProjectModal.tsx
+++ b/frontend/components/Project/ProjectModal.tsx
@@ -107,18 +107,10 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
     };
 
     useEffect(() => {
-        if (formData.area_id) {
-            const area = areas.find((a) => a.id === formData.area_id);
-            const areaUid = area?.uid || formData.area_uid;
-            if (areaUid) {
-                fetchGoals(areaUid)
-                    .then(setAvailableGoals)
-                    .catch(() => setAvailableGoals([]));
-            }
-        } else {
-            setAvailableGoals([]);
-        }
-    }, [formData.area_id]);
+        fetchGoals()
+            .then(setAvailableGoals)
+            .catch(() => setAvailableGoals([]));
+    }, []);
 
     // Manage body scroll when modal is open
     useEffect(() => {
@@ -636,24 +628,18 @@ const ProjectModal: React.FC<ProjectModalProps> = ({
                                                     <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
                                                         Goal
                                                     </h3>
-                                                    {!formData.area_id ? (
-                                                        <p className="text-sm text-gray-400 dark:text-gray-500">
-                                                            Select an area first to see its goals.
-                                                        </p>
-                                                    ) : (
-                                                        <GoalDropdown
-                                                            goalId={formData.goal_id ?? null}
-                                                            isMaintenance={!!formData.is_maintenance}
-                                                            goals={availableGoals}
-                                                            onChange={(id, maintenance) =>
-                                                                setFormData((prev) => ({
-                                                                    ...prev,
-                                                                    goal_id: id,
-                                                                    is_maintenance: maintenance,
-                                                                }))
-                                                            }
-                                                        />
-                                                    )}
+                                                    <GoalDropdown
+                                                        goalId={formData.goal_id ?? null}
+                                                        isMaintenance={!!formData.is_maintenance}
+                                                        goals={availableGoals}
+                                                        onChange={(id, maintenance) =>
+                                                            setFormData((prev) => ({
+                                                                ...prev,
+                                                                goal_id: id,
+                                                                is_maintenance: maintenance,
+                                                            }))
+                                                        }
+                                                    />
                                                 </div>
                                             )}
 

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { Area } from '../entities/Area';
 import { Note } from '../entities/Note';
 import { Tag } from '../entities/Tag';
+import { Goal } from '../entities/Goal';
 import SidebarAreas from './Sidebar/SidebarAreas';
 import SidebarFooter from './Sidebar/SidebarFooter';
 import SidebarNav from './Sidebar/SidebarNav';
@@ -10,6 +11,7 @@ import SidebarNotes from './Sidebar/SidebarNotes';
 import SidebarHabits from './Sidebar/SidebarHabits';
 import SidebarProjects from './Sidebar/SidebarProjects';
 import SidebarTags from './Sidebar/SidebarTags';
+import SidebarGoals from './Sidebar/SidebarGoals';
 import SidebarViews from './Sidebar/SidebarViews';
 import SidebarPeople from './Sidebar/SidebarPeople';
 import SidebarBoards from './Sidebar/SidebarBoards';
@@ -30,6 +32,7 @@ interface SidebarProps {
     openNoteModal: (note: Note | null) => void;
     openAreaModal: (area: Area | null) => void;
     openTagModal: (tag: Tag | null) => void;
+    openGoalModal: (goal: Goal | null) => void;
     openNewHabit: () => void;
     notes: Note[];
     areas: Area[];
@@ -48,6 +51,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     openNoteModal,
     openAreaModal,
     openTagModal,
+    openGoalModal,
     openNewHabit,
     notes,
     areas,
@@ -107,6 +111,11 @@ const Sidebar: React.FC<SidebarProps> = ({
                             location={location}
                             isDarkMode={isDarkMode}
                             openAreaModal={openAreaModal}
+                        />
+                        <SidebarGoals
+                            handleNavClick={handleNavClick}
+                            location={location}
+                            openGoalModal={openGoalModal}
                         />
                         <SidebarNotes
                             handleNavClick={handleNavClick}

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { Area } from '../entities/Area';
 import { Note } from '../entities/Note';
 import { Tag } from '../entities/Tag';
-import { Goal } from '../entities/Goal';
 import SidebarAreas from './Sidebar/SidebarAreas';
 import SidebarFooter from './Sidebar/SidebarFooter';
 import SidebarNav from './Sidebar/SidebarNav';
@@ -32,7 +31,6 @@ interface SidebarProps {
     openNoteModal: (note: Note | null) => void;
     openAreaModal: (area: Area | null) => void;
     openTagModal: (tag: Tag | null) => void;
-    openGoalModal: (goal: Goal | null) => void;
     openNewHabit: () => void;
     notes: Note[];
     areas: Area[];
@@ -51,7 +49,6 @@ const Sidebar: React.FC<SidebarProps> = ({
     openNoteModal,
     openAreaModal,
     openTagModal,
-    openGoalModal,
     openNewHabit,
     notes,
     areas,
@@ -115,7 +112,6 @@ const Sidebar: React.FC<SidebarProps> = ({
                         <SidebarGoals
                             handleNavClick={handleNavClick}
                             location={location}
-                            openGoalModal={openGoalModal}
                         />
                         <SidebarNotes
                             handleNavClick={handleNavClick}

--- a/frontend/components/Sidebar/SidebarGoals.tsx
+++ b/frontend/components/Sidebar/SidebarGoals.tsx
@@ -1,0 +1,121 @@
+import React, { useEffect, useState } from 'react';
+import { Location } from 'react-router-dom';
+import {
+    FlagIcon,
+    PlusCircleIcon,
+    ChevronDownIcon,
+    ChevronRightIcon,
+} from '@heroicons/react/24/outline';
+import { Goal } from '../../entities/Goal';
+import { useTranslation } from 'react-i18next';
+import { useStore } from '../../store/useStore';
+import { createGoalUrl } from '../../utils/slugUtils';
+
+interface SidebarGoalsProps {
+    handleNavClick: (path: string, title: string, icon: JSX.Element) => void;
+    location: Location;
+    openGoalModal: (goal: Goal | null) => void;
+}
+
+const SidebarGoals: React.FC<SidebarGoalsProps> = ({
+    handleNavClick,
+    location,
+    openGoalModal,
+}) => {
+    const { t } = useTranslation();
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const goals = useStore((state: any) => state.goalsStore.goals);
+    const hasLoaded = useStore((state: any) => state.goalsStore.hasLoaded);
+    const loadGoals = useStore((state: any) => state.goalsStore.loadGoals);
+
+    useEffect(() => {
+        if (!hasLoaded) loadGoals();
+    }, [hasLoaded, loadGoals]);
+
+    const isActive = (path: string) => location.pathname === path;
+
+    const itemClass = (path: string) =>
+        `group flex justify-between items-center rounded-md px-4 py-1.5 text-sm cursor-pointer hover:text-black dark:hover:text-white ${
+            isActive(path)
+                ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white'
+                : 'text-gray-700 dark:text-gray-300'
+        }`;
+
+    const activeGoals = goals.filter((g: Goal) => g.status === 'active');
+
+    return (
+        <div className={`flex flex-col space-y-1${isExpanded ? ' pb-3' : ''}`}>
+            <div
+                className={`group flex justify-between items-center px-4 py-2 uppercase rounded-md text-xs tracking-wider cursor-pointer hover:text-black dark:hover:text-white ${
+                    isActive('/goals')
+                        ? 'bg-gray-200 dark:bg-gray-700 text-gray-900 dark:text-white'
+                        : 'text-gray-700 dark:text-gray-300'
+                }`}
+                onClick={() =>
+                    handleNavClick('/goals', t('sidebar.goals', 'Goals'), <FlagIcon className="h-5 w-5 mr-2" />)
+                }
+            >
+                <span className="flex items-center">
+                    <FlagIcon className="h-5 w-5 mr-2" />
+                    {t('sidebar.goals', 'Goals')}
+                </span>
+                <div className="flex items-center gap-1">
+                    <button
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            openGoalModal(null);
+                        }}
+                        className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
+                        aria-label={t('sidebar.addGoalAriaLabel', 'Add Goal')}
+                        title={t('sidebar.addGoalTitle', 'Add Goal')}
+                    >
+                        <PlusCircleIcon className="h-5 w-5" />
+                    </button>
+                    {activeGoals.length > 0 && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                setIsExpanded((v) => !v);
+                            }}
+                            className="text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
+                            aria-label={isExpanded ? 'Collapse goals list' : 'Expand goals list'}
+                        >
+                            {isExpanded ? (
+                                <ChevronDownIcon className="h-4 w-4" />
+                            ) : (
+                                <ChevronRightIcon className="h-4 w-4" />
+                            )}
+                        </button>
+                    )}
+                </div>
+            </div>
+
+            {isExpanded && (
+                <div className="max-h-80 overflow-y-auto overscroll-y-contain flex flex-col space-y-1">
+                    {activeGoals.map((goal: Goal) => {
+                        const goalPath = goal.uid ? createGoalUrl({ uid: goal.uid, title: goal.title }) : '/goals';
+                        return (
+                            <div
+                                key={goal.uid ?? goal.id}
+                                className={itemClass(goalPath)}
+                                onClick={() =>
+                                    handleNavClick(goalPath, goal.title, <FlagIcon className="h-4 w-4 mr-2" />)
+                                }
+                            >
+                                <span className="flex items-center truncate">
+                                    <span className="w-5 mr-2 flex items-center justify-center flex-shrink-0">
+                                        <FlagIcon className="h-4 w-4 text-blue-500" />
+                                    </span>
+                                    <span className="truncate">{goal.title}</span>
+                                </span>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default SidebarGoals;

--- a/frontend/components/Sidebar/SidebarGoals.tsx
+++ b/frontend/components/Sidebar/SidebarGoals.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Location } from 'react-router-dom';
+import { Location, useNavigate } from 'react-router-dom';
 import {
     FlagIcon,
     PlusCircleIcon,
@@ -14,15 +14,14 @@ import { createGoalUrl } from '../../utils/slugUtils';
 interface SidebarGoalsProps {
     handleNavClick: (path: string, title: string, icon: JSX.Element) => void;
     location: Location;
-    openGoalModal: (goal: Goal | null) => void;
 }
 
 const SidebarGoals: React.FC<SidebarGoalsProps> = ({
     handleNavClick,
     location,
-    openGoalModal,
 }) => {
     const { t } = useTranslation();
+    const navigate = useNavigate();
     const [isExpanded, setIsExpanded] = useState(false);
 
     const goals = useStore((state: any) => state.goalsStore.goals);
@@ -64,7 +63,7 @@ const SidebarGoals: React.FC<SidebarGoalsProps> = ({
                     <button
                         onClick={(e) => {
                             e.stopPropagation();
-                            openGoalModal(null);
+                            navigate('/goal/new');
                         }}
                         className="opacity-0 group-hover:opacity-100 transition-opacity text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white focus:outline-none"
                         aria-label={t('sidebar.addGoalAriaLabel', 'Add Goal')}

--- a/frontend/components/Task/TaskDetails.tsx
+++ b/frontend/components/Task/TaskDetails.tsx
@@ -33,6 +33,7 @@ import {
     TaskDeferUntilCard,
     TaskAttachmentsCard,
     TaskAssignedToCard,
+    TaskGoalCard,
 } from './TaskDetails/';
 import TaskAIInsights, { TaskAIInsightsHandle } from '../AI/TaskAIInsights';
 import {
@@ -79,6 +80,7 @@ const TaskDetails: React.FC = () => {
     const tagsStore = useStore((state: any) => state.tagsStore);
     const tasksStore = useStore((state: any) => state.tasksStore);
     const areasStore = useStore((state: any) => state.areasStore);
+    const goalsStore = useStore((state: any) => state.goalsStore);
     const task = useStore((state: any) =>
         state.tasksStore.tasks.find((t: Task) => t.uid === uid)
     );
@@ -202,6 +204,12 @@ const TaskDetails: React.FC = () => {
             areasStore.loadAreas();
         }
     }, [areasStore]);
+
+    useEffect(() => {
+        if (!goalsStore.hasLoaded && !goalsStore.isLoading) {
+            goalsStore.loadGoals();
+        }
+    }, [goalsStore]);
 
     const handleStartRecurrenceEdit = () => {
         setRecurrenceForm({
@@ -1200,6 +1208,40 @@ const TaskDetails: React.FC = () => {
         }
     };
 
+    const handleGoalSelection = async (goal: any) => {
+        if (!task?.uid) return;
+        try {
+            taskModifiedRef.current = true;
+            await updateTask(task.uid, { goal_id: goal.id });
+            if (uid) {
+                const updatedTask = await fetchTaskByUid(uid);
+                tasksStore.updateTaskInStore(updatedTask);
+            }
+            showSuccessToast(t('task.goalUpdated', 'Goal updated'));
+            setTimelineRefreshKey((prev) => prev + 1);
+        } catch (error) {
+            console.error('Error updating goal:', error);
+            showErrorToast(t('task.goalUpdateError', 'Failed to update goal'));
+        }
+    };
+
+    const handleClearGoal = async () => {
+        if (!task?.uid) return;
+        try {
+            taskModifiedRef.current = true;
+            await updateTask(task.uid, { goal_id: null });
+            if (uid) {
+                const updatedTask = await fetchTaskByUid(uid);
+                tasksStore.updateTaskInStore(updatedTask);
+            }
+            showSuccessToast(t('task.goalCleared', 'Goal cleared'));
+            setTimelineRefreshKey((prev) => prev + 1);
+        } catch (error) {
+            console.error('Error clearing goal:', error);
+            showErrorToast(t('task.goalClearError', 'Failed to clear goal'));
+        }
+    };
+
     const handleAssignPerson = async (personUid: string | null) => {
         if (!task?.uid) return;
         try {
@@ -1423,6 +1465,13 @@ const TaskDetails: React.FC = () => {
                                     onAreaSelect={handleAreaSelection}
                                     onAreaClear={handleClearArea}
                                     getAreaLink={getAreaLink}
+                                />
+
+                                <TaskGoalCard
+                                    task={task}
+                                    goals={goalsStore.goals}
+                                    onGoalSelect={handleGoalSelection}
+                                    onGoalClear={handleClearGoal}
                                 />
 
                                 <TaskAssignedToCard

--- a/frontend/components/Task/TaskDetails/TaskGoalCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskGoalCard.tsx
@@ -1,0 +1,177 @@
+import React, { useRef, useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router-dom';
+import { ArrowRightIcon, FlagIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Goal } from '../../../entities/Goal';
+import { Task } from '../../../entities/Task';
+import { createGoalUrl } from '../../../utils/slugUtils';
+
+interface TaskGoalCardProps {
+    task: Task;
+    goals: Goal[];
+    onGoalSelect: (goal: Goal) => Promise<void>;
+    onGoalClear: () => Promise<void>;
+}
+
+const TaskGoalCard: React.FC<TaskGoalCardProps> = ({
+    task,
+    goals,
+    onGoalSelect,
+    onGoalClear,
+}) => {
+    const { t } = useTranslation();
+    const [dropdownOpen, setDropdownOpen] = useState(false);
+    const [searchQuery, setSearchQuery] = useState('');
+    const dropdownRef = useRef<HTMLDivElement>(null);
+
+    const selectedGoal = goals.find((g) => g.id === task.goal_id) ?? null;
+
+    useEffect(() => {
+        const handleClickOutside = (e: MouseEvent) => {
+            if (
+                dropdownOpen &&
+                dropdownRef.current &&
+                !dropdownRef.current.contains(e.target as Node)
+            ) {
+                setDropdownOpen(false);
+                setSearchQuery('');
+            }
+        };
+
+        if (dropdownOpen) {
+            document.addEventListener('mousedown', handleClickOutside);
+            return () => document.removeEventListener('mousedown', handleClickOutside);
+        }
+    }, [dropdownOpen]);
+
+    const filteredGoals = goals.filter((g) =>
+        g.title.toLowerCase().includes(searchQuery.toLowerCase())
+    );
+
+    const activeGoals = filteredGoals.filter((g) => g.status === 'active');
+    const inactiveGoals = filteredGoals.filter((g) => g.status !== 'active');
+
+    const handleSelect = async (goal: Goal) => {
+        await onGoalSelect(goal);
+        setDropdownOpen(false);
+        setSearchQuery('');
+    };
+
+    const handleClear = async () => {
+        await onGoalClear();
+        setDropdownOpen(false);
+        setSearchQuery('');
+    };
+
+    return (
+        <div ref={dropdownRef} className="space-y-2">
+            {dropdownOpen ? (
+                <div className="rounded-lg shadow-sm bg-white dark:bg-gray-900 border-2 border-gray-50 dark:border-gray-800">
+                    <div className="p-3">
+                        <input
+                            type="text"
+                            autoFocus
+                            value={searchQuery}
+                            onChange={(e) => setSearchQuery(e.target.value)}
+                            placeholder={t('goals.searchGoals', 'Search goals…')}
+                            className="w-full text-sm border border-gray-200 dark:border-gray-700 rounded-md px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                        />
+                        <div className="mt-2 max-h-48 overflow-y-auto space-y-0.5">
+                            {selectedGoal && (
+                                <button
+                                    onClick={handleClear}
+                                    className="w-full text-left text-sm px-3 py-1.5 rounded text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 flex items-center gap-2"
+                                >
+                                    <XMarkIcon className="h-3.5 w-3.5" />
+                                    {t('goals.clearGoal', 'Remove goal')}
+                                </button>
+                            )}
+                            {activeGoals.length === 0 && inactiveGoals.length === 0 ? (
+                                <div className="text-sm text-gray-400 dark:text-gray-500 px-3 py-2">
+                                    {t('goals.noGoalsFound', 'No goals found')}
+                                </div>
+                            ) : (
+                                <>
+                                    {activeGoals.map((goal) => (
+                                        <button
+                                            key={goal.id}
+                                            onClick={() => handleSelect(goal)}
+                                            className="w-full text-left text-sm px-3 py-1.5 rounded text-gray-800 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center gap-2"
+                                        >
+                                            <FlagIcon className="h-3.5 w-3.5 text-blue-500 flex-shrink-0" />
+                                            {goal.title}
+                                        </button>
+                                    ))}
+                                    {inactiveGoals.length > 0 && (
+                                        <>
+                                            <div className="px-3 py-1 text-xs text-gray-400 dark:text-gray-500 border-t border-gray-100 dark:border-gray-700 mt-1">
+                                                {t('goals.inactive', 'Inactive')}
+                                            </div>
+                                            {inactiveGoals.map((goal) => (
+                                                <button
+                                                    key={goal.id}
+                                                    onClick={() => handleSelect(goal)}
+                                                    className="w-full text-left text-sm px-3 py-1.5 rounded text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 flex items-center gap-2"
+                                                >
+                                                    <FlagIcon className="h-3.5 w-3.5 flex-shrink-0" />
+                                                    {goal.title} ({goal.status})
+                                                </button>
+                                            ))}
+                                        </>
+                                    )}
+                                </>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            ) : selectedGoal ? (
+                <div className="rounded-lg shadow-sm bg-white dark:bg-gray-900 border-2 border-gray-50 dark:border-gray-800 hover:border-gray-200 dark:hover:border-gray-700 transition-colors p-4">
+                    <div className="flex items-center justify-between gap-2">
+                        <div
+                            className="flex items-center gap-2 min-w-0 cursor-pointer flex-1"
+                            onClick={() => setDropdownOpen(true)}
+                        >
+                            <FlagIcon className="h-4 w-4 text-blue-500 flex-shrink-0" />
+                            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+                                {selectedGoal.title}
+                            </span>
+                        </div>
+                        <div className="flex items-center gap-1 flex-shrink-0">
+                            {selectedGoal.uid && (
+                                <Link
+                                    to={createGoalUrl({ uid: selectedGoal.uid, title: selectedGoal.title })}
+                                    onClick={(e) => e.stopPropagation()}
+                                    className="p-1.5 rounded-full text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/30 transition-colors"
+                                    title={t('goals.viewGoal', 'Go to goal')}
+                                >
+                                    <ArrowRightIcon className="h-4 w-4" />
+                                </Link>
+                            )}
+                            <button
+                                onClick={handleClear}
+                                className="p-1.5 rounded-full text-gray-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
+                                title={t('goals.clearGoal', 'Remove goal')}
+                            >
+                                <XMarkIcon className="h-4 w-4" />
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            ) : (
+                <div
+                    onClick={() => setDropdownOpen(true)}
+                    className="rounded-lg shadow-sm bg-white dark:bg-gray-900 border-2 border-gray-50 dark:border-gray-800 hover:border-gray-200 dark:hover:border-gray-700 p-6 cursor-pointer transition-colors"
+                >
+                    <div className="flex flex-col items-center justify-center py-8 text-gray-500 dark:text-gray-400">
+                        <FlagIcon className="h-12 w-12 mb-3 opacity-50" />
+                        <span className="text-sm text-center">
+                            {t('task.noGoal', 'Assign to a goal')}
+                        </span>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default TaskGoalCard;

--- a/frontend/components/Task/TaskDetails/index.ts
+++ b/frontend/components/Task/TaskDetails/index.ts
@@ -10,3 +10,4 @@ export { default as TaskDeferUntilCard } from './TaskDeferUntilCard';
 export { default as TaskAttachmentsCard } from './TaskAttachmentsCard';
 export { default as TaskAreaCard } from './TaskAreaCard';
 export { default as TaskAssignedToCard } from './TaskAssignedToCard';
+export { default as TaskGoalCard } from './TaskGoalCard';

--- a/frontend/entities/Goal.ts
+++ b/frontend/entities/Goal.ts
@@ -1,10 +1,14 @@
+import { Area } from './Area';
+import { Task } from './Task';
+import { Project } from './Project';
+
 export type GoalHorizon = 'season' | 'year';
 export type GoalStatus = 'active' | 'achieved' | 'paused' | 'dropped';
 
 export interface Goal {
     id?: number;
     uid?: string;
-    area_id: number;
+    area_id?: number | null;
     user_id?: number;
     title: string;
     why?: string | null;
@@ -13,4 +17,7 @@ export interface Goal {
     status: GoalStatus;
     created_at?: string;
     updated_at?: string;
+    Area?: Area | null;
+    Tasks?: Task[];
+    Projects?: Project[];
 }

--- a/frontend/entities/Task.ts
+++ b/frontend/entities/Task.ts
@@ -22,6 +22,8 @@ export interface Task {
     area_id?: number;
     area_uid?: string;
     Area?: Area;
+    goal_id?: number | null;
+    goal_uid?: string | null;
     created_at?: string;
     updated_at?: string;
     recurrence_type?: RecurrenceType;

--- a/frontend/store/useStore.ts
+++ b/frontend/store/useStore.ts
@@ -5,6 +5,7 @@ import { Note } from '../entities/Note';
 import { Task } from '../entities/Task';
 import { Tag } from '../entities/Tag';
 import { InboxItem } from '../entities/InboxItem';
+import { Goal } from '../entities/Goal';
 
 interface NotesStore {
     notes: Note[];
@@ -119,6 +120,17 @@ interface UserSettingsStore {
     setShowTaskContextMenu: (enabled: boolean) => void;
 }
 
+interface GoalsStore {
+    goals: Goal[];
+    isLoading: boolean;
+    isError: boolean;
+    hasLoaded: boolean;
+    setGoals: (goals: Goal[]) => void;
+    setLoading: (isLoading: boolean) => void;
+    setError: (isError: boolean) => void;
+    loadGoals: (forceReload?: boolean) => Promise<void>;
+}
+
 interface HabitsStore {
     habits: Task[];
     isLoading: boolean;
@@ -134,6 +146,7 @@ interface HabitsStore {
 interface StoreState {
     notesStore: NotesStore;
     areasStore: AreasStore;
+    goalsStore: GoalsStore;
     projectsStore: ProjectsStore;
     tagsStore: TagsStore;
     tasksStore: TasksStore;
@@ -235,6 +248,57 @@ export const useStore = create<StoreState>((set: any) => ({
                 set((state) => ({
                     areasStore: {
                         ...state.areasStore,
+                        isError: true,
+                        isLoading: false,
+                        hasLoaded: true,
+                    },
+                }));
+            }
+        },
+    },
+    goalsStore: {
+        goals: [],
+        isLoading: false,
+        isError: false,
+        hasLoaded: false,
+        setGoals: (goals) =>
+            set((state) => ({ goalsStore: { ...state.goalsStore, goals } })),
+        setLoading: (isLoading) =>
+            set((state) => ({
+                goalsStore: { ...state.goalsStore, isLoading },
+            })),
+        setError: (isError) =>
+            set((state) => ({ goalsStore: { ...state.goalsStore, isError } })),
+        loadGoals: async (forceReload = false) => {
+            const state = useStore.getState();
+            if (state.goalsStore.isLoading) return;
+            if (state.goalsStore.hasLoaded && !forceReload) return;
+
+            const { fetchGoals } = await import('../utils/goalsService');
+
+            set((state) => ({
+                goalsStore: {
+                    ...state.goalsStore,
+                    isLoading: true,
+                    isError: false,
+                },
+            }));
+
+            try {
+                const goals = await fetchGoals();
+                set((state) => ({
+                    goalsStore: {
+                        ...state.goalsStore,
+                        goals,
+                        isLoading: false,
+                        hasLoaded: true,
+                    },
+                }));
+            } catch (error) {
+                console.error('loadGoals: Failed to load goals:', error);
+                set((state) => ({
+                    goalsStore: {
+                        ...state.goalsStore,
                         isError: true,
                         isLoading: false,
                         hasLoaded: true,

--- a/frontend/utils/goalsService.ts
+++ b/frontend/utils/goalsService.ts
@@ -14,6 +14,16 @@ export const fetchGoals = async (areaUid?: string): Promise<Goal[]> => {
     return data.goals;
 };
 
+export const fetchGoalByUid = async (uid: string): Promise<Goal> => {
+    const response = await fetch(getApiPath(`goals/${uid}`), {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+    });
+    await handleAuthResponse(response, 'Failed to fetch goal.');
+    const data = await response.json();
+    return data.goal;
+};
+
 export const createGoal = async (
     data: Omit<Goal, 'id' | 'uid' | 'user_id' | 'created_at' | 'updated_at'>
 ): Promise<{ goal: Goal; active_goals_count: number }> => {

--- a/frontend/utils/slugUtils.ts
+++ b/frontend/utils/slugUtils.ts
@@ -129,3 +129,16 @@ export function createTagUrl(tag: { uid?: string; name: string }): string {
     const uidSlug = createUidSlug(tag.uid, tag.name);
     return `/tag/${uidSlug}`;
 }
+
+/**
+ * Creates a goal URL using uid-slug format
+ * @param goal - Goal object with uid and title
+ * @returns The goal URL path (e.g., "/goal/abc123-launch-new-product")
+ */
+export function createGoalUrl(goal: { uid?: string; title: string }): string {
+    if (!goal.uid) {
+        throw new Error('Goal uid is required');
+    }
+    const uidSlug = createUidSlug(goal.uid, goal.title);
+    return `/goal/${uidSlug}`;
+}


### PR DESCRIPTION
## Description

Completes the standalone goals system with a redesigned UX and deep area integration:

- **No more modal for create/edit**: goal creation and editing now happen inline on the `GoalDetails` page (`/goal/new` for create, edit button toggles inline form)
- **Goals list aligned with Areas page**: cards adopt the linked area's color, area filter tabs at the top, centered layout matching the Areas grid
- **GoalDetails header**: area shown as a clickable breadcrumb chip (colored, links to the area page)
- **GoalDetails tasks**: uses the shared `TaskList` component instead of a custom row
- **GoalDetails projects**: uses `border-l-4` color bar format consistent with other project lists
- **AreaModal**: goals dropdown lets you assign/unassign goals when editing an existing area
- **AreaDetails**: goals section shows linked goals with a hover-to-unlink button; assignment moved entirely to the edit modal
- **Backend**: `goals/repository.js` attaches `projects_count` and `tasks_count` to list responses; all queries scoped to `user_id` to prevent cross-user data leakage
- **Security fix**: `_attachCounts` and `findByUid` includes now scope `Project` and `Task` queries to the requesting user

## Type of Change

- [x] New feature (adds functionality)
- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #

## Testing

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Database migrations included and tested (if applicable)

## Additional Notes

The `GoalModal` component is retained in the codebase (used nowhere now) — can be deleted in a follow-up cleanup PR.