### PR TITLE
Add docker-compose.dev.yml to build from local source

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,15 @@
+services:
+  tududi:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: tududi-dev
+    env_file:
+      - path: .env
+        required: false
+    volumes:
+      - ./tududi_db:/app/db
+      - ./uploads:/app/uploads
+    ports:
+      - "3002:3002"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

Adds `docker-compose.dev.yml`, which builds the image from local source (`build: .`) instead of pulling `chrisvel/tududi:latest`. Useful for testing a change end-to-end in a real container before opening a PR — split out of #1377 at [@chrisvel's request](https://github.com/chrisvel/tududi/pull/1377#pullrequestreview-4892383683) since it's unrelated to that bug fix.

```bash
docker compose -f docker-compose.dev.yml up -d --build
```

`env_file` uses `required: false`, so it won't hard-fail for someone who hasn't created a `.env` yet — it just runs with whatever defaults `config.js` already falls back to (e.g. a random session secret each restart). Tested locally both with and without a `.env` present; with one, config loads and the app runs normally, without one it still starts and serves `/api/health` successfully rather than erroring out on `docker compose up`.

## Test plan

- [x] `docker compose -f docker-compose.dev.yml config` — validates with and without `.env` present
- [x] `docker compose -f docker-compose.dev.yml up -d --build` with a real `.env` — container reaches `healthy`, app fully functional
- [x] Same command with `.env` removed — container still starts and reaches `healthy`, `GET /api/health` returns 200 (previously this would have hard-failed compose entirely)
