### PR TITLE
fix(mcp): support defer_until on task create/update tools

### DIFF
--- a/backend/modules/mcp/tools/taskTools.js
+++ b/backend/modules/mcp/tools/taskTools.js
@@ -8,7 +8,14 @@ const {
 const { buildTaskAttributes } = require('../../tasks/core/builders');
 const { Op } = require('sequelize');
 const { Task, Project, Tag } = require('../../../models');
-const { validateProjectAccess } = require('../../tasks/utils/validation');
+const {
+    validateProjectAccess,
+    validateDeferUntilAndDueDate,
+    getRecurringParentEndDate,
+} = require('../../tasks/utils/validation');
+const {
+    processDeferUntilForStorage,
+} = require('../../../utils/timezone-utils');
 const permissionsService = require('../../../services/permissionsService');
 
 async function findTaskByIdentifier(identifier) {
@@ -220,6 +227,11 @@ function registerTaskTools(server, context, tools) {
                     type: 'string',
                     description: 'Due date (ISO 8601 format)',
                 },
+                defer_until: {
+                    type: 'string',
+                    description:
+                        'Defer until date/time (ISO 8601 format) - task is hidden from view until this point',
+                },
                 project_id: {
                     type: 'number',
                     description: 'Project ID to assign task to',
@@ -240,13 +252,22 @@ function registerTaskTools(server, context, tools) {
                 ? await validateProjectAccess(params.project_id, context.userId)
                 : null;
 
+            const dueDate = params.due_date || null;
+            const deferUntil = processDeferUntilForStorage(
+                params.defer_until,
+                context.user.timezone
+            );
+
+            validateDeferUntilAndDueDate(deferUntil, dueDate);
+
             const taskData = {
                 user_id: context.userId,
                 name: params.name,
                 note: params.description || '',
                 priority: params.priority ? priorityMap[params.priority] : 1,
                 status: 0, // pending
-                due_date: params.due_date || null,
+                due_date: dueDate,
+                defer_until: deferUntil,
                 project_id: resolvedProjectId,
             };
 
@@ -299,56 +320,72 @@ function registerTaskTools(server, context, tools) {
     });
 
     // 4. update_task - Update existing task
+    const updateTaskProperties = {
+        id: {
+            type: ['number', 'string'],
+            description: 'Task ID or UID',
+        },
+        name: { type: 'string', description: 'New task name' },
+        description: { type: 'string', description: 'New description' },
+        priority: {
+            type: 'string',
+            enum: ['low', 'medium', 'high'],
+        },
+        status: {
+            type: 'string',
+            enum: [
+                'not_started',
+                'pending',
+                'in_progress',
+                'done',
+                'completed',
+                'archived',
+                'waiting',
+                'cancelled',
+                'planned',
+            ],
+        },
+        due_date: { type: 'string', description: 'New due date' },
+        defer_until: {
+            type: 'string',
+            description:
+                'Defer until date/time (ISO 8601 format) - task is hidden from view until this point; pass null or an empty string to clear it',
+        },
+        project_id: {
+            type: 'number',
+            description:
+                'Project ID to assign task to (use null to remove project)',
+        },
+        today: {
+            type: 'boolean',
+            description: 'Add to Today list',
+        },
+        tags: {
+            type: 'array',
+            items: { type: 'string' },
+            description:
+                'Array of tag names to assign (replaces existing tags)',
+        },
+    };
+
     tools.push({
         name: 'update_task',
         description: 'Update an existing task',
         inputSchema: {
             type: 'object',
-            properties: {
-                id: {
-                    type: ['number', 'string'],
-                    description: 'Task ID or UID',
-                },
-                name: { type: 'string', description: 'New task name' },
-                description: { type: 'string', description: 'New description' },
-                priority: {
-                    type: 'string',
-                    enum: ['low', 'medium', 'high'],
-                },
-                status: {
-                    type: 'string',
-                    enum: [
-                        'not_started',
-                        'pending',
-                        'in_progress',
-                        'done',
-                        'completed',
-                        'archived',
-                        'waiting',
-                        'cancelled',
-                        'planned',
-                    ],
-                },
-                due_date: { type: 'string', description: 'New due date' },
-                project_id: {
-                    type: 'number',
-                    description:
-                        'Project ID to assign task to (use null to remove project)',
-                },
-                today: {
-                    type: 'boolean',
-                    description: 'Add to Today list',
-                },
-                tags: {
-                    type: 'array',
-                    items: { type: 'string' },
-                    description:
-                        'Array of tag names to assign (replaces existing tags)',
-                },
-            },
+            properties: updateTaskProperties,
             required: ['id'],
         },
         handler: async (params) => {
+            const unsupportedFields = Object.keys(params).filter(
+                (key) => !(key in updateTaskProperties)
+            );
+            if (unsupportedFields.length > 0) {
+                throw new Error(
+                    `Unsupported field(s) for update_task: ${unsupportedFields.join(', ')}`
+                );
+            }
+
             const task = await findTaskByIdentifier(params.id);
 
             if (!task) {
@@ -392,6 +429,12 @@ function registerTaskTools(server, context, tools) {
             }
             if (params.due_date !== undefined)
                 updates.due_date = params.due_date;
+            if (params.defer_until !== undefined) {
+                updates.defer_until = processDeferUntilForStorage(
+                    params.defer_until,
+                    context.user.timezone
+                );
+            }
             if (params.project_id !== undefined) {
                 const validProjectId = await validateProjectAccess(
                     params.project_id,
@@ -400,6 +443,29 @@ function registerTaskTools(server, context, tools) {
                 updates.project_id = validProjectId;
             }
             if (params.today !== undefined) updates.today = params.today;
+
+            if (
+                updates.due_date !== undefined ||
+                updates.defer_until !== undefined
+            ) {
+                const finalDueDate =
+                    updates.due_date !== undefined
+                        ? updates.due_date
+                        : task.due_date;
+                const finalDeferUntil =
+                    updates.defer_until !== undefined
+                        ? updates.defer_until
+                        : task.defer_until;
+                const recurringParentEndDate = await getRecurringParentEndDate(
+                    task.recurring_parent_id,
+                    context.userId
+                );
+                validateDeferUntilAndDueDate(
+                    finalDeferUntil,
+                    finalDueDate,
+                    recurringParentEndDate
+                );
+            }
 
             await task.update(updates);
 

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -44,6 +44,7 @@ const {
     validateDeferUntilAndDueDate,
     validateAreaAccess,
     validateGoalAccess,
+    getRecurringParentEndDate,
 } = require('./utils/validation');
 const {
     buildTaskAttributes,
@@ -81,33 +82,6 @@ const {
 
 if (process.env.NODE_ENV === 'development') {
     enableQueryLogging();
-}
-
-/**
- * Fetches the recurrence end date for a recurring parent task.
- * Used for validating defer_until dates on recurring task instances.
- *
- * @param {number|null|undefined} recurringParentId - The ID of the recurring parent task
- * @param {number} userId - The user ID for access control
- * @returns {Promise<Date|null|undefined>} The parent's recurrence_end_date, null (infinite), or undefined (no parent)
- *          - undefined: no recurring parent (not a recurring instance)
- *          - null: recurring parent with no end date (infinite recurrence)
- *          - Date: recurring parent with specific end date
- */
-async function getRecurringParentEndDate(recurringParentId, userId) {
-    // No parent ID provided - not a recurring instance
-    if (!recurringParentId) return undefined;
-
-    const parent = await taskRepository.findByIdAndUser(
-        recurringParentId,
-        userId
-    );
-
-    // Parent not found or no access - treat as non-recurring (undefined)
-    if (!parent) return undefined;
-
-    // Return the end date (null for infinite, Date for specific end)
-    return parent.recurrence_end_date;
 }
 
 function expandRecurringTasks(

--- a/backend/modules/tasks/utils/validation.js
+++ b/backend/modules/tasks/utils/validation.js
@@ -189,6 +189,32 @@ async function validateGoalAccess(goalIdOrUid, userId) {
     return goal.id;
 }
 
+/**
+ * Fetches the recurrence end date for a recurring parent task.
+ * Used for validating defer_until dates on recurring task instances.
+ *
+ * @param {number|null|undefined} recurringParentId - The ID of the recurring parent task
+ * @param {number} userId - The user ID for access control
+ * @returns {Promise<Date|null|undefined>} The parent's recurrence_end_date, null (infinite), or undefined (no parent)
+ *          - undefined: no recurring parent (not a recurring instance)
+ *          - null: recurring parent with no end date (infinite recurrence)
+ *          - Date: recurring parent with specific end date
+ */
+async function getRecurringParentEndDate(recurringParentId, userId) {
+    // No parent ID provided - not a recurring instance
+    if (!recurringParentId) return undefined;
+
+    const parent = await Task.findOne({
+        where: { id: recurringParentId, user_id: userId },
+    });
+
+    // Parent not found or no access - treat as non-recurring (undefined)
+    if (!parent) return undefined;
+
+    // Return the end date (null for infinite, Date for specific end)
+    return parent.recurrence_end_date;
+}
+
 module.exports = {
     isValidTaskUid,
     validateProjectAccess,
@@ -196,4 +222,5 @@ module.exports = {
     validateDeferUntilAndDueDate,
     validateAreaAccess,
     validateGoalAccess,
+    getRecurringParentEndDate,
 };

--- a/backend/tests/integration/mcp/mcp-tools.test.js
+++ b/backend/tests/integration/mcp/mcp-tools.test.js
@@ -358,6 +358,52 @@ describe('MCP Tools Integration', () => {
                 const { content } = getToolContent(response);
                 expect(content.task.due_date).toBeDefined();
             });
+
+            it('should create a task with defer_until', async () => {
+                const dueDate = new Date(Date.now() + 172800000).toISOString();
+                const deferUntil = new Date(
+                    Date.now() + 86400000
+                ).toISOString();
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'create_task',
+                    {
+                        name: 'Task with Defer Until',
+                        due_date: dueDate,
+                        defer_until: deferUntil,
+                    }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.task.defer_until).toBeDefined();
+                expect(content.task.defer_until).not.toBeNull();
+            });
+
+            it('should reject a defer_until after the due date', async () => {
+                const dueDate = new Date(Date.now() + 86400000).toISOString();
+                const deferUntil = new Date(
+                    Date.now() + 172800000
+                ).toISOString();
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'create_task',
+                    {
+                        name: 'Bad Defer Until',
+                        due_date: dueDate,
+                        defer_until: deferUntil,
+                    }
+                );
+
+                expect(response.status).toBe(200);
+                const jsonRpc = parseSseResponse(response.text);
+                expect(jsonRpc.result.isError).toBe(true);
+
+                const created = await Task.findOne({
+                    where: { user_id: user.id, name: 'Bad Defer Until' },
+                });
+                expect(created).toBeNull();
+            });
         });
 
         describe('get_task', () => {
@@ -506,6 +552,87 @@ describe('MCP Tools Integration', () => {
 
                 await task.reload();
                 expect(task.status).toBe(6);
+            });
+
+            it('should update defer_until and persist it', async () => {
+                const task = await Task.create({
+                    user_id: user.id,
+                    name: 'Defer Me',
+                    status: 0,
+                    due_date: new Date(Date.now() + 172800000),
+                });
+                const deferUntil = new Date(
+                    Date.now() + 86400000
+                ).toISOString();
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'update_task',
+                    { id: task.id, defer_until: deferUntil }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.task.defer_until).toBeDefined();
+                expect(content.task.defer_until).not.toBeNull();
+
+                await task.reload();
+                expect(task.defer_until).not.toBeNull();
+            });
+
+            it('should reject a defer_until after the due date', async () => {
+                const dueDate = new Date(Date.now() + 86400000);
+                const task = await Task.create({
+                    user_id: user.id,
+                    name: 'Defer After Due',
+                    status: 0,
+                    due_date: dueDate,
+                });
+                const badDeferUntil = new Date(
+                    Date.now() + 172800000
+                ).toISOString();
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'update_task',
+                    { id: task.id, defer_until: badDeferUntil }
+                );
+
+                expect(response.status).toBe(200);
+                const jsonRpc = parseSseResponse(response.text);
+                expect(jsonRpc.result.isError).toBe(true);
+
+                await task.reload();
+                expect(task.defer_until).toBeNull();
+            });
+
+            it('should reject unsupported fields instead of silently ignoring them', async () => {
+                const task = await Task.create({
+                    user_id: user.id,
+                    name: 'Untouched',
+                    status: 0,
+                });
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'update_task',
+                    {
+                        id: task.id,
+                        name: 'Should Not Apply',
+                        recurrence_type: 'daily',
+                        recurrence_interval: 1,
+                    }
+                );
+
+                expect(response.status).toBe(200);
+                const jsonRpc = parseSseResponse(response.text);
+                expect(jsonRpc.result.isError).toBe(true);
+                const { content } = getToolContent(response);
+                expect(content._rawError).toContain('recurrence_type');
+                expect(content._rawError).toContain('recurrence_interval');
+
+                await task.reload();
+                expect(task.name).toBe('Untouched');
             });
         });
 

--- a/docs/14-mcp-integration.md
+++ b/docs/14-mcp-integration.md
@@ -239,6 +239,7 @@ Create a new task.
 | `description` | string | No | Task description/note |
 | `priority` | string | No | `low`, `medium`, or `high` (default: `medium`) |
 | `due_date` | string | No | ISO 8601 date |
+| `defer_until` | string | No | ISO 8601 date/time; task is hidden from view until this point |
 | `project_id` | number | No | Assign to a project |
 | `tags` | string[] | No | Array of tag names to apply |
 
@@ -269,7 +270,12 @@ Update an existing task.
 | `priority` | string | No | `low`, `medium`, `high` |
 | `status` | string | No | `pending`, `in_progress`, `completed`, `archived` |
 | `due_date` | string | No | New due date (ISO 8601) |
+| `defer_until` | string | No | New defer until date/time (ISO 8601); pass `null` or `""` to clear it |
+| `project_id` | number | No | Reassign to a project (`null` to remove) |
 | `today` | boolean | No | Add to Today list |
+| `tags` | string[] | No | Array of tag names (replaces existing tags) |
+
+Any parameter not in the table above is rejected with an error rather than silently ignored.
 
 **Example:**
 


### PR DESCRIPTION
## Description

The MCP `update_task` tool silently ignored `defer_until` and any other field not on its hand-maintained allowlist: the call returned a success response with the full task object, but nothing had actually changed, and there was no signal to the caller that part of the request was dropped.

This PR:
- Adds `defer_until` as a supported, timezone-aware parameter on both `create_task` and `update_task`, validated against `due_date` (and the recurring parent's end date, when applicable) using the same rules the REST API already enforces.
- Extracts the REST route's local `getRecurringParentEndDate` helper into `tasks/utils/validation.js` so both the REST route and the MCP tool share one implementation instead of duplicating it.
- Makes `update_task` reject calls containing any field outside its documented schema with a clear error, instead of silently discarding them (per the issue's secondary suggestion).

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1389

## Testing

**How did you test this?**

Added integration tests covering: creating/updating a task with `defer_until`, rejecting a `defer_until` after the due date, and rejecting unsupported fields (e.g. `recurrence_type`, `recurrence_interval`) on `update_task`. Ran the full backend task and MCP test suites plus lint.

**Commands run:**

- [x] `npm run lint:fix` / `npm run lint` (zero errors)
- [x] `cd backend && npx jest tests/integration/mcp/mcp-tools.test.js` (75 passed)
- [x] `cd backend && npx jest tests/unit/modules/tasks tests/integration/tasks tests/unit/utils/validation.test.js` (141 passed)
- [x] `npm run pre-push`

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests
- [x] Updated documentation (docs/14-mcp-integration.md)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

`create_task` and `update_task` still don't send `defer_until`/`due_date` through the exact same builder pipeline the REST API uses (`buildTaskAttributes`/`buildUpdateAttributes`), since the MCP tool's field set is intentionally smaller. If more parity is wanted later, that pipeline could be reused directly.
