### PR TITLE
fix(profile): correctly report has_password for OIDC users

### DIFF
--- a/backend/modules/users/repository.js
+++ b/backend/modules/users/repository.js
@@ -13,6 +13,7 @@ const PROFILE_ATTRIBUTES = [
     'timezone',
     'first_day_of_week',
     'avatar_image',
+    'password_digest',
     'has_password',
     'telegram_bot_token',
     'telegram_chat_id',

--- a/backend/modules/users/service.js
+++ b/backend/modules/users/service.js
@@ -121,7 +121,10 @@ class UsersService {
             }
         }
 
-        return user;
+        const profile = user.toJSON();
+        profile.has_password = !!user.password_digest;
+        delete profile.password_digest;
+        return profile;
     }
 
     /**

--- a/backend/tests/integration/users.test.js
+++ b/backend/tests/integration/users.test.js
@@ -37,6 +37,29 @@ describe('Users Routes', () => {
             expect(response.body).toHaveProperty('task_summary_frequency');
         });
 
+        it('should return has_password true when user has a password', async () => {
+            const response = await agent.get('/api/profile');
+
+            expect(response.status).toBe(200);
+            expect(response.body.has_password).toBe(true);
+        });
+
+        it('should return has_password false when user has no password', async () => {
+            await user.update({ password_digest: null });
+
+            const response = await agent.get('/api/profile');
+
+            expect(response.status).toBe(200);
+            expect(response.body.has_password).toBe(false);
+        });
+
+        it('should not expose password_digest in profile response', async () => {
+            const response = await agent.get('/api/profile');
+
+            expect(response.status).toBe(200);
+            expect(response.body).not.toHaveProperty('password_digest');
+        });
+
         it('should require authentication', async () => {
             const response = await request(app).get('/api/profile');
 


### PR DESCRIPTION
## Description

The `has_password` field on the profile API response was always returning `false` for all users, even those who had a password set. This caused OIDC/SSO users with a password to see incorrect warnings ("You have no password set") and get stuck in a contradiction: the UI showed the "Set Password" form (no current-password field) while the backend correctly required a current password to update it.

**Root cause:** The `has_password` field is a Sequelize virtual attribute whose getter checks `this.password_digest != null`. However, `password_digest` was not included in `PROFILE_ATTRIBUTES`, so when the profile was fetched with that restricted attribute list, `password_digest` was `undefined`. JavaScript's loose equality makes `undefined != null` evaluate to `false`, so `has_password` always returned `false`.

**Fix:**
- Add `password_digest` to `PROFILE_ATTRIBUTES` so the virtual getter can compute correctly
- In `getProfile()`, convert to a plain object and delete `password_digest` before returning, so the password hash is never sent to the client
- Add tests verifying correct `has_password` values for both states and that `password_digest` is not exposed

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1361

## Testing

```bash
npm test -- --testPathPattern="tests/integration/users"
# 1620 tests passed
npm run lint
# 0 errors
```

New tests added:
- `should return has_password true when user has a password`
- `should return has_password false when user has no password`
- `should not expose password_digest in profile response`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally
- [x] My changes generate no new linting errors