### PR TITLE
fix(habits): respect frequency period for completion state and streaks

### DIFF
--- a/backend/modules/habits/habitService.js
+++ b/backend/modules/habits/habitService.js
@@ -1,31 +1,30 @@
+'use strict';
+
 const { RecurringCompletion } = require('../../models');
 const { Op } = require('sequelize');
 
 class HabitService {
-    /**
-     * Log a habit completion
-     * Updates streak counters and creates completion record
-     */
     async logCompletion(task, completedAt = new Date()) {
         if (!task.habit_mode) {
             throw new Error('Task is not a habit');
         }
 
-        const dayStart = new Date(completedAt);
-        dayStart.setHours(0, 0, 0, 0);
-        const dayEnd = new Date(completedAt);
-        dayEnd.setHours(23, 59, 59, 999);
+        const period = task.habit_frequency_period || 'daily';
+        const { start: periodStart, end: periodEnd } = this.getPeriodWindow(
+            period,
+            completedAt
+        );
 
-        const existingToday = await RecurringCompletion.findOne({
+        const existingInPeriod = await RecurringCompletion.findOne({
             where: {
                 task_id: task.id,
                 skipped: false,
-                completed_at: { [Op.between]: [dayStart, dayEnd] },
+                completed_at: { [Op.between]: [periodStart, periodEnd] },
             },
         });
 
-        if (existingToday) {
-            return { completion: existingToday, task };
+        if (existingInPeriod) {
+            return { completion: existingInPeriod, task };
         }
 
         const completion = await RecurringCompletion.create({
@@ -35,7 +34,7 @@ class HabitService {
             skipped: false,
         });
 
-        // Update cached counters and mark as done for today
+        // Update cached counters and mark as done for the period
         const updates = await this.calculateStreakUpdates(task, completedAt);
         updates.status = 2; // Mark as done
         updates.completed_at = completedAt;
@@ -44,21 +43,92 @@ class HabitService {
         return { completion, task };
     }
 
-    /**
-     * Calculate streak updates based on completion
-     * This is the core habit logic
-     */
+    // Returns the start of the period (Monday for weekly, 1st for monthly, midnight for daily)
+    getPeriodStart(period, date) {
+        const d = new Date(date);
+        if (period === 'weekly') {
+            const day = d.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+            const diff = day === 0 ? -6 : 1 - day; // back to Monday
+            d.setDate(d.getDate() + diff);
+        } else if (period === 'monthly') {
+            d.setDate(1);
+        }
+        d.setHours(0, 0, 0, 0);
+        return d;
+    }
+
+    // Returns the start of the previous period
+    getPreviousPeriodStart(period, periodStart) {
+        const d = new Date(periodStart);
+        if (period === 'weekly') {
+            d.setDate(d.getDate() - 7);
+        } else if (period === 'monthly') {
+            d.setMonth(d.getMonth() - 1);
+        } else {
+            d.setDate(d.getDate() - 1);
+        }
+        return d;
+    }
+
+    // Returns the start of the next period (used for best-streak calculation)
+    getNextPeriodStart(period, periodStart) {
+        const d = new Date(periodStart);
+        if (period === 'weekly') {
+            d.setDate(d.getDate() + 7);
+        } else if (period === 'monthly') {
+            d.setMonth(d.getMonth() + 1);
+        } else {
+            d.setDate(d.getDate() + 1);
+        }
+        return d;
+    }
+
+    // Returns {start, end} bounding the entire period that contains asOfDate
+    getPeriodWindow(period, asOfDate) {
+        const start = this.getPeriodStart(period, asOfDate);
+        const end = new Date(start);
+        if (period === 'weekly') {
+            end.setDate(start.getDate() + 6);
+            end.setHours(23, 59, 59, 999);
+        } else if (period === 'monthly') {
+            end.setMonth(start.getMonth() + 1, 0); // last day of current month
+            end.setHours(23, 59, 59, 999);
+        } else {
+            end.setHours(23, 59, 59, 999);
+        }
+        return { start, end };
+    }
+
+    // Current streak: consecutive periods (counting backward from asOfDate) each with ≥1 completion
+    calculatePeriodStreak(completions, asOfDate, period) {
+        if (!completions.length) return 0;
+
+        const completionPeriods = new Set(
+            completions.map((c) =>
+                this.getPeriodStart(period, new Date(c.completed_at)).getTime()
+            )
+        );
+
+        let streak = 0;
+        let current = this.getPeriodStart(period, asOfDate);
+
+        while (completionPeriods.has(current.getTime())) {
+            streak++;
+            current = this.getPreviousPeriodStart(period, current);
+        }
+
+        return streak;
+    }
+
     async calculateStreakUpdates(task, completedAt) {
         const updates = {
             habit_total_completions: task.habit_total_completions + 1,
             habit_last_completion_at: completedAt,
         };
 
-        // Calculate new streak
         const newStreak = await this.calculateCurrentStreak(task, completedAt);
         updates.habit_current_streak = newStreak;
 
-        // Update best streak if needed
         if (newStreak > task.habit_best_streak) {
             updates.habit_best_streak = newStreak;
         }
@@ -66,9 +136,6 @@ class HabitService {
         return updates;
     }
 
-    /**
-     * Recalculate all streak values after a completion is deleted
-     */
     async recalculateStreaks(task) {
         const completions = await RecurringCompletion.findAll({
             where: {
@@ -78,80 +145,75 @@ class HabitService {
             order: [['completed_at', 'DESC']],
         });
 
-        const distinctDays = new Set(
-            completions.map((c) => {
-                const d = new Date(c.completed_at);
-                d.setHours(0, 0, 0, 0);
-                return d.getTime();
-            })
+        const period = task.habit_frequency_period || 'daily';
+
+        const distinctPeriods = new Set(
+            completions.map((c) =>
+                this.getPeriodStart(period, new Date(c.completed_at)).getTime()
+            )
         ).size;
 
         const updates = {
-            habit_total_completions: distinctDays,
+            habit_total_completions: distinctPeriods,
             habit_last_completion_at:
                 completions.length > 0 ? completions[0].completed_at : null,
         };
 
-        // Calculate current streak
         updates.habit_current_streak =
             completions.length > 0
-                ? this.calculateCalendarStreak(completions, new Date())
+                ? this.calculatePeriodStreak(completions, new Date(), period)
                 : 0;
 
-        // Calculate best streak (need to check all possible streaks)
-        updates.habit_best_streak = this.calculateBestStreak(completions);
+        updates.habit_best_streak = this.calculateBestStreak(
+            completions,
+            period
+        );
 
         return updates;
     }
 
-    /**
-     * Calculate the best (longest) streak from completion history
-     */
-    calculateBestStreak(completions) {
+    // Best streak ever achieved: longest run of consecutive completed periods
+    calculateBestStreak(completions, period = 'daily') {
         if (completions.length === 0) return 0;
+
+        // Normalize to period starts and deduplicate, sorted ascending
+        const periodStarts = [
+            ...new Set(
+                completions.map((c) =>
+                    this.getPeriodStart(
+                        period,
+                        new Date(c.completed_at)
+                    ).getTime()
+                )
+            ),
+        ].sort((a, b) => a - b);
 
         let bestStreak = 0;
         let currentStreak = 0;
-        let lastDate = null;
+        let lastPeriodStart = null;
 
-        // Sort by date ascending for this calculation
-        const sorted = [...completions].sort(
-            (a, b) => new Date(a.completed_at) - new Date(b.completed_at)
-        );
-
-        for (const completion of sorted) {
-            const completedDate = new Date(completion.completed_at);
-            completedDate.setHours(0, 0, 0, 0);
-
-            if (!lastDate) {
+        for (const ts of periodStarts) {
+            const current = new Date(ts);
+            if (!lastPeriodStart) {
                 currentStreak = 1;
             } else {
-                const diffDays = Math.floor(
-                    (completedDate - lastDate) / (1000 * 60 * 60 * 24)
+                const expectedNext = this.getNextPeriodStart(
+                    period,
+                    lastPeriodStart
                 );
-
-                if (diffDays === 1) {
-                    // Consecutive day
+                if (current.getTime() === expectedNext.getTime()) {
                     currentStreak++;
-                } else if (diffDays === 0) {
-                    // Same day, don't change streak
-                    continue;
                 } else {
-                    // Streak broken
                     bestStreak = Math.max(bestStreak, currentStreak);
                     currentStreak = 1;
                 }
             }
-
-            lastDate = new Date(completedDate);
+            lastPeriodStart = current;
         }
 
         return Math.max(bestStreak, currentStreak);
     }
 
-    /**
-     * Calculate current streak based on streak mode
-     */
     async calculateCurrentStreak(task, asOfDate = new Date()) {
         const completions = await RecurringCompletion.findAll({
             where: {
@@ -163,59 +225,26 @@ class HabitService {
 
         if (completions.length === 0) return 0;
 
+        const period = task.habit_frequency_period || 'daily';
+
         if (task.habit_streak_mode === 'calendar') {
-            return this.calculateCalendarStreak(completions, asOfDate);
+            return this.calculatePeriodStreak(completions, asOfDate, period);
         } else {
             return this.calculateScheduledStreak(task, completions, asOfDate);
         }
     }
 
-    /**
-     * Calendar streak: consecutive days with completions
-     */
+    // Calendar streak delegates to period-aware implementation
     calculateCalendarStreak(completions, asOfDate) {
-        let streak = 0;
-        let currentDate = new Date(asOfDate);
-        currentDate.setHours(0, 0, 0, 0);
-
-        const completionDates = completions.map((c) => {
-            const d = new Date(c.completed_at);
-            d.setHours(0, 0, 0, 0);
-            return d.getTime();
-        });
-
-        const uniqueDates = [...new Set(completionDates)].sort((a, b) => b - a);
-
-        for (const dateTimestamp of uniqueDates) {
-            const expectedDate = currentDate.getTime();
-            if (dateTimestamp === expectedDate) {
-                streak++;
-                currentDate.setDate(currentDate.getDate() - 1);
-            } else if (dateTimestamp < expectedDate) {
-                break; // Gap in streak
-            }
-        }
-
-        return streak;
+        return this.calculatePeriodStreak(completions, asOfDate, 'daily');
     }
 
-    /**
-     * Scheduled streak: consecutive scheduled occurrences completed
-     * Uses recurrence pattern to determine expected dates
-     */
+    // Scheduled streak uses the task's frequency period
     calculateScheduledStreak(task, completions, asOfDate) {
-        // Implementation depends on recurrence pattern
-        // For MVP: simplified version - count consecutive scheduled periods with completions
-        // Full implementation would use recurringTaskService to calculate expected dates
-
-        // Simplified: treat as calendar streak for now
-        // TODO: Implement full scheduled streak logic in Phase 2
-        return this.calculateCalendarStreak(completions, asOfDate);
+        const period = task.habit_frequency_period || 'daily';
+        return this.calculatePeriodStreak(completions, asOfDate, period);
     }
 
-    /**
-     * Get habit statistics for a period
-     */
     async getHabitStats(task, startDate, endDate) {
         const completions = await RecurringCompletion.findAll({
             where: {
@@ -231,7 +260,6 @@ class HabitService {
         const totalCompletions = completions.length;
         const currentStreak = task.habit_current_streak;
 
-        // Calculate completion rate if target is set
         let completionRate = null;
         if (task.habit_target_count && task.habit_frequency_period) {
             const target = this.calculatePeriodTarget(task, startDate, endDate);
@@ -250,9 +278,6 @@ class HabitService {
         };
     }
 
-    /**
-     * Calculate target completions for a date range
-     */
     calculatePeriodTarget(task, startDate, endDate) {
         if (!task.habit_target_count || !task.habit_frequency_period) {
             return 0;
@@ -272,16 +297,10 @@ class HabitService {
         }
     }
 
-    /**
-     * Check if habit is due today based on flexibility mode
-     */
     isDueToday(task, today = new Date()) {
         if (task.habit_flexibility_mode === 'flexible') {
-            // Flexible: always available
             return true;
         } else {
-            // Strict: check if today matches recurrence pattern
-            // Leverage existing recurringTaskService logic
             const {
                 calculateNextDueDate,
             } = require('../tasks/recurringTaskService');

--- a/backend/tests/unit/modules/habits/habitService.test.js
+++ b/backend/tests/unit/modules/habits/habitService.test.js
@@ -1,0 +1,204 @@
+'use strict';
+
+jest.mock('../../../../models', () => ({
+    RecurringCompletion: {
+        findOne: jest.fn(),
+        findAll: jest.fn(),
+        create: jest.fn(),
+    },
+}));
+
+const habitService = require('../../../../modules/habits/habitService');
+
+function makeCompletion(isoDate) {
+    return { completed_at: isoDate, skipped: false };
+}
+
+describe('HabitService - getPeriodStart', () => {
+    it('returns midnight of the same day for daily', () => {
+        const date = new Date('2026-08-06T14:30:00');
+        const result = habitService.getPeriodStart('daily', date);
+        expect(result.getFullYear()).toBe(2026);
+        expect(result.getMonth()).toBe(7); // August
+        expect(result.getDate()).toBe(6);
+        expect(result.getHours()).toBe(0);
+        expect(result.getMinutes()).toBe(0);
+    });
+
+    it('returns the Monday of the week for weekly', () => {
+        // 2026-08-06 is a Thursday
+        const thursday = new Date('2026-08-06T10:00:00');
+        const result = habitService.getPeriodStart('weekly', thursday);
+        expect(result.getDate()).toBe(3); // Monday 2026-08-03
+        expect(result.getMonth()).toBe(7);
+        expect(result.getFullYear()).toBe(2026);
+        expect(result.getHours()).toBe(0);
+    });
+
+    it('handles Sunday as last day of week (not first)', () => {
+        const sunday = new Date('2026-08-09T10:00:00');
+        const result = habitService.getPeriodStart('weekly', sunday);
+        expect(result.getDate()).toBe(3); // same week Monday
+    });
+
+    it('returns the 1st of the month for monthly', () => {
+        const date = new Date('2026-08-15T10:00:00');
+        const result = habitService.getPeriodStart('monthly', date);
+        expect(result.getDate()).toBe(1);
+        expect(result.getMonth()).toBe(7);
+        expect(result.getFullYear()).toBe(2026);
+    });
+});
+
+describe('HabitService - getPeriodWindow', () => {
+    it('daily window spans the full day', () => {
+        const date = new Date('2026-08-06T14:00:00');
+        const { start, end } = habitService.getPeriodWindow('daily', date);
+        expect(start.getHours()).toBe(0);
+        expect(end.getHours()).toBe(23);
+        expect(end.getMinutes()).toBe(59);
+        expect(start.getDate()).toBe(6);
+        expect(end.getDate()).toBe(6);
+    });
+
+    it('weekly window spans Monday–Sunday', () => {
+        const thursday = new Date('2026-08-06T10:00:00');
+        const { start, end } = habitService.getPeriodWindow('weekly', thursday);
+        expect(start.getDate()).toBe(3); // Monday
+        expect(end.getDate()).toBe(9); // Sunday
+        expect(end.getHours()).toBe(23);
+        expect(end.getMinutes()).toBe(59);
+    });
+
+    it('monthly window spans the full calendar month', () => {
+        const date = new Date('2026-02-15T10:00:00');
+        const { start, end } = habitService.getPeriodWindow('monthly', date);
+        expect(start.getDate()).toBe(1);
+        expect(end.getDate()).toBe(28); // Feb 2026 has 28 days
+        expect(end.getMonth()).toBe(1);
+        expect(end.getHours()).toBe(23);
+    });
+});
+
+describe('HabitService - calculatePeriodStreak', () => {
+    it('returns 0 for no completions', () => {
+        expect(
+            habitService.calculatePeriodStreak([], new Date(), 'daily')
+        ).toBe(0);
+    });
+
+    it('daily: counts consecutive days', () => {
+        const today = new Date('2026-08-06T10:00:00');
+        const completions = [
+            makeCompletion('2026-08-06T09:00:00'),
+            makeCompletion('2026-08-05T09:00:00'),
+            makeCompletion('2026-08-04T09:00:00'),
+        ];
+        expect(
+            habitService.calculatePeriodStreak(completions, today, 'daily')
+        ).toBe(3);
+    });
+
+    it('daily: streak breaks on gap', () => {
+        const today = new Date('2026-08-06T10:00:00');
+        const completions = [
+            makeCompletion('2026-08-06T09:00:00'),
+            makeCompletion('2026-08-04T09:00:00'), // gap on Aug 5
+        ];
+        expect(
+            habitService.calculatePeriodStreak(completions, today, 'daily')
+        ).toBe(1);
+    });
+
+    it('weekly: counts consecutive weeks', () => {
+        // 2026-08-06 is Thursday, in week of Aug 3
+        const today = new Date('2026-08-06T10:00:00');
+        const completions = [
+            makeCompletion('2026-08-05T09:00:00'), // this week (Aug 3–9)
+            makeCompletion('2026-07-28T09:00:00'), // prev week (Jul 27 – Aug 2)
+            makeCompletion('2026-07-21T09:00:00'), // week before (Jul 20–26)
+        ];
+        expect(
+            habitService.calculatePeriodStreak(completions, today, 'weekly')
+        ).toBe(3);
+    });
+
+    it('weekly: streak is 0 when current week has no completion', () => {
+        const today = new Date('2026-08-06T10:00:00'); // week of Aug 3
+        const completions = [
+            makeCompletion('2026-07-28T09:00:00'), // last week only
+        ];
+        expect(
+            habitService.calculatePeriodStreak(completions, today, 'weekly')
+        ).toBe(0);
+    });
+
+    it('weekly: multiple completions in same week count as 1', () => {
+        const today = new Date('2026-08-06T10:00:00');
+        const completions = [
+            makeCompletion('2026-08-04T09:00:00'), // Tue this week
+            makeCompletion('2026-08-05T09:00:00'), // Wed this week
+            makeCompletion('2026-07-28T09:00:00'), // prev week
+        ];
+        expect(
+            habitService.calculatePeriodStreak(completions, today, 'weekly')
+        ).toBe(2);
+    });
+
+    it('monthly: counts consecutive months', () => {
+        const today = new Date('2026-08-06T10:00:00');
+        const completions = [
+            makeCompletion('2026-08-05T09:00:00'), // August
+            makeCompletion('2026-07-15T09:00:00'), // July
+            makeCompletion('2026-06-10T09:00:00'), // June
+        ];
+        expect(
+            habitService.calculatePeriodStreak(completions, today, 'monthly')
+        ).toBe(3);
+    });
+
+    it('monthly: streak is 0 when current month has no completion', () => {
+        const today = new Date('2026-08-06T10:00:00');
+        const completions = [
+            makeCompletion('2026-07-15T09:00:00'), // last month only
+        ];
+        expect(
+            habitService.calculatePeriodStreak(completions, today, 'monthly')
+        ).toBe(0);
+    });
+});
+
+describe('HabitService - calculateBestStreak', () => {
+    it('returns 0 for no completions', () => {
+        expect(habitService.calculateBestStreak([], 'daily')).toBe(0);
+    });
+
+    it('daily: finds the longest consecutive run', () => {
+        const completions = [
+            makeCompletion('2026-08-01T09:00:00'),
+            makeCompletion('2026-08-02T09:00:00'),
+            makeCompletion('2026-08-03T09:00:00'),
+            makeCompletion('2026-08-05T09:00:00'), // gap
+            makeCompletion('2026-08-06T09:00:00'),
+        ];
+        expect(habitService.calculateBestStreak(completions, 'daily')).toBe(3);
+    });
+
+    it('weekly: consecutive weeks form best streak', () => {
+        const completions = [
+            makeCompletion('2026-07-07T09:00:00'), // week of Jul 6
+            makeCompletion('2026-07-14T09:00:00'), // week of Jul 13
+            makeCompletion('2026-07-21T09:00:00'), // week of Jul 20
+            makeCompletion('2026-08-05T09:00:00'), // week of Aug 3 (gap)
+        ];
+        expect(habitService.calculateBestStreak(completions, 'weekly')).toBe(3);
+    });
+
+    it('weekly: defaults to daily behavior when period not provided', () => {
+        const completions = [
+            makeCompletion('2026-08-01T09:00:00'),
+            makeCompletion('2026-08-02T09:00:00'),
+        ];
+        expect(habitService.calculateBestStreak(completions)).toBe(2);
+    });
+});

--- a/frontend/components/Habits/HabitCard.tsx
+++ b/frontend/components/Habits/HabitCard.tsx
@@ -8,6 +8,7 @@ import {
 import { CheckCircleIcon as CheckCircleSolid } from '@heroicons/react/24/solid';
 import { useTranslation } from 'react-i18next';
 import { fetchHabitCompletions } from '../../utils/habitsService';
+import { isHabitCompletedInPeriod } from '../../utils/habitUtils';
 
 interface HabitCardProps {
     habit: Task;
@@ -58,16 +59,7 @@ const HabitCard: React.FC<HabitCardProps> = ({ habit, onComplete, onEdit }) => {
 
     const days = last30Days();
 
-    const isCompletedToday = (() => {
-        if (!habit.habit_last_completion_at) return false;
-        const last = new Date(habit.habit_last_completion_at);
-        const today = new Date();
-        return (
-            last.getFullYear() === today.getFullYear() &&
-            last.getMonth() === today.getMonth() &&
-            last.getDate() === today.getDate()
-        );
-    })();
+    const isCompletedToday = isHabitCompletedInPeriod(habit);
 
     const frequencyLabel =
         habit.habit_target_count && habit.habit_frequency_period

--- a/frontend/components/Habits/HabitsTodayWidget.tsx
+++ b/frontend/components/Habits/HabitsTodayWidget.tsx
@@ -3,6 +3,7 @@ import { useStore } from '../../store/useStore';
 import { CheckCircleIcon, FireIcon } from '@heroicons/react/24/outline';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { isHabitCompletedInPeriod } from '../../utils/habitUtils';
 
 /**
  * Compact widget for Today view showing today's habits
@@ -18,7 +19,9 @@ const HabitsTodayWidget: React.FC = () => {
         loadHabits();
     }, [loadHabits]);
 
-    const habitsForToday = habits.filter((h) => h.status !== 3); // Not archived
+    const habitsForToday = habits.filter(
+        (h) => h.status !== 3 && !isHabitCompletedInPeriod(h)
+    );
 
     if (habitsForToday.length === 0) return null;
 

--- a/frontend/utils/habitUtils.ts
+++ b/frontend/utils/habitUtils.ts
@@ -1,0 +1,38 @@
+import { Task } from '../entities/Task';
+
+function getWeekStart(date: Date): Date {
+    const d = new Date(date);
+    const day = d.getDay(); // 0=Sun, 1=Mon, ..., 6=Sat
+    const diff = day === 0 ? -6 : 1 - day; // adjust back to Monday
+    d.setDate(d.getDate() + diff);
+    d.setHours(0, 0, 0, 0);
+    return d;
+}
+
+export function isHabitCompletedInPeriod(
+    habit: Task,
+    now: Date = new Date()
+): boolean {
+    if (!habit.habit_last_completion_at) return false;
+    const last = new Date(habit.habit_last_completion_at);
+    const period = habit.habit_frequency_period ?? 'daily';
+
+    if (period === 'weekly') {
+        const weekStart = getWeekStart(now);
+        const weekEnd = new Date(weekStart);
+        weekEnd.setDate(weekStart.getDate() + 6);
+        weekEnd.setHours(23, 59, 59, 999);
+        return last >= weekStart && last <= weekEnd;
+    } else if (period === 'monthly') {
+        return (
+            last.getFullYear() === now.getFullYear() &&
+            last.getMonth() === now.getMonth()
+        );
+    } else {
+        return (
+            last.getFullYear() === now.getFullYear() &&
+            last.getMonth() === now.getMonth() &&
+            last.getDate() === now.getDate()
+        );
+    }
+}


### PR DESCRIPTION
## Description

Weekly and monthly habits were incorrectly behaving like daily habits. The same-day window was used everywhere regardless of `habit_frequency_period`, causing three observable bugs:

1. **Habit resets the next day** — `isCompletedToday` in `HabitCard.tsx` and the widget filter only checked whether `habit_last_completion_at` was today. For a weekly habit completed on Monday, it showed as pending again on Tuesday.
2. **Streak shows 0** — `calculateCalendarStreak` stepped back one calendar day at a time. A weekly habit completed once per week had a gap every single day, breaking the streak immediately.
3. **Duplicate completions** — `logCompletion`'s duplicate guard used a same-day `[dayStart, dayEnd]` window. On Tuesday through Sunday, it allowed logging again for a weekly habit, inflating `habit_total_completions`.

## Changes

**Backend (`habitService.js`):**
- Added `getPeriodStart(period, date)` — normalises a date to Monday midnight (weekly), 1st of month midnight (monthly), or today midnight (daily)
- Added `getPeriodWindow(period, asOfDate)` — returns `{start, end}` for the full current period
- Replaced the same-day duplicate guard in `logCompletion` with `getPeriodWindow`
- Added `calculatePeriodStreak(completions, asOfDate, period)` — groups completions into periods and counts consecutive periods walking backward; replaces the broken `calculateCalendarStreak` (daily-only) and stub `calculateScheduledStreak`
- Updated `calculateBestStreak` to accept `period` and use period normalization
- Updated `recalculateStreaks` to count distinct periods (not distinct days) and use the new streak logic

**Frontend:**
- New `frontend/utils/habitUtils.ts` with `isHabitCompletedInPeriod(habit)` — checks `habit_last_completion_at` against the current day/week/month based on `habit_frequency_period`
- `HabitCard.tsx` — replaced the inline `isCompletedToday` IIFE with `isHabitCompletedInPeriod`
- `HabitsTodayWidget.tsx` — added `!isHabitCompletedInPeriod(h)` to the filter so already-completed habits are hidden

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issues

Fixes #1360

## Testing

```bash
npm run backend:test:unit    # 745 tests, all pass
npm run backend:lint         # 0 errors
npm run frontend:lint        # 0 errors
```

New unit tests added in `backend/tests/unit/modules/habits/habitService.test.js` covering:
- `getPeriodStart` for daily/weekly/monthly, including Sunday edge case
- `getPeriodWindow` boundaries for all three periods
- `calculatePeriodStreak` for consecutive and gapped runs in all periods, including the multi-completion-per-period deduplication case
- `calculateBestStreak` for daily and weekly periods

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix is effective
- [x] New and existing tests pass
- [x] I have run linting without errors