### PR TITLE
fix(tasks, caldav): make "ghost tasks" deletable and stop them coming back

### DIFF
--- a/backend/middleware/authorize.js
+++ b/backend/middleware/authorize.js
@@ -23,6 +23,19 @@ function hasAccess(requiredAccess, resourceType, getResourceUid, options = {}) {
             if (forbiddenStatus === 404) {
                 return res.status(404).json({ error: notFoundMessage });
             }
+
+            // A resource that no longer exists is not "forbidden" - it is gone.
+            // Answering 403 here leaves clients holding a stale uid (a deleted
+            // or never-synced task) unable to tell the two apart, so the row
+            // can never be cleared from the UI.
+            const exists = await permissionsService.resourceExists(
+                resourceType,
+                uid
+            );
+            if (!exists) {
+                return res.status(404).json({ error: notFoundMessage });
+            }
+
             return res.status(403).json({ error: 'Forbidden' });
         } catch (err) {
             next(err);

--- a/backend/migrations/20260809000001-add-remote-href-to-caldav-sync-state.js
+++ b/backend/migrations/20260809000001-add-remote-href-to-caldav-sync-state.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const { safeAddColumns } = require('../utils/migration-utils');
+
+const INDEX_NAME = 'caldav_sync_state_calendar_href_idx';
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await safeAddColumns(queryInterface, 'caldav_sync_state', [
+            {
+                name: 'remote_href',
+                definition: {
+                    type: Sequelize.STRING,
+                    allowNull: true,
+                },
+            },
+        ]);
+
+        // Not safeAddIndex: it treats an index as present when any one of the
+        // requested fields is already indexed, and calendar_id is, so the
+        // composite index would silently never be created.
+        const indexes = await queryInterface.showIndex('caldav_sync_state');
+        if (!indexes.some((index) => index.name === INDEX_NAME)) {
+            await queryInterface.addIndex(
+                'caldav_sync_state',
+                ['calendar_id', 'remote_href'],
+                { name: INDEX_NAME }
+            );
+        }
+    },
+
+    async down(queryInterface) {
+        await queryInterface.removeIndex('caldav_sync_state', INDEX_NAME);
+        await queryInterface.removeColumn('caldav_sync_state', 'remote_href');
+    },
+};

--- a/backend/models/caldav_sync_state.js
+++ b/backend/models/caldav_sync_state.js
@@ -29,6 +29,13 @@ module.exports = (sequelize) => {
                 type: DataTypes.STRING,
                 allowNull: false,
             },
+            // Path of the resource on the remote server. Set from the href the
+            // server reported, because a CalDAV resource is not required to live
+            // at <uid>.ics and externally created ones generally do not.
+            remote_href: {
+                type: DataTypes.STRING,
+                allowNull: true,
+            },
             last_modified: {
                 type: DataTypes.DATE,
                 allowNull: false,
@@ -79,6 +86,9 @@ module.exports = (sequelize) => {
                 },
                 {
                     fields: ['sync_status'],
+                },
+                {
+                    fields: ['calendar_id', 'remote_href'],
                 },
                 {
                     fields: ['task_id', 'calendar_id'],

--- a/backend/modules/caldav/repositories/sync-state-repository.js
+++ b/backend/modules/caldav/repositories/sync-state-repository.js
@@ -1,5 +1,6 @@
 const BaseRepository = require('../../../shared/database/BaseRepository');
 const { CalDAVSyncState } = require('../../../models');
+const { normalizeHref } = require('../utils/href-utils');
 
 class SyncStateRepository extends BaseRepository {
     constructor() {
@@ -23,6 +24,16 @@ class SyncStateRepository extends BaseRepository {
 
     async findByETag(etag, options = {}) {
         return this.findOne({ etag }, options);
+    }
+
+    async findByCalendarAndHref(calendarId, remoteHref, options = {}) {
+        const href = normalizeHref(remoteHref);
+        if (!href) return null;
+
+        return this.findOne(
+            { calendar_id: calendarId, remote_href: href },
+            options
+        );
     }
 
     async findConflicts(calendarId = null, options = {}) {
@@ -170,10 +181,32 @@ class SyncStateRepository extends BaseRepository {
         const syncStates = await this.findByCalendarId(calendarId, options);
 
         await Promise.all(
-            syncStates.map((state) => this.delete(state, options))
+            syncStates.map((state) => this.destroy(state, options))
         );
 
         return syncStates.length;
+    }
+
+    async deleteByTaskId(taskId, options = {}) {
+        const syncStates = await this.findByTaskId(taskId, options);
+
+        await Promise.all(
+            syncStates.map((state) => this.destroy(state, options))
+        );
+
+        return syncStates.length;
+    }
+
+    async deleteByTaskAndCalendar(taskId, calendarId, options = {}) {
+        const syncState = await this.findByTaskAndCalendar(
+            taskId,
+            calendarId,
+            options
+        );
+        if (!syncState) return 0;
+
+        await this.destroy(syncState, options);
+        return 1;
     }
 }
 

--- a/backend/modules/caldav/services/task-deletion-service.js
+++ b/backend/modules/caldav/services/task-deletion-service.js
@@ -1,0 +1,70 @@
+const logger = require('../../../services/logService');
+const SyncStateRepository = require('../repositories/sync-state-repository');
+const CalendarRepository = require('../repositories/calendar-repository');
+const RemoteCalendarRepository = require('../repositories/remote-calendar-repository');
+const PushPhase = require('../sync/push-phase');
+
+const pushPhase = new PushPhase();
+
+// A task deleted in Tududi has to be deleted on every CalDAV server it was
+// pulled from. Without this the next pull still finds the VTODO, no local task
+// matches it, and the merge phase re-creates the row - the task comes back after
+// every delete, which is the "ghost task" in #1371.
+//
+// Must run before the task row is destroyed: the sync state is looked up by
+// task id, and the remote DELETE needs the task's uid.
+async function deleteTaskFromRemotes(task) {
+    const result = { attempted: 0, deleted: 0, errors: [] };
+
+    const syncStates = await SyncStateRepository.findByTaskId(task.id);
+    if (syncStates.length === 0) {
+        return result;
+    }
+
+    for (const syncState of syncStates) {
+        const calendar = await CalendarRepository.findById(
+            syncState.calendar_id
+        );
+        const remoteCalendar = calendar
+            ? await RemoteCalendarRepository.findByLocalCalendarId(calendar.id)
+            : null;
+
+        if (!remoteCalendar || !remoteCalendar.enabled) {
+            continue;
+        }
+
+        result.attempted++;
+
+        try {
+            await pushPhase.deleteTaskFromRemote(
+                task,
+                remoteCalendar,
+                calendar
+            );
+            result.deleted++;
+        } catch (error) {
+            // Deleting locally is still the right outcome - the user asked for
+            // it - but say plainly that the remote copy survived, because the
+            // next pull will bring the task back.
+            logger.logError(
+                `Failed to delete task ${task.uid} from remote calendar ${remoteCalendar.id}: ${error.message}. The task may reappear on the next sync.`,
+                error
+            );
+            result.errors.push({
+                remoteCalendarId: remoteCalendar.id,
+                error: error.message,
+            });
+        }
+    }
+
+    // Tasks are destroyed with foreign keys disabled, so the ON DELETE CASCADE
+    // never fires and any state left by a failed or skipped remote would be
+    // orphaned.
+    await SyncStateRepository.deleteByTaskId(task.id);
+
+    return result;
+}
+
+module.exports = {
+    deleteTaskFromRemotes,
+};

--- a/backend/modules/caldav/sync/merge-phase.js
+++ b/backend/modules/caldav/sync/merge-phase.js
@@ -5,6 +5,7 @@ const SyncStateRepository = require('../repositories/sync-state-repository');
 const CalendarRepository = require('../repositories/calendar-repository');
 const ConflictResolver = require('./conflict-resolver');
 const { uid: generateUid } = require('../../../utils/uid');
+const { normalizeHref, extractUidFromHref } = require('../utils/href-utils');
 
 class MergePhase {
     async execute(calendar, changedTasks, options = {}) {
@@ -58,26 +59,50 @@ class MergePhase {
     }
 
     async _handleDeletion(change, calendar, dryRun, results) {
-        const uid = this._extractUidFromHref(change.href);
-        const existingTask = await Task.findOne({
-            where: { uid, user_id: calendar.user_id },
-        });
+        // Resolve by the href we recorded when the task was pulled. Only fall
+        // back to reading a uid out of the filename for sync states written
+        // before remote_href existed - for an externally created resource that
+        // filename is not the uid, and guessing finds the wrong task or none.
+        const hrefState = await SyncStateRepository.findByCalendarAndHref(
+            calendar.id,
+            change.href
+        );
+
+        const uid = extractUidFromHref(change.href);
+
+        const existingTask = hrefState
+            ? await Task.findOne({
+                  where: { id: hrefState.task_id, user_id: calendar.user_id },
+              })
+            : await Task.findOne({
+                  where: { uid, user_id: calendar.user_id },
+              });
 
         if (!existingTask) {
             logger.logInfo(
-                `Task ${uid} already deleted or doesn't exist, skipping`
+                `Task for ${change.href} already deleted or doesn't exist, skipping`
             );
+
+            // The row is gone but its sync state may not be: the task table is
+            // written with foreign keys disabled, so the cascade never fires.
+            if (!dryRun && hrefState) {
+                await SyncStateRepository.destroy(hrefState);
+            }
             return;
         }
 
-        const syncState = await SyncStateRepository.findByTaskAndCalendar(
-            existingTask.id,
-            calendar.id
-        );
+        const taskUid = existingTask.uid;
+
+        const syncState =
+            hrefState ||
+            (await SyncStateRepository.findByTaskAndCalendar(
+                existingTask.id,
+                calendar.id
+            ));
 
         if (syncState && existingTask.updated_at > syncState.last_synced_at) {
             logger.logInfo(
-                `Task ${uid} was modified locally after remote deletion, conflict detected`
+                `Task ${taskUid} was modified locally after remote deletion, conflict detected`
             );
 
             if (!dryRun) {
@@ -90,7 +115,7 @@ class MergePhase {
             }
 
             results.conflicts.push({
-                uid,
+                uid: taskUid,
                 taskId: existingTask.id,
                 type: 'remote_deleted_local_modified',
             });
@@ -102,8 +127,8 @@ class MergePhase {
             await SyncStateRepository.deleteByTaskId(existingTask.id);
         }
 
-        results.deleted.push({ uid, taskId: existingTask.id });
-        logger.logInfo(`Task ${uid} deleted`);
+        results.deleted.push({ uid: taskUid, taskId: existingTask.id });
+        logger.logInfo(`Task ${taskUid} deleted`);
     }
 
     async _handleCreateOrUpdate(change, calendar, dryRun, results) {
@@ -144,7 +169,9 @@ class MergePhase {
                 calendar,
                 etag,
                 dryRun,
-                results
+                results,
+                null,
+                href
             );
             return;
         }
@@ -161,7 +188,8 @@ class MergePhase {
                 etag,
                 dryRun,
                 results,
-                existingTask
+                existingTask,
+                href
             );
             return;
         }
@@ -196,7 +224,8 @@ class MergePhase {
                 calendar,
                 etag,
                 dryRun,
-                results
+                results,
+                href
             );
         }
     }
@@ -274,7 +303,8 @@ class MergePhase {
         etag,
         dryRun,
         results,
-        existingTask = null
+        existingTask = null,
+        href = null
     ) {
         if (dryRun) {
             results.merged.push({
@@ -304,6 +334,11 @@ class MergePhase {
 
         await SyncStateRepository.createOrUpdate(task.id, calendar.id, {
             etag,
+            // Omitted rather than nulled when the server gave no href, so an
+            // already-recorded path is never overwritten with nothing.
+            ...(normalizeHref(href)
+                ? { remote_href: normalizeHref(href) }
+                : {}),
             last_modified: new Date(),
             last_synced_at: new Date(),
             sync_status: 'synced',
@@ -324,7 +359,8 @@ class MergePhase {
         calendar,
         etag,
         dryRun,
-        results
+        results,
+        href = null
     ) {
         if (dryRun) {
             results.merged.push({
@@ -345,6 +381,11 @@ class MergePhase {
 
         await SyncStateRepository.createOrUpdate(existingTask.id, calendar.id, {
             etag,
+            // Omitted rather than nulled when the server gave no href, so an
+            // already-recorded path is never overwritten with nothing.
+            ...(normalizeHref(href)
+                ? { remote_href: normalizeHref(href) }
+                : {}),
             last_modified: new Date(),
             last_synced_at: new Date(),
             sync_status: 'synced',
@@ -467,11 +508,6 @@ class MergePhase {
         );
 
         return task;
-    }
-
-    _extractUidFromHref(href) {
-        const match = href.match(/([^/]+)\.ics$/);
-        return match ? match[1] : href;
     }
 }
 

--- a/backend/modules/caldav/sync/push-phase.js
+++ b/backend/modules/caldav/sync/push-phase.js
@@ -6,6 +6,7 @@ const SyncStateRepository = require('../repositories/sync-state-repository');
 const RemoteCalendarRepository = require('../repositories/remote-calendar-repository');
 const { serializeTaskToVTODO } = require('../icalendar/vtodo-serializer');
 const encryptionService = require('../services/encryption-service');
+const { buildRemoteTaskUrl, normalizeHref } = require('../utils/href-utils');
 
 class PushPhase {
     async execute(calendar, userId, options = {}) {
@@ -148,16 +149,21 @@ class PushPhase {
             remoteCalendar.password_encrypted
         );
 
-        const baseUrl = remoteCalendar.server_url.replace(/\/$/, '');
-        const calendarPath = remoteCalendar.calendar_path.replace(/^\//, '');
-        const taskUrl = `${baseUrl}/${calendarPath}/${task.uid}.ics`;
-
-        const vtodoString = await serializeTaskToVTODO(task);
-
         const syncState = await SyncStateRepository.findByTaskAndCalendar(
             task.id,
             calendar.id
         );
+
+        // Push to the path the resource actually lives at. Re-deriving it from
+        // the uid would PUT a second copy alongside the original for any task
+        // that was created by another CalDAV client.
+        const taskUrl = buildRemoteTaskUrl(
+            remoteCalendar,
+            syncState?.remote_href,
+            task.uid
+        );
+
+        const vtodoString = await serializeTaskToVTODO(task);
 
         try {
             const headers = {
@@ -187,6 +193,7 @@ class PushPhase {
 
             await SyncStateRepository.createOrUpdate(task.id, calendar.id, {
                 etag: newEtag || syncState?.etag,
+                remote_href: normalizeHref(taskUrl),
                 last_modified: new Date(),
                 last_synced_at: new Date(),
                 sync_status: 'synced',
@@ -245,9 +252,16 @@ class PushPhase {
             remoteCalendar.password_encrypted
         );
 
-        const baseUrl = remoteCalendar.server_url.replace(/\/$/, '');
-        const calendarPath = remoteCalendar.calendar_path.replace(/^\//, '');
-        const taskUrl = `${baseUrl}/${calendarPath}/${task.uid}.ics`;
+        const syncState = await SyncStateRepository.findByTaskAndCalendar(
+            task.id,
+            calendar.id
+        );
+
+        const taskUrl = buildRemoteTaskUrl(
+            remoteCalendar,
+            syncState?.remote_href,
+            task.uid
+        );
 
         try {
             await axios({
@@ -263,7 +277,10 @@ class PushPhase {
                 ),
             });
 
-            await SyncStateRepository.deleteByTaskId(task.id);
+            await SyncStateRepository.deleteByTaskAndCalendar(
+                task.id,
+                calendar.id
+            );
 
             logger.logInfo(`Task ${task.uid} successfully deleted from remote`);
 
@@ -277,7 +294,10 @@ class PushPhase {
                 logger.logInfo(
                     `Task ${task.uid} already deleted from remote, clearing sync state`
                 );
-                await SyncStateRepository.deleteByTaskId(task.id);
+                await SyncStateRepository.deleteByTaskAndCalendar(
+                    task.id,
+                    calendar.id
+                );
                 return {
                     taskId: task.id,
                     uid: task.uid,

--- a/backend/modules/caldav/utils/href-utils.js
+++ b/backend/modules/caldav/utils/href-utils.js
@@ -1,0 +1,51 @@
+// A CalDAV resource lives at a path the *creating* client chose, and only that
+// client gets to choose it. tasks.org, DAVx5 and iOS Reminders all store a VTODO
+// under a server- or client-generated filename that has nothing to do with its
+// UID, so the href reported by the server is the only reliable way back to a
+// remote object. Deriving the URL from the task uid instead reaches a resource
+// that does not exist.
+
+function normalizeHref(href) {
+    if (!href || typeof href !== 'string') return null;
+
+    const trimmed = href.trim();
+    if (!trimmed) return null;
+
+    // Absolute hrefs are legal in a multistatus response. Keeping only the path
+    // means a stored href stays valid if the server_url is later edited (host
+    // renamed, http -> https).
+    try {
+        return new URL(trimmed).pathname;
+    } catch {
+        return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+    }
+}
+
+function buildRemoteTaskUrl(remoteCalendar, remoteHref, taskUid) {
+    const baseUrl = remoteCalendar.server_url.replace(/\/$/, '');
+
+    const href = normalizeHref(remoteHref);
+    if (href) {
+        return `${baseUrl}${href}`;
+    }
+
+    // No href on record: the task has never been seen on this server, so Tududi
+    // is the creating client and picks the filename itself.
+    const calendarPath = remoteCalendar.calendar_path
+        .replace(/^\//, '')
+        .replace(/\/$/, '');
+    return `${baseUrl}/${calendarPath}/${taskUid}.ics`;
+}
+
+function extractUidFromHref(href) {
+    if (!href || typeof href !== 'string') return null;
+
+    const match = href.match(/([^/]+)\.ics$/i);
+    return match ? decodeURIComponent(match[1]) : href;
+}
+
+module.exports = {
+    normalizeHref,
+    buildRemoteTaskUrl,
+    extractUidFromHref,
+};

--- a/backend/modules/caldav/webdav/task-handlers.js
+++ b/backend/modules/caldav/webdav/task-handlers.js
@@ -3,9 +3,8 @@ const { matchesETag } = require('../utils/etag-generator');
 const taskRepository = require('../../tasks/repository');
 const vtodoSerializer = require('../icalendar/vtodo-serializer');
 const vtodoParser = require('../icalendar/vtodo-parser');
-const syncStateRepository = require('../repositories/sync-state-repository');
 const { resolveProjectIdForPut } = require('./projects');
-const { nanoid } = require('nanoid');
+const { deleteTaskFromRemotes } = require('../services/task-deletion-service');
 
 async function handleGetTask(req, res) {
     try {
@@ -158,6 +157,15 @@ async function handleDeleteTask(req, res) {
             if (!matchesETag(ifMatch, currentEtag)) {
                 return res.status(412).send('Precondition Failed');
             }
+        }
+
+        // Same reason as the REST delete route: a task removed here must also be
+        // removed from any CalDAV server Tududi pulls it from, or the next sync
+        // re-creates it (#1371).
+        try {
+            await deleteTaskFromRemotes(task);
+        } catch (error) {
+            console.error('CalDAV remote delete error:', error);
         }
 
         await taskRepository.delete(task.id, req.currentUser.id);

--- a/backend/modules/tasks/events.js
+++ b/backend/modules/tasks/events.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { Task, TaskEvent } = require('../../models');
 const { isValidUid } = require('../../utils/slug-utils');
+const { isValidTaskUid } = require('./utils/validation');
 const {
     getTaskTimeline,
     getTaskCompletionTime,
@@ -13,7 +14,7 @@ const router = express.Router();
 // GET /api/task/:uid/timeline - Get task event timeline
 router.get('/task/:uid/timeline', async (req, res) => {
     try {
-        if (!isValidUid(req.params.uid))
+        if (!isValidTaskUid(req.params.uid))
             return res.status(400).json({ error: 'Invalid UID' });
 
         const permissionsService = require('../../services/permissionsService');
@@ -49,7 +50,7 @@ router.get('/task/:uid/timeline', async (req, res) => {
 // GET /api/task/:uid/completion-time - Get task completion analytics
 router.get('/task/:uid/completion-time', async (req, res) => {
     try {
-        if (!isValidUid(req.params.uid))
+        if (!isValidTaskUid(req.params.uid))
             return res.status(400).json({ error: 'Invalid UID' });
 
         const permissionsService = require('../../services/permissionsService');

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -36,9 +36,9 @@ const {
     getUpcomingRangeInUTC,
 } = require('../../utils/timezone-utils');
 const permissionsService = require('../../services/permissionsService');
-const { isValidUid } = require('../../utils/slug-utils');
 
 const {
+    isValidTaskUid,
     validateProjectAccess,
     validateParentTaskAccess,
     validateDeferUntilAndDueDate,
@@ -1014,7 +1014,7 @@ router.delete('/task/:uid', requireTaskWriteAccess, async (req, res) => {
 
 router.get('/task/:uid/subtasks', async (req, res) => {
     try {
-        if (!isValidUid(req.params.uid)) {
+        if (!isValidTaskUid(req.params.uid)) {
             return res.status(400).json({ error: 'Invalid UID' });
         }
 
@@ -1046,7 +1046,7 @@ router.get('/task/:uid/subtasks', async (req, res) => {
 
 router.get('/task/:uid/next-iterations', async (req, res) => {
     try {
-        if (!isValidUid(req.params.uid)) {
+        if (!isValidTaskUid(req.params.uid)) {
             return res.status(400).json({ error: 'Invalid UID' });
         }
 

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -985,6 +985,18 @@ router.delete('/task/:uid', requireTaskWriteAccess, async (req, res) => {
             }
         }
 
+        // Before the row goes away, so the remote copy does not survive to be
+        // pulled back in as a new task on the next sync (#1371). Required lazily
+        // because the CalDAV module already depends on this one.
+        try {
+            const {
+                deleteTaskFromRemotes,
+            } = require('../caldav/services/task-deletion-service');
+            await deleteTaskFromRemotes(task);
+        } catch (error) {
+            logError('Error removing task from CalDAV remotes:', error);
+        }
+
         await sequelize.query('PRAGMA foreign_keys = OFF');
 
         try {

--- a/backend/modules/tasks/utils/validation.js
+++ b/backend/modules/tasks/utils/validation.js
@@ -6,6 +6,19 @@ function isUid(value) {
     return isNaN(Number(str)) || !Number.isInteger(Number(str));
 }
 
+const MAX_TASK_UID_LENGTH = 255;
+
+// Tasks created by CalDAV clients (tasks.org, DAVx5, iOS Reminders) keep the
+// remote VTODO UID, which is not a Tududi nanoid. Route params must therefore
+// accept any non-empty identifier and let the database lookup decide.
+function isValidTaskUid(value) {
+    return (
+        typeof value === 'string' &&
+        value.length > 0 &&
+        value.length <= MAX_TASK_UID_LENGTH
+    );
+}
+
 async function validateProjectAccess(projectIdOrUid, userId) {
     if (!projectIdOrUid || !projectIdOrUid.toString().trim()) {
         return null;
@@ -177,6 +190,7 @@ async function validateGoalAccess(goalIdOrUid, userId) {
 }
 
 module.exports = {
+    isValidTaskUid,
     validateProjectAccess,
     validateParentTaskAccess,
     validateDeferUntilAndDueDate,

--- a/backend/services/permissionsService.js
+++ b/backend/services/permissionsService.js
@@ -14,6 +14,22 @@ async function getSharedUidsForUser(resourceType, userId) {
     return Array.from(set);
 }
 
+const RESOURCE_MODELS = { project: Project, task: Task, note: Note };
+
+// Whether the resource row still exists, regardless of who may read it.
+// Used to tell "gone" apart from "not yours" when access is denied.
+async function resourceExists(resourceType, resourceUid) {
+    const model = RESOURCE_MODELS[resourceType];
+    if (!model || !resourceUid) return false;
+
+    const row = await model.findOne({
+        where: { uid: resourceUid },
+        attributes: ['id'],
+        raw: true,
+    });
+    return !!row;
+}
+
 async function getAccess(userId, resourceType, resourceUid) {
     if (await isAdmin(userId)) return ACCESS.ADMIN;
 
@@ -172,6 +188,7 @@ async function ownershipOrPermissionWhere(resourceType, userId, cache = null) {
 module.exports = {
     ACCESS,
     getAccess,
+    resourceExists,
     ownershipOrPermissionWhere,
     getSharedUidsForUser,
 };

--- a/backend/tests/integration/caldav-ghost-tasks.test.js
+++ b/backend/tests/integration/caldav-ghost-tasks.test.js
@@ -1,0 +1,318 @@
+const request = require('supertest');
+const bcrypt = require('bcrypt');
+const axios = require('axios');
+const app = require('../../app');
+const {
+    sequelize,
+    User,
+    Task,
+    CalDAVCalendar,
+    CalDAVRemoteCalendar,
+    CalDAVSyncState,
+} = require('../../models');
+const syncEngine = require('../../modules/caldav/sync/sync-engine');
+const encryptionService = require('../../modules/caldav/services/encryption-service');
+const {
+    normalizeHref,
+    buildRemoteTaskUrl,
+    extractUidFromHref,
+} = require('../../modules/caldav/utils/href-utils');
+
+jest.mock('axios');
+
+// A "ghost task" (#1371) is a task that comes back after every delete. It is
+// created by a CalDAV client such as tasks.org, so its VTODO lives at a path the
+// client chose, and its UID is a remote UUID rather than a Tududi nanoid.
+const REMOTE_UID = '3f7c2b1a-8e5d-4c9f-9a2b-1d6e4f0a7c33';
+const REMOTE_HREF = '/calendars/test/tasks/1754712345678-9021.ics';
+
+function reportWithTask(href, uid, etag) {
+    return `<?xml version="1.0" encoding="utf-8" ?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+  <d:response>
+    <d:href>${href}</d:href>
+    <d:propstat>
+      <d:prop>
+        <d:getetag>"${etag}"</d:getetag>
+        <cal:calendar-data>BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VTODO
+UID:${uid}
+SUMMARY:Ghost Task
+STATUS:NEEDS-ACTION
+END:VTODO
+END:VCALENDAR</cal:calendar-data>
+      </d:prop>
+      <d:status>HTTP/1.1 200 OK</d:status>
+    </d:propstat>
+  </d:response>
+</d:multistatus>`;
+}
+
+describe('CalDAV ghost tasks', () => {
+    let testUser;
+    let calendar;
+    let remoteCalendar;
+    let agent;
+
+    beforeAll(async () => {
+        await sequelize.sync({ force: true });
+    });
+
+    beforeEach(async () => {
+        testUser = await User.create({
+            email: 'ghost@test.com',
+            password_digest: await bcrypt.hash('password123', 10),
+            verified: true,
+        });
+
+        calendar = await CalDAVCalendar.create({
+            uid: 'ghost-calendar-uid',
+            user_id: testUser.id,
+            name: 'Ghost Calendar',
+            enabled: true,
+            sync_direction: 'bidirectional',
+            sync_interval_minutes: 15,
+            conflict_resolution: 'last_write_wins',
+        });
+
+        remoteCalendar = await CalDAVRemoteCalendar.create({
+            user_id: testUser.id,
+            local_calendar_id: calendar.id,
+            name: 'Ghost Remote Calendar',
+            server_url: 'https://caldav.example.com',
+            calendar_path: '/calendars/test/tasks/',
+            username: 'testuser',
+            password_encrypted: encryptionService.encrypt('password123'),
+            auth_type: 'basic',
+            enabled: true,
+            sync_direction: 'bidirectional',
+        });
+
+        agent = request.agent(app);
+        await agent
+            .post('/api/login')
+            .send({ email: 'ghost@test.com', password: 'password123' });
+    });
+
+    afterEach(async () => {
+        await CalDAVSyncState.destroy({ where: {} });
+        await CalDAVRemoteCalendar.destroy({ where: {} });
+        await CalDAVCalendar.destroy({ where: {} });
+        await Task.destroy({ where: {} });
+        await User.destroy({ where: {} });
+        jest.clearAllMocks();
+    });
+
+    afterAll(async () => {
+        await sequelize.close();
+    });
+
+    async function pullGhostTask() {
+        axios.mockResolvedValueOnce({
+            status: 207,
+            data: reportWithTask(REMOTE_HREF, REMOTE_UID, 'etag-1'),
+        });
+
+        await syncEngine.syncCalendar(calendar.id, testUser.id, {
+            direction: 'pull',
+        });
+
+        return Task.findOne({ where: { uid: REMOTE_UID } });
+    }
+
+    describe('href utilities', () => {
+        test('normalizes absolute and relative hrefs to a path', () => {
+            expect(normalizeHref('https://caldav.example.com/cal/a.ics')).toBe(
+                '/cal/a.ics'
+            );
+            expect(normalizeHref('/cal/a.ics')).toBe('/cal/a.ics');
+            expect(normalizeHref('cal/a.ics')).toBe('/cal/a.ics');
+            expect(normalizeHref('')).toBeNull();
+            expect(normalizeHref(null)).toBeNull();
+        });
+
+        test('prefers the recorded href over a uid-derived path', () => {
+            expect(
+                buildRemoteTaskUrl(remoteCalendar, REMOTE_HREF, REMOTE_UID)
+            ).toBe(`https://caldav.example.com${REMOTE_HREF}`);
+        });
+
+        test('falls back to <uid>.ics when no href is recorded', () => {
+            expect(buildRemoteTaskUrl(remoteCalendar, null, 'abc123')).toBe(
+                'https://caldav.example.com/calendars/test/tasks/abc123.ics'
+            );
+        });
+
+        test('extracts a uid from a conventional href', () => {
+            expect(extractUidFromHref('/cal/task-1.ics')).toBe('task-1');
+        });
+    });
+
+    describe('pull phase', () => {
+        test('records the remote href of a pulled task', async () => {
+            const task = await pullGhostTask();
+
+            expect(task).not.toBeNull();
+
+            const syncState = await CalDAVSyncState.findOne({
+                where: { task_id: task.id, calendar_id: calendar.id },
+            });
+
+            expect(syncState.remote_href).toBe(REMOTE_HREF);
+        });
+    });
+
+    describe('deleting a task in Tududi', () => {
+        test('deletes the remote resource at its real href, not <uid>.ics', async () => {
+            const task = await pullGhostTask();
+
+            axios.mockResolvedValueOnce({ status: 204 });
+
+            const response = await agent.delete(`/api/task/${task.uid}`);
+            expect(response.status).toBe(200);
+
+            const deleteCall = axios.mock.calls
+                .map(([config]) => config)
+                .find((config) => config.method === 'DELETE');
+
+            expect(deleteCall).toBeDefined();
+            expect(deleteCall.url).toBe(
+                `https://caldav.example.com${REMOTE_HREF}`
+            );
+            // The path the old code guessed, which 404s on the real server.
+            expect(deleteCall.url).not.toContain(`${REMOTE_UID}.ics`);
+        });
+
+        test('does not resurrect the task on the next pull', async () => {
+            const task = await pullGhostTask();
+
+            axios.mockResolvedValueOnce({ status: 204 });
+            await agent.delete(`/api/task/${task.uid}`);
+
+            // The server no longer lists the resource, because the DELETE above
+            // actually reached it.
+            axios.mockResolvedValueOnce({
+                status: 207,
+                data: `<?xml version="1.0" encoding="utf-8" ?>
+<d:multistatus xmlns:d="DAV:" xmlns:cal="urn:ietf:params:xml:ns:caldav">
+</d:multistatus>`,
+            });
+
+            await syncEngine.syncCalendar(calendar.id, testUser.id, {
+                direction: 'pull',
+            });
+
+            expect(
+                await Task.findOne({ where: { uid: REMOTE_UID } })
+            ).toBeNull();
+        });
+
+        test('removes the sync state so no row is orphaned', async () => {
+            const task = await pullGhostTask();
+
+            axios.mockResolvedValueOnce({ status: 204 });
+            await agent.delete(`/api/task/${task.uid}`);
+
+            const remaining = await CalDAVSyncState.findAll({
+                where: { task_id: task.id },
+            });
+            expect(remaining).toHaveLength(0);
+        });
+
+        test('still deletes locally when the remote server is unreachable', async () => {
+            const task = await pullGhostTask();
+
+            axios.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+            const response = await agent.delete(`/api/task/${task.uid}`);
+
+            expect(response.status).toBe(200);
+            expect(await Task.findByPk(task.id)).toBeNull();
+        });
+
+        test('deletes locally when the resource is already gone remotely', async () => {
+            const task = await pullGhostTask();
+
+            axios.mockRejectedValueOnce({ response: { status: 404 } });
+
+            const response = await agent.delete(`/api/task/${task.uid}`);
+
+            expect(response.status).toBe(200);
+            expect(await Task.findByPk(task.id)).toBeNull();
+        });
+
+        test('makes no remote call for a task that was never synced', async () => {
+            const localTask = await Task.create({
+                uid: 'local-only-task',
+                user_id: testUser.id,
+                name: 'Local only',
+                status: 0,
+            });
+
+            const response = await agent.delete(`/api/task/${localTask.uid}`);
+
+            expect(response.status).toBe(200);
+            expect(axios).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('pushing a task back to the remote', () => {
+        test('updates the existing resource instead of creating a duplicate', async () => {
+            const task = await pullGhostTask();
+
+            await CalDAVSyncState.update(
+                { last_synced_at: new Date(Date.now() - 60000) },
+                { where: { task_id: task.id, calendar_id: calendar.id } }
+            );
+            await task.update({ name: 'Renamed in Tududi' });
+
+            axios.mockResolvedValueOnce({
+                status: 204,
+                headers: { etag: '"etag-2"' },
+            });
+
+            await syncEngine.syncCalendar(calendar.id, testUser.id, {
+                direction: 'push',
+            });
+
+            const putCall = axios.mock.calls
+                .map(([config]) => config)
+                .find((config) => config.method === 'PUT');
+
+            expect(putCall).toBeDefined();
+            expect(putCall.url).toBe(
+                `https://caldav.example.com${REMOTE_HREF}`
+            );
+        });
+    });
+
+    describe('remote deletion of an externally created task', () => {
+        test('deletes the local task matched by href, not by filename', async () => {
+            const task = await pullGhostTask();
+
+            axios.mockResolvedValueOnce({
+                status: 207,
+                data: `<?xml version="1.0" encoding="utf-8" ?>
+<d:multistatus xmlns:d="DAV:">
+  <d:response>
+    <d:href>${REMOTE_HREF}</d:href>
+    <d:status>HTTP/1.1 404 Not Found</d:status>
+  </d:response>
+</d:multistatus>`,
+            });
+
+            const result = await syncEngine.syncCalendar(
+                calendar.id,
+                testUser.id,
+                { direction: 'pull' }
+            );
+
+            expect(result.phases.merge.deleted).toHaveLength(1);
+            expect(await Task.findByPk(task.id)).toBeNull();
+            expect(
+                await CalDAVSyncState.findAll({ where: { task_id: task.id } })
+            ).toHaveLength(0);
+        });
+    });
+});

--- a/backend/tests/integration/caldav-sync-engine.test.js
+++ b/backend/tests/integration/caldav-sync-engine.test.js
@@ -373,7 +373,11 @@ END:VCALENDAR</cal:calendar-data>
                 calendar_id: calendar.id,
                 etag: 'etag-1',
                 last_modified: new Date(),
-                last_synced_at: new Date(),
+                // Backdated: the push phase only considers a task changed when
+                // updated_at is strictly greater than last_synced_at, and both
+                // stamps land in the same millisecond often enough to make this
+                // test flaky when it uses "now".
+                last_synced_at: new Date(Date.now() - 60000),
                 sync_status: 'synced',
             });
 

--- a/backend/tests/integration/ghost-tasks.test.js
+++ b/backend/tests/integration/ghost-tasks.test.js
@@ -1,0 +1,152 @@
+const request = require('supertest');
+const app = require('../../app');
+const { Task, CalDAVCalendar } = require('../../models');
+const { createTestUser } = require('../helpers/testUtils');
+
+// Regression tests for #1371: tasks that are visible in the UI but whose uid
+// cannot be resolved server-side ("ghost tasks") answered 403 Forbidden to
+// every request, so the row could never be removed. Tasks synced from CalDAV
+// clients also carry a remote UID that Tududi's uid format check rejected.
+describe('Ghost tasks and externally synced uids', () => {
+    let user, otherUser, agent;
+
+    beforeEach(async () => {
+        user = await createTestUser({
+            email: `ghost_${Date.now()}@example.com`,
+        });
+        otherUser = await createTestUser({
+            email: `other_${Date.now()}@example.com`,
+        });
+
+        agent = request.agent(app);
+        await agent
+            .post('/api/login')
+            .send({ email: user.email, password: 'password123' });
+    });
+
+    describe('tasks that no longer exist', () => {
+        const missingUid = 'abcdefghijklmno';
+
+        it('GET /api/task/:uid returns 404, not 403', async () => {
+            const res = await agent.get(`/api/task/${missingUid}`);
+            expect(res.status).toBe(404);
+            expect(res.body.error).toBe('Task not found.');
+        });
+
+        it('DELETE /api/task/:uid returns 404, not 403', async () => {
+            const res = await agent.delete(`/api/task/${missingUid}`);
+            expect(res.status).toBe(404);
+            expect(res.body.error).toBe('Task not found.');
+        });
+
+        it('PATCH /api/task/:uid returns 404, not 403', async () => {
+            const res = await agent
+                .patch(`/api/task/${missingUid}`)
+                .send({ status: 2 });
+            expect(res.status).toBe(404);
+            expect(res.body.error).toBe('Task not found.');
+        });
+
+        it("still returns 403 for another user's existing task", async () => {
+            const otherTask = await Task.create({
+                name: 'Other Task',
+                user_id: otherUser.id,
+            });
+
+            const get = await agent.get(`/api/task/${otherTask.uid}`);
+            expect(get.status).toBe(403);
+            expect(get.body.error).toBe('Forbidden');
+
+            const del = await agent.delete(`/api/task/${otherTask.uid}`);
+            expect(del.status).toBe(403);
+            expect(del.body.error).toBe('Forbidden');
+        });
+    });
+
+    describe('tasks created by a CalDAV client', () => {
+        // tasks.org / DAVx5 keep their own VTODO UID, which is not a Tududi uid
+        const remoteUid = '3f7c2b1a-8e5d-4c9f-9a2b-1d6e4f0a7c33';
+        let authHeader;
+
+        beforeEach(async () => {
+            await CalDAVCalendar.create({
+                uid: `cal-${Date.now()}`,
+                user_id: user.id,
+                name: 'Test Calendar',
+                enabled: true,
+            });
+
+            authHeader =
+                'Basic ' +
+                Buffer.from(`${user.email}:password123`).toString('base64');
+
+            const vtodo = [
+                'BEGIN:VCALENDAR',
+                'VERSION:2.0',
+                'PRODID:-//tasks.org//android//EN',
+                'BEGIN:VTODO',
+                `UID:${remoteUid}`,
+                'SUMMARY:Double check MX records',
+                'DUE;VALUE=DATE:20260809',
+                'STATUS:NEEDS-ACTION',
+                'END:VTODO',
+                'END:VCALENDAR',
+            ].join('\r\n');
+
+            await request(app)
+                .put(
+                    `/caldav/${encodeURIComponent(user.email)}/tasks/${remoteUid}.ics`
+                )
+                .set('Authorization', authHeader)
+                .set('Content-Type', 'text/calendar')
+                .send(vtodo)
+                .expect(201);
+        });
+
+        it('stores the remote uid', async () => {
+            const task = await Task.findOne({ where: { uid: remoteUid } });
+            expect(task).not.toBeNull();
+            expect(task.user_id).toBe(user.id);
+        });
+
+        it('serves the subtasks endpoint', async () => {
+            const res = await agent.get(`/api/task/${remoteUid}/subtasks`);
+            expect(res.status).toBe(200);
+            expect(res.body).toEqual([]);
+        });
+
+        it('serves the next-iterations endpoint', async () => {
+            const res = await agent.get(
+                `/api/task/${remoteUid}/next-iterations`
+            );
+            expect(res.status).toBe(200);
+            expect(res.body.iterations).toEqual([]);
+        });
+
+        it('serves the timeline endpoint', async () => {
+            const res = await agent.get(`/api/task/${remoteUid}/timeline`);
+            expect(res.status).toBe(200);
+        });
+
+        it('can be fetched and deleted from the web UI', async () => {
+            const get = await agent.get(`/api/task/${remoteUid}`);
+            expect(get.status).toBe(200);
+            expect(get.body.uid).toBe(remoteUid);
+
+            const del = await agent.delete(`/api/task/${remoteUid}`);
+            expect(del.status).toBe(200);
+
+            expect(
+                await Task.findOne({ where: { uid: remoteUid } })
+            ).toBeNull();
+        });
+
+        it('rejects an empty or oversized uid with 400', async () => {
+            const res = await agent.get(
+                `/api/task/${'x'.repeat(256)}/subtasks`
+            );
+            expect(res.status).toBe(400);
+            expect(res.body.error).toBe('Invalid UID');
+        });
+    });
+});

--- a/backend/tests/integration/permissions-tasks.test.js
+++ b/backend/tests/integration/permissions-tasks.test.js
@@ -20,15 +20,15 @@ describe('Tasks Permissions', () => {
             .send({ email: user.email, password: 'password123' });
     });
 
-    it("GET /api/task/:id should return 403 for other user's task", async () => {
+    it('GET /api/task/:id should return 404 (routes are keyed by uid)', async () => {
         const otherTask = await Task.create({
             name: 'Other Task',
             user_id: otherUser.id,
         });
 
         const res = await agent.get(`/api/task/${otherTask.id}`);
-        expect(res.status).toBe(403);
-        expect(res.body.error).toBe('Forbidden');
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe('Task not found.');
     });
 
     it("GET /api/task/:uid should return 403 for other user's task", async () => {

--- a/backend/tests/integration/tasks.test.js
+++ b/backend/tests/integration/tasks.test.js
@@ -194,13 +194,13 @@ describe('Tasks Routes', () => {
             expect(response.body.original_name).toBe(updateData.name);
         });
 
-        it('should return 403 for non-existent task', async () => {
+        it('should return 404 for non-existent task', async () => {
             const response = await agent
                 .patch('/api/task/nonexistent-uid-12345')
                 .send({ name: 'Updated' });
 
-            expect(response.status).toBe(403);
-            expect(response.body.error).toBe('Forbidden');
+            expect(response.status).toBe(404);
+            expect(response.body.error).toBe('Task not found.');
         });
 
         it("should not allow updating other user's tasks", async () => {
@@ -254,13 +254,13 @@ describe('Tasks Routes', () => {
             expect(deletedTask).toBeNull();
         }, 10000); // 10 second timeout for DELETE operations
 
-        it('should return 403 for non-existent task', async () => {
+        it('should return 404 for non-existent task', async () => {
             const response = await agent.delete(
                 '/api/task/nonexistent-uid-12345'
             );
 
-            expect(response.status).toBe(403);
-            expect(response.body.error).toBe('Forbidden');
+            expect(response.status).toBe(404);
+            expect(response.body.error).toBe('Task not found.');
         });
 
         it("should not allow deleting other user's tasks", async () => {

--- a/backend/tests/unit/middleware/authorize.test.js
+++ b/backend/tests/unit/middleware/authorize.test.js
@@ -15,6 +15,8 @@ describe('authorize middleware – hasAccess', () => {
         res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
         next = jest.fn();
         jest.clearAllMocks();
+        // Default: the resource is there, only the permission is missing
+        permissionsService.resourceExists.mockResolvedValue(true);
     });
 
     // --- UID resolution ---
@@ -138,6 +140,30 @@ describe('authorize middleware – hasAccess', () => {
         expect(res.status).toHaveBeenCalledWith(403);
         expect(res.json).toHaveBeenCalledWith({ error: 'Forbidden' });
         expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should return 404 when the resource does not exist', async () => {
+        permissionsService.getAccess.mockResolvedValue('none');
+        permissionsService.resourceExists.mockResolvedValue(false);
+        const mw = hasAccess('ro', 'task', () => 'gone-uid', {
+            notFoundMessage: 'Task not found.',
+        });
+
+        await mw(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(404);
+        expect(res.json).toHaveBeenCalledWith({ error: 'Task not found.' });
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should not check existence when access is granted', async () => {
+        permissionsService.getAccess.mockResolvedValue('rw');
+        const mw = hasAccess('rw', 'task', () => 'uid1');
+
+        await mw(req, res, next);
+
+        expect(permissionsService.resourceExists).not.toHaveBeenCalled();
+        expect(next).toHaveBeenCalled();
     });
 
     // --- User ID extraction ---

--- a/frontend/utils/__tests__/tasksService.delete.test.ts
+++ b/frontend/utils/__tests__/tasksService.delete.test.ts
@@ -1,0 +1,58 @@
+import { deleteTask } from '../tasksService';
+
+jest.mock('../authUtils', () => ({
+    handleAuthResponse: jest.fn(async (response: Response, message: string) => {
+        if (!response.ok) throw new Error(message);
+        return response;
+    }),
+    getDefaultHeaders: () => ({}),
+    getPostHeadersWithCsrf: async () => ({}),
+}));
+
+// jsdom has no Response constructor, so stub the parts fetch callers use
+const jsonResponse = (status: number, body: unknown) =>
+    ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+    }) as Response;
+
+describe('deleteTask', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it('resolves when the task is deleted', async () => {
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(
+                jsonResponse(200, { message: 'Task successfully deleted' })
+            ) as jest.Mock;
+
+        await expect(deleteTask('abcdefghijklmno')).resolves.toBeUndefined();
+    });
+
+    // #1371: a stale row pointing at a task that no longer exists must be
+    // removable from the UI instead of failing every delete attempt.
+    it('resolves when the task no longer exists', async () => {
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(
+                jsonResponse(404, { error: 'Task not found.' })
+            ) as jest.Mock;
+
+        await expect(deleteTask('abcdefghijklmno')).resolves.toBeUndefined();
+    });
+
+    it('still rejects when the task exists but is not accessible', async () => {
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(
+                jsonResponse(403, { error: 'Forbidden' })
+            ) as jest.Mock;
+
+        await expect(deleteTask('abcdefghijklmno')).rejects.toThrow(
+            'Failed to delete task.'
+        );
+    });
+});

--- a/frontend/utils/tasksService.ts
+++ b/frontend/utils/tasksService.ts
@@ -164,6 +164,14 @@ export const deleteTask = async (taskUid: string): Promise<void> => {
         }
     );
 
+    // A task that is already gone on the server is in the state the caller
+    // asked for. Treating 404 as success lets stale rows (e.g. left behind by
+    // an interrupted CalDAV sync) be cleared from the UI instead of failing
+    // every delete attempt.
+    if (response.status === 404) {
+        return;
+    }
+
     await handleAuthResponse(response, 'Failed to delete task.');
 };
 


### PR DESCRIPTION
## Description

Tasks that show up in the list but cannot be deleted ("ghost tasks", #1371). Two separate defects, one per commit: the API could not report what was wrong, and the CalDAV sync kept re-creating the row.

### 1. The API answered `403` to everything (`hasAccess`, `deleteTask`, uid guard)

A task whose `uid` did not resolve server-side answered `403 Forbidden` to *every* request, including `DELETE`. The UI only surfaced "Failed to delete task.", so the row could never be removed. This matches the log in #1371:

```
"DELETE /api/task/[REDACTED_ID] HTTP/1.1" 403 21
"GET    /api/task/[REDACTED_ID] HTTP/1.1" 403 21
```

(`21` bytes = `{"error":"Forbidden"}` from `hasAccess`.)

- **`hasAccess` tells "gone" apart from "not yours".** It called `getAccess()`, which returns `none` both for a resource the user may not touch *and* for a resource that does not exist. It now checks existence when access is denied and answers `404` if the row is gone. A task that exists but belongs to another user still returns `403`.
- **`deleteTask` treats `404` as success.** A task that is already gone is in the state the caller asked for, so the stale row is dropped from the list.
- **The task uid route guard no longer rejects externally synced uids.** `isValidUid` only accepts a 15-char Tududi nanoid, but a task created by a CalDAV client keeps its remote VTODO UID, e.g. `3f7c2b1a-8e5d-4c9f-9a2b-1d6e4f0a7c33`. Every such task got `400 Invalid UID` from `/task/:uid/subtasks`, `/next-iterations`, `/timeline` and `/completion-time` — which is also why those tasks could not be worked with in the UI (see #1332). The guard now accepts any non-empty uid up to 255 chars and lets the database lookup decide.

Side effect worth noting: the service worker treats a `403` on an API GET as an expired session and clears the cached user data. Ghost tasks were triggering that on every open; they now return `404` and no longer do.

### 2. The CalDAV sync re-created the task after every delete

Root cause of how the row gets into that state.

**A task deleted in Tududi was never deleted on the server it came from.** `PushPhase.deleteTaskFromRemote` had no callers anywhere in the codebase. `DELETE /api/task/:uid` destroyed the local row and nothing else, so the next pull still found the VTODO, no local task matched its UID, and `MergePhase._handleCreateOrUpdate` re-created it. The task came back after every delete.

**Wiring that method up is not enough**, because it built the resource URL as `<calendarPath>/<task.uid>.ics`. Only the client that *creates* a CalDAV resource chooses its path, and tasks.org, DAVx5 and iOS Reminders all pick a filename unrelated to the UID. So the `DELETE` would `404`, which the code read as "already deleted" and cleared the sync state for — while the remote copy survived to be pulled back in. The same guess had two more consequences: `PUT` wrote a *duplicate* resource alongside the original instead of updating it, and `_extractUidFromHref` resolved an incoming remote deletion to the wrong local task, or to none.

Changes:

- **Record the real href.** New nullable `remote_href` on `caldav_sync_state`, set from the href the server reported during pull and from the URL actually written during push. New `href-utils` normalises absolute or relative hrefs to a path, so a stored href survives a later edit of `server_url`.
- **Use it for `PUT` and `DELETE`**, falling back to `<uid>.ics` only for a task the server has never seen (where Tududi *is* the creating client).
- **Resolve remote deletions by href** rather than by parsing a uid out of the filename, with the old filename parse kept as a fallback for sync states written before this column existed.
- **Propagate local deletions.** New `task-deletion-service` deletes the task from every remote it is synced to, called from both the REST delete route and the CalDAV `DELETE` handler, before the row is destroyed. A remote that is unreachable is logged and the local delete still goes through.
- **Fix the sync-state cleanup paths.** `SyncStateRepository.deleteByTaskId` was called in three places but never existed, and `deleteByCalendarId` called a `this.delete` that BaseRepository does not define — both threw `TypeError`. Tasks are destroyed with `PRAGMA foreign_keys = OFF`, so the `ON DELETE CASCADE` never covered this and the rows were left orphaned.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1371

## Testing

**How did you test this?**

`backend/tests/integration/ghost-tasks.test.js` (API behaviour):

- `GET`/`PATCH`/`DELETE /api/task/:uid` for a uid that does not exist → `404 Task not found.` (was `403`)
- another user's *existing* task → still `403 Forbidden` (regression guard)
- a task created through the CalDAV `PUT` path with a tasks.org-style UUID uid: `/subtasks`, `/next-iterations` and `/timeline` return `200` (were `400 Invalid UID`), and the task can be fetched and deleted from the web API
- an oversized uid still returns `400 Invalid UID`

`backend/tests/integration/caldav-ghost-tasks.test.js` (sync behaviour), driving a full pull/merge/push through a mocked CalDAV server, with the VTODO at a href that is *not* `<uid>.ics`:

- pulling records the remote href on the sync state
- deleting in Tududi issues the `DELETE` to the recorded href, not to `<uid>.ics`
- after that delete, the next pull does **not** re-create the task
- the sync state is removed rather than orphaned
- the local delete still succeeds when the remote is unreachable, and when the resource is already `404` there
- a task that was never synced makes no remote call at all
- pushing a local edit `PUT`s to the existing resource instead of creating a duplicate
- a remote deletion is matched to the right local task by href
- unit coverage for `normalizeHref` / `buildRemoteTaskUrl` / `extractUidFromHref`

`frontend/utils/__tests__/tasksService.delete.test.ts` covers `deleteTask` resolving on `200` and `404` and still rejecting on `403`.

Updated three existing tests that asserted the old `403` behaviour. Also backdated `last_synced_at` in an existing push test in `caldav-sync-engine.test.js`: it compared two timestamps written in the same millisecond and failed roughly 2 runs in 5 on `main`.

**Commands run:**

- [x] `npm run backend:test` — 1668 passed / 1670, the 2 failures are pre-existing cross-suite flakiness (a run on the unmodified base failed 5 *different* tests); both pass in isolation
- [x] `npx jest tests/integration/caldav tests/integration/tasks tests/integration/ghost-tasks` — 145 passed, 11 suites
- [x] `npm run lint:fix` + `npm run lint` — 0 errors
- [x] `npx prettier --check` on the changed files
- [x] `npm run db:migrate` — applied, verified the column and index exist, and confirmed re-running the migration is a no-op

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [x] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

The migration adds a nullable column, so existing sync states keep working: they simply have no href on record and fall back to the old `<uid>.ics` path until the next pull fills it in.

One limitation worth being explicit about: if the remote server is unreachable at the moment of deletion, the task is still deleted locally and can be pulled back on the next sync. Making that airtight needs a deletion tombstone that survives to be retried, which is a larger change than this fix.

`safeAddIndex` could not be used for the new composite index — it treats an index as already present when *any* one of the requested fields is indexed, and `calendar_id` already is, so the index would silently never be created. The migration checks for the index by name instead.
