### PR TITLE
feat(inbox): gate clarify feature behind ENABLE_INBOX_CLARIFY flag

### DIFF
--- a/frontend/components/Inbox/InboxItems.tsx
+++ b/frontend/components/Inbox/InboxItems.tsx
@@ -28,6 +28,7 @@ import { fetchAreas } from '../../utils/areasService';
 import { fetchProjects } from '../../utils/projectsService';
 import { useStore } from '../../store/useStore';
 import ClarifyOverlay, { ClarifyStep, ClarifyOutcome } from './ClarifyOverlay';
+import { ENABLE_INBOX_CLARIFY } from '../../config/featureFlags';
 
 interface ClarifyState {
     active: boolean;
@@ -668,7 +669,7 @@ const InboxItems: React.FC = () => {
                             </span>
 
                             {/* Process N button */}
-                            {inboxItems.length > 0 && !clarify.active && (
+                            {ENABLE_INBOX_CLARIFY && inboxItems.length > 0 && !clarify.active && (
                                 <span
                                     role="button"
                                     tabIndex={0}
@@ -681,7 +682,7 @@ const InboxItems: React.FC = () => {
                             )}
 
                             {/* Trashed affordance */}
-                            {trashedCount > 0 && (
+                            {ENABLE_INBOX_CLARIFY && trashedCount > 0 && (
                                 <span
                                     role="button"
                                     tabIndex={0}
@@ -721,7 +722,7 @@ const InboxItems: React.FC = () => {
                         {inboxListExpanded && (
                             <div className="flex flex-col">
                                 {/* Clarify overlay — shown instead of the list when active */}
-                                {clarify.active && !clarify.pendingModalUid && (() => {
+                                {ENABLE_INBOX_CLARIFY && clarify.active && !clarify.pendingModalUid && (() => {
                                     const uid = clarify.itemUids[clarify.currentIndex];
                                     const currentItem = inboxItems.find((i) => i.uid === uid);
                                     const isDone = clarify.currentIndex >= clarify.itemUids.length;
@@ -740,8 +741,8 @@ const InboxItems: React.FC = () => {
                                     );
                                 })()}
 
-                                {/* Normal item list — hidden while clarify is active */}
-                                {!clarify.active && inboxItems.map((item) => (
+                                {/* Normal item list */}
+                                {(!ENABLE_INBOX_CLARIFY || !clarify.active) && inboxItems.map((item) => (
                                     <InboxItemDetail
                                         key={item.uid || item.id}
                                         item={item}
@@ -752,12 +753,12 @@ const InboxItems: React.FC = () => {
                                         openNoteModal={handleOpenNoteModal}
                                         projects={projects}
                                         isNew={item.uid === lastAddedUid}
-                                        onReClarify={startSingleClarify}
+                                        onReClarify={ENABLE_INBOX_CLARIFY ? startSingleClarify : undefined}
                                     />
                                 ))}
 
                                 {/* Load more */}
-                                {!clarify.active && pagination.hasMore && (
+                                {(!ENABLE_INBOX_CLARIFY || !clarify.active) && pagination.hasMore && (
                                     <div className="flex justify-center pt-5">
                                         <button
                                             onClick={handleLoadMore}
@@ -783,7 +784,7 @@ const InboxItems: React.FC = () => {
                                 )}
 
                                 {/* Item count */}
-                                {!clarify.active && (
+                                {(!ENABLE_INBOX_CLARIFY || !clarify.active) && (
                                     <div className="text-center text-xs text-gray-400 dark:text-gray-500 pt-4 pb-2">
                                         {t(
                                             'inbox.showingItems',

--- a/frontend/config/featureFlags.ts
+++ b/frontend/config/featureFlags.ts
@@ -12,10 +12,17 @@ export const ENABLE_NOTE_COLOR = parseBooleanFlag(
     true
 );
 
+export const ENABLE_INBOX_CLARIFY = parseBooleanFlag(
+    process.env.ENABLE_INBOX_CLARIFY,
+    false
+);
+
 export type FeatureFlags = {
     ENABLE_NOTE_COLOR: boolean;
+    ENABLE_INBOX_CLARIFY: boolean;
 };
 
 export const featureFlags: FeatureFlags = {
     ENABLE_NOTE_COLOR,
+    ENABLE_INBOX_CLARIFY,
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -81,6 +81,7 @@ module.exports = {
             Object.fromEntries(
                 Object.entries({
                     ENABLE_NOTE_COLOR: process.env.ENABLE_NOTE_COLOR,
+                    ENABLE_INBOX_CLARIFY: process.env.ENABLE_INBOX_CLARIFY,
                     TUDUDI_BASE_PATH: process.env.TUDUDI_BASE_PATH || '',
                 }).map(([key, value]) => [
                     `process.env.${key}`,


### PR DESCRIPTION
## Description

Hides the inbox clarify workflow behind an `ENABLE_INBOX_CLARIFY` environment flag (default `false`). The inbox now shows just the collapsible "Recently captured" header and item list with no clarify UI visible by default.

The feature can be re-enabled by setting `ENABLE_INBOX_CLARIFY=true` in the environment.

## Type of Change

- [x] New feature (non-breaking change which adds new functionality)

## What gets gated

- **"Process N" bulk button** in the "Recently captured" header
- **"X trashed · restore" affordance** in the header
- **ClarifyOverlay** decision-tree panel shown when processing items
- **Per-item "Re-clarify" link** in each inbox card

## Testing

```bash
npm run lint:fix
npm run lint
```

Zero errors, 2 pre-existing warnings in an unrelated test file.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have run the linter and fixed all errors
- [x] No new warnings introduced