### PR TITLE
Add root .env.example for docker-compose, expand CLAUDE.md

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,8 +93,6 @@ PGID=1001
 
 # FF_ENABLE_BACKUPS=false
 # FF_ENABLE_CALDAV=false
-# FF_ENABLE_CALENDAR=false
-# FF_ENABLE_HABITS=false
 # FF_ENABLE_MCP=false
 
 # ---------------------------------------------------------------------------

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,194 @@
+# Tududi — Docker Compose environment file
+#
+# Copy this file to `.env` (same directory as docker-compose.yml) and fill
+# in the values you need. docker-compose.yml loads it via `env_file`.
+#
+#   cp .env.example .env
+#
+# Uncommented variables below are required (or have a safe default already
+# set). Commented-out variables are optional — remove the leading `#` and
+# set a value to enable that feature. See the linked docs/*.md files for
+# full details on each feature.
+
+# ---------------------------------------------------------------------------
+# Core (required)
+# ---------------------------------------------------------------------------
+
+# Initial admin account, created on first boot if no users exist yet.
+TUDUDI_USER_EMAIL=admin@example.com
+TUDUDI_USER_PASSWORD=change-me-to-a-secure-password
+
+# Used to sign session cookies. Generate with: openssl rand -hex 64
+TUDUDI_SESSION_SECRET=change-me-please-use-openssl-rand-hex-64
+
+# ---------------------------------------------------------------------------
+# Networking / reverse proxy
+# ---------------------------------------------------------------------------
+
+# Comma-separated list of origins allowed to call the API (CORS).
+TUDUDI_ALLOWED_ORIGINS=http://localhost:3002
+
+# REQUIRED when running behind a reverse proxy (Nginx, Caddy, Traefik, etc.)
+# so Express reads client IPs from X-Forwarded-For correctly.
+#   false          - don't trust any proxy (default, use for direct access)
+#   true / 1       - trust the first hop (recommended for a single proxy)
+#   loopback       - trust loopback addresses (127.0.0.1/::1)
+#   172.16.0.0/12  - trust a specific subnet
+TUDUDI_TRUST_PROXY=false
+
+# Session cookie 'secure' flag. 'auto' detects HTTPS via X-Forwarded-Proto
+# when TUDUDI_TRUST_PROXY is set; use 'false' only for local HTTP testing.
+# COOKIE_SECURE=auto
+
+# Set 'true' to disable HSTS headers (local HTTP testing of prod builds only).
+# DISABLE_HSTS=false
+
+# Set 'true' to send CSP upgrade-insecure-requests. Only enable if Tududi is
+# served over HTTPS end-to-end (e.g. via reverse proxy) — otherwise blank page.
+# UPGRADE_INSECURE_REQUESTS=false
+
+# Public base URL of this deployment. Required for OIDC callback URLs and
+# used in generated links (e.g. password reset emails).
+# BASE_URL=https://tududi.example.com
+
+# ---------------------------------------------------------------------------
+# Storage / runtime user
+# ---------------------------------------------------------------------------
+
+# Must match the container-side path used in the `volumes:` uploads mount.
+TUDUDI_UPLOAD_PATH=/app/uploads
+
+# Host UID/GID that owns the mounted ./tududi_db and ./uploads directories.
+# Set to match your host user: `id -u` / `id -g`.
+PUID=1001
+PGID=1001
+
+# Max upload size per file, in MB.
+# FILE_UPLOAD_LIMIT_MB=10
+
+# ---------------------------------------------------------------------------
+# Email (password reset, notifications)
+# ---------------------------------------------------------------------------
+
+# ENABLE_EMAIL=false
+# EMAIL_SMTP_HOST=smtp.gmail.com
+# EMAIL_SMTP_PORT=587
+# EMAIL_SMTP_SECURE=false
+# EMAIL_SMTP_USERNAME=your-email@example.com
+# EMAIL_SMTP_PASSWORD=your-app-password
+# EMAIL_FROM_ADDRESS=noreply@example.com
+# EMAIL_FROM_NAME=Tududi
+# REGISTRATION_TOKEN_EXPIRY_HOURS=24
+
+# ---------------------------------------------------------------------------
+# Background jobs / integrations
+# ---------------------------------------------------------------------------
+
+# DISABLE_SCHEDULER=false
+# DISABLE_TELEGRAM=false
+
+# ---------------------------------------------------------------------------
+# Feature flags
+# ---------------------------------------------------------------------------
+
+# FF_ENABLE_BACKUPS=false
+# FF_ENABLE_CALDAV=false
+# FF_ENABLE_CALENDAR=false
+# FF_ENABLE_HABITS=false
+# FF_ENABLE_MCP=false
+
+# ---------------------------------------------------------------------------
+# OIDC / SSO — see docs/10-oidc-sso.md
+# ---------------------------------------------------------------------------
+
+# OIDC_ENABLED=false
+
+# Set to false to disable password login/registration (SSO-only mode).
+# PASSWORD_AUTH_ENABLED=true
+
+# Single provider:
+# OIDC_PROVIDER_NAME=PocketID
+# OIDC_PROVIDER_SLUG=pocketid
+# OIDC_ISSUER_URL=https://pocketid.app
+# OIDC_CLIENT_ID=your-client-id
+# OIDC_CLIENT_SECRET=your-client-secret
+# OIDC_SCOPE=openid profile email
+# OIDC_AUTO_PROVISION=true
+# OIDC_ADMIN_EMAIL_DOMAINS=example.com,company.com
+
+# Multiple providers (numbered, repeat the block per provider):
+# OIDC_PROVIDER_1_NAME=Google
+# OIDC_PROVIDER_1_SLUG=google
+# OIDC_PROVIDER_1_ISSUER=https://accounts.google.com
+# OIDC_PROVIDER_1_CLIENT_ID=xxx.apps.googleusercontent.com
+# OIDC_PROVIDER_1_CLIENT_SECRET=xxx
+# OIDC_PROVIDER_1_AUTO_PROVISION=true
+
+# ---------------------------------------------------------------------------
+# CalDAV synchronization — see docs/11-caldav-sync.md
+# ---------------------------------------------------------------------------
+
+# CALDAV_ENABLED=false
+
+# Encrypts stored remote-calendar passwords. Falls back to TUDUDI_SESSION_SECRET
+# if unset — set explicitly for production. Generate with: openssl rand -hex 32
+# ENCRYPTION_KEY=your-256-bit-encryption-key
+
+# CALDAV_DEFAULT_SYNC_INTERVAL=15          # Minutes
+# CALDAV_MAX_RECURRING_INSTANCES=365       # Future instances to expand
+# CALDAV_CONFLICT_RESOLUTION=last_write_wins
+# CALDAV_RATE_LIMIT=60                     # Requests per minute
+# CALDAV_MAX_SYNC_TASKS=1000               # Max tasks per sync
+# CALDAV_REQUEST_TIMEOUT=30000             # Milliseconds
+# CALDAV_LOG_LEVEL=info
+# CALDAV_LOG_REQUESTS=false
+
+# ---------------------------------------------------------------------------
+# AI Assistant (Daily Brief, Task/Project Insights) — see docs/13-ai-assistant.md
+# Works with OpenAI or any OpenAI-compatible provider (Ollama, vLLM, LM
+# Studio, Groq, Azure OpenAI, etc). Leave unset to disable the feature.
+# ---------------------------------------------------------------------------
+
+# LLM_API_KEY=sk-...
+# LLM_BASE_URL=https://api.openai.com/v1   # e.g. http://host.docker.internal:8000/v1 for local vLLM
+# LLM_MODEL=gpt-4o-mini                    # must match a model your provider serves
+
+# ---------------------------------------------------------------------------
+# Google Calendar integration (optional)
+# ---------------------------------------------------------------------------
+
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+# GOOGLE_REDIRECT_URI=http://localhost:3002/api/calendar/oauth/callback
+
+# ---------------------------------------------------------------------------
+# Project templates / marketplace
+# ---------------------------------------------------------------------------
+
+# PROJECT_TEMPLATES_ENABLED=true
+# MAX_TEMPLATES_PER_USER=50
+# MARKETPLACE_URL=https://cloud.tududi.com
+# MARKETPLACE_API_KEY=your-api-token-from-cloud-dashboard
+
+# ---------------------------------------------------------------------------
+# API docs
+# ---------------------------------------------------------------------------
+
+# Serve Swagger UI at /api-docs (requires authentication either way).
+# SWAGGER_ENABLED=true
+
+# ---------------------------------------------------------------------------
+# Rate limiting (advanced — defaults are sane for most deployments)
+# ---------------------------------------------------------------------------
+
+# RATE_LIMITING_ENABLED=true
+# RATE_LIMIT_AUTH_WINDOW_MS=900000         # 15 minutes
+# RATE_LIMIT_AUTH_MAX=5
+# RATE_LIMIT_API_WINDOW_MS=900000
+# RATE_LIMIT_API_MAX=100
+# RATE_LIMIT_AUTH_API_WINDOW_MS=900000
+# RATE_LIMIT_AUTH_API_MAX=1000
+# RATE_LIMIT_CREATE_WINDOW_MS=900000
+# RATE_LIMIT_CREATE_MAX=50
+# RATE_LIMIT_API_KEY_WINDOW_MS=3600000     # 1 hour
+# RATE_LIMIT_API_KEY_MAX=10

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 # Tududi - Developer Guide
 
 This documentation is designed for AI assistants and developers working with the tududi codebase. For user-facing documentation, see [README.md](README.md). For contribution guidelines, see [CONTRIBUTING.md](.github/CONTRIBUTING.md).
@@ -18,6 +22,70 @@ npm install
 npm run db:init
 npm start  # Frontend on :8080, Backend on :3002
 ```
+
+---
+
+## Common Commands
+
+**Development** (two servers, run together via `npm start` or separately):
+```bash
+npm run backend:dev    # nodemon, backend on :3002
+npm run frontend:dev   # webpack-dev-server, frontend on :8080, proxies /api to :3002
+```
+
+**Build:**
+```bash
+npm run build           # tsc --noEmit + webpack production build -> /dist
+```
+
+**Lint & format** (run both frontend and backend unless scoped):
+```bash
+npm run lint             # eslint: frontend + backend
+npm run lint:fix
+npm run format:fix       # prettier --write: frontend + backend
+```
+
+**Tests:**
+```bash
+npm test                              # backend Jest suite (alias: npm run backend:test)
+npm run backend:test:unit             # backend/tests/unit only
+npm run backend:test:integration      # backend/tests/integration only
+cd backend && npx jest tests/unit/models/task.test.js   # single backend test file
+npm run frontend:test                 # frontend Jest + React Testing Library
+npm run frontend:test -- TaskItem     # single frontend test by name pattern
+npm run test:ui                       # Playwright E2E (headless)
+npm run test:ui:headed                # Playwright E2E, visible browser
+npm run test:coverage                 # coverage for both frontend and backend
+```
+
+**Before opening a PR:**
+```bash
+npm run pre-push   # lint-staged (runs on the staged diff)
+```
+(`pre-release` runs the full lint:fix + format:fix + test + test:ui suite.)
+
+**Database** (all operate on `backend/`):
+```bash
+npm run db:init             # first-time setup
+npm run db:migrate          # run pending migrations (dev)
+npm run db:reset            # wipe and reinit
+npm run db:seed             # seed dev data
+npm run migration:create    # scaffold a new migration
+npm run migration:status    # check applied/pending migrations
+```
+
+---
+
+## Architecture at a Glance
+
+See [docs/architecture.md](docs/architecture.md) for full diagrams; the essentials:
+
+- **Dev mode is two servers.** Webpack dev server (`:8080`) serves the React app with HMR and proxies `/api/*` and `/locales/*` to the Express API (`:3002`). In production, Express serves the compiled `/dist` bundle directly alongside the API — one process, one port.
+- **Backend is organized into self-contained modules** under `/backend/modules/[feature]/`, each typically with `routes.js` (Express router, thin) → `repository.js` (Sequelize data access) → optional `operations/` (business logic too complex for the repository) and `core/` (`serializers.js`, `builders.js`, `parsers.js`). Routes never touch Sequelize models directly — they call the repository. See [docs/backend-patterns.md](docs/backend-patterns.md).
+- **Data hierarchy:** `User → Area → Project → Task → Subtask`, with `Tag` many-to-many across Tasks/Notes/Projects, and `Task` self-referencing for both subtasks (`parent_task_id`) and recurring instances (`recurring_parent_id`). Areas and Goals are optional containers — Projects can exist without either.
+- **Three auth methods**, all resolving to `req.currentUser`: session cookies (web UI, `express-session` + Sequelize store), Bearer API tokens (`tt_...`, for automation/MCP), and OAuth2 JWT bearer tokens (when OIDC is enabled, validated against the provider's JWKS). Authorization is enforced per-request via `hasAccess(level, resourceType, getResourceUid)` in `/backend/middleware/authorize.js`; ownership grants RW automatically, sharing grants RO/RW/ADMIN via the `Permission` model, and Tasks/Notes inherit access from their parent Project.
+- **Frontend state** is split three ways: Zustand (`/frontend/store/useStore.ts`) for global UI/cache state, SWR for server data fetching/revalidation, and local `useState` for component-only state. API calls go through `/frontend/utils/[resource]Service.ts` wrappers, not ad-hoc `fetch`.
+- **Recurring tasks** are the most complex subsystem — a recurring task is a pattern record; completed/generated instances are separate Task rows linked via `recurring_parent_id`, with `taskScheduler.js` (node-cron) and `recurringTaskService.js` driving generation. See [docs/01-recurring-tasks-behavior.md](docs/01-recurring-tasks-behavior.md) before touching this code.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-# Tududi - Developer Guide
+## Tududi - Developer Guide
 
 This documentation is designed for AI assistants and developers working with the tududi codebase. For user-facing documentation, see [README.md](README.md). For contribution guidelines, see [CONTRIBUTING.md](.github/CONTRIBUTING.md).
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ docker run \
 
 Navigate to [http://localhost:3002](http://localhost:3002) and login with your credentials.
 
+### Using docker-compose
+
+The repo also includes a `docker-compose.yml`. It reads its configuration from a `.env` file, so copy the example first:
+
+```bash
+cp .env.example .env
+# edit .env with your values, then:
+docker-compose up -d
+```
+
 ### Reverse Proxy Setup
 
 When running behind a reverse proxy (Caddy, Nginx, Traefik, etc.), set `TUDUDI_TRUST_PROXY` so that Express correctly reads client IPs from `X-Forwarded-For` headers. Without this, `express-rate-limit` will log a validation error.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,16 +2,8 @@ services:
   tududi:
     image: chrisvel/tududi:latest
     container_name: tududi
-    environment:
-      - TUDUDI_USER_EMAIL=admin@example.com
-      - TUDUDI_USER_PASSWORD=your-secure-password
-      - TUDUDI_SESSION_SECRET=changeme-please-use-openssl
-      - TUDUDI_ALLOWED_ORIGINS=http://localhost:3002
-      - TUDUDI_TRUST_PROXY=false
-      - TUDUDI_UPLOAD_PATH=/app/uploads
-      # Runtime UID/GID configuration - set these to match your host user/group
-      - PUID=1001
-      - PGID=1001
+    env_file:
+      - .env
     volumes:
       - ./tududi_db:/app/db
       - ./uploads:/app/uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   tududi:
     image: chrisvel/tududi:latest
     container_name: tududi
+    # Requires: cp .env.example .env — see .env.example for all options
     env_file:
       - .env
     volumes:


### PR DESCRIPTION
## Summary
- Adds a documented `.env.example` at the repo root covering every environment variable the app reads (core auth, networking/reverse-proxy, storage, email, feature flags, OIDC/SSO, CalDAV, AI Assistant/LLM provider config, Google Calendar, project templates, Swagger, rate limiting), organized by section with links to the relevant `docs/*.md` pages.
- Switches `docker-compose.yml` from an inline `environment:` list to `env_file: [.env]`, so deployment secrets (session secret, admin password, API keys) live in a git-ignored `.env` file instead of the tracked compose file.
- Expands `CLAUDE.md` with a **Common Commands** section (dev servers, build, lint/format, running a single backend/frontend test, E2E, DB migrations) and an **Architecture at a Glance** section (dev-mode proxy setup, backend module pattern, data hierarchy, the three auth methods, frontend state split, recurring-tasks subsystem), so this info doesn't require opening several `docs/*.md` files to find.

## Test plan
- [x] `cp .env.example .env`, fill in required vars, `docker-compose up -d`, confirm the container starts and picks up the values (e.g. login with `TUDUDI_USER_EMAIL`/`TUDUDI_USER_PASSWORD`)
- [x] Confirm `docker-compose config` resolves env vars correctly from `.env`
- [x] Review `CLAUDE.md` additions for accuracy against current code