### PR TITLE
fix(auth): prevent password loss during migration and improve error messages for NULL password_digest

### DIFF
--- a/backend/migrations/20260420000004-make-password-optional.js
+++ b/backend/migrations/20260420000004-make-password-optional.js
@@ -56,13 +56,7 @@ module.exports = {
         );
         const hasPassword = columns.some((col) => col.name === 'password');
 
-        const passwordColumn = hasPasswordDigest
-            ? 'password_digest'
-            : hasPassword
-              ? 'password'
-              : null;
-
-        if (!passwordColumn) {
+        if (!hasPasswordDigest && !hasPassword) {
             throw new Error(
                 'Neither password nor password_digest column found in users table'
             );
@@ -121,8 +115,21 @@ module.exports = {
         );
 
         const columnsWithoutPassword = columnsToSelect.filter(
-            (col) => col !== passwordColumn && col !== 'password_digest'
+            (col) => col !== 'password' && col !== 'password_digest'
         );
+
+        // When both columns exist, use COALESCE to prefer password_digest but
+        // fall back to password for users who still have their hash there.
+        // When only one column exists, select it directly.
+        let passwordSelectExpr;
+        if (hasPasswordDigest && hasPassword) {
+            passwordSelectExpr =
+                'COALESCE(password_digest, password) as password_digest';
+        } else if (hasPasswordDigest) {
+            passwordSelectExpr = 'password_digest as password_digest';
+        } else {
+            passwordSelectExpr = 'password as password_digest';
+        }
 
         const insertColumns = [
             ...columnsWithoutPassword,
@@ -131,7 +138,7 @@ module.exports = {
         ];
         const selectColumns = [
             ...columnsWithoutPassword,
-            `${passwordColumn} as password_digest`,
+            passwordSelectExpr,
             ...aiColumnsToSelect,
         ];
 

--- a/backend/modules/auth/service.js
+++ b/backend/modules/auth/service.js
@@ -200,8 +200,15 @@ class AuthService {
         }
 
         if (!user.password_digest) {
+            const oidcEnabled =
+                (process.env.OIDC_ENABLED || '').toLowerCase() === 'true';
+            if (oidcEnabled) {
+                throw new UnauthorizedError(
+                    'This account has no password set. Please sign in with your SSO provider, or contact an administrator to set a password.'
+                );
+            }
             throw new UnauthorizedError(
-                'This account uses SSO. Please sign in with your SSO provider.'
+                'This account has no password set. Please contact an administrator to reset your password.'
             );
         }
 


### PR DESCRIPTION
## Description

Fixes a root-cause bug where non-admin users' passwords were silently wiped when the `make-password-optional` migration ran on a database that had **both** a legacy `password` column and a newer `password_digest` column simultaneously.

### Root cause

Early versions of Tududi used `sequelize.sync()` on every startup. When the migration `20250615000001-create-users` created the `users` table with a `password` column, a subsequent `sync()` call would add the `password_digest` column alongside it. The result was a table with **both** columns, where `password` was never written to by the app (bcrypt hashes always went to `password_digest`), but the column still existed.

When `20260420000004-make-password-optional` ran to standardise on `password_digest`, it picked `password_digest` as the source column unconditionally whenever that column existed — even when it was `NULL` for some users. This silently dropped those users' password hashes.

After the migration, the admin user's `password_digest` was repaired by the `user-create.js` startup script (which always re-hashes the `TUDUDI_USER_PASSWORD` env var). Non-admin users had no such recovery, leaving them unable to log in.

### Changes

**`backend/migrations/20260420000004-make-password-optional.js`**
- When **both** `password` and `password_digest` columns exist, use `COALESCE(password_digest, password)` so that users with their hash in the old `password` column are not silently broken.
- Fix the `columnsWithoutPassword` filter to always exclude both `password` and `password_digest` columns regardless of which one is the source.

**`backend/modules/auth/service.js`**
- Distinguish between OIDC-enabled deployments and non-OIDC ones when `password_digest` is `NULL`. The old message ("This account uses SSO. Please sign in with your SSO provider.") was misleading for non-OIDC users affected by the migration bug. The new messages direct the user to the right action in each case.

## Type of Change
- [x] Bug fix

## Related Issues
Fixes #1363

## Testing
- All 1,615 pre-existing passing tests continue to pass.
- The 2 failing tests (`oauth`, `mcp-routing`) are pre-existing and unrelated to these changes.
- Manually verified the migration logic covers all three schema states: `password`-only, `password_digest`-only, and both columns coexisting.

## Checklist
- [x] Code follows project conventions
- [x] `npm run lint:fix` and `npm run lint` pass with zero errors
- [x] Existing tests pass
- [x] Changes are backward-compatible

## Additional Notes

Users who were already affected by the old migration bug (i.e., who have `NULL` `password_digest` after a previous update) **cannot** be recovered automatically — the old password hash is gone. Those users need an admin to reset their password via the Admin → Users panel. The improved error message now guides them to do that rather than confusingly pointing to SSO.