### PR TITLE
Fix area overview/detail count mismatch

### DIFF
--- a/backend/tests/integration/areas.test.js
+++ b/backend/tests/integration/areas.test.js
@@ -1,6 +1,6 @@
 const request = require('supertest');
 const app = require('../../app');
-const { Area, User } = require('../../models');
+const { Area, Goal, Task, User } = require('../../models');
 const { createTestUser } = require('../helpers/testUtils');
 
 describe('Areas Routes', () => {
@@ -99,6 +99,44 @@ describe('Areas Routes', () => {
 
             expect(response.status).toBe(401);
             expect(response.body.error).toBe('Authentication required');
+        });
+
+        it('should include goal and task counts, covering all goal/task statuses', async () => {
+            await Goal.create({
+                title: 'Ship the roadmap',
+                area_id: area1.id,
+                user_id: user.id,
+                status: 'active',
+            });
+            await Goal.create({
+                title: 'Wrap up last quarter',
+                area_id: area1.id,
+                user_id: user.id,
+                status: 'achieved',
+            });
+            await Task.create({
+                name: 'Open task',
+                area_id: area1.id,
+                user_id: user.id,
+                status: 0, // not_started
+            });
+            await Task.create({
+                name: 'Done task',
+                area_id: area1.id,
+                user_id: user.id,
+                status: 2, // done
+            });
+
+            const response = await agent.get('/api/areas');
+
+            expect(response.status).toBe(200);
+            const workArea = response.body.find((a) => a.uid === area1.uid);
+            expect(workArea.goals_count).toBe(2);
+            expect(workArea.tasks_count).toBe(2);
+
+            const personalArea = response.body.find((a) => a.uid === area2.uid);
+            expect(personalArea.goals_count).toBe(0);
+            expect(personalArea.tasks_count).toBe(0);
         });
     });
 

--- a/frontend/__tests__/setup.ts
+++ b/frontend/__tests__/setup.ts
@@ -1,2 +1,13 @@
 // Jest setup for frontend tests
 import '@testing-library/jest-dom';
+
+// jsdom doesn't expose TextEncoder/TextDecoder, but react-router-dom requires
+// them at import time. Polyfill from Node's util module.
+import { TextEncoder, TextDecoder } from 'util';
+
+if (typeof (globalThis as any).TextEncoder === 'undefined') {
+    (globalThis as any).TextEncoder = TextEncoder;
+}
+if (typeof (globalThis as any).TextDecoder === 'undefined') {
+    (globalThis as any).TextDecoder = TextDecoder;
+}

--- a/frontend/components/Area/AreaDetails.tsx
+++ b/frontend/components/Area/AreaDetails.tsx
@@ -189,7 +189,7 @@ const AreaDetails: React.FC = () => {
                             <div className={`mt-3 flex gap-4 text-xs ${area.color ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'}`}>
                                 <span>{areaProjects.length} {t('areas.projects', 'projects')}</span>
                                 <span>{areaGoals.length} {t('areas.goals', 'goals')}</span>
-                                <span>{activeTasks.length} {t('areas.tasks', 'tasks')}</span>
+                                <span>{areaTasks.length} {t('areas.tasks', 'tasks')}</span>
                             </div>
                         </div>
                         <button

--- a/frontend/components/Area/__tests__/AreaDetails.test.tsx
+++ b/frontend/components/Area/__tests__/AreaDetails.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import AreaDetails from '../AreaDetails';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (_key: string, fallback: string) => fallback,
+    }),
+}));
+
+const area = {
+    id: 1,
+    uid: 'areauid1',
+    name: 'Work',
+    description: '',
+    color: null,
+};
+
+const goals = [
+    { uid: 'goal-1', title: 'Goal one', area_id: 1, status: 'active' },
+    { uid: 'goal-2', title: 'Goal two', area_id: 1, status: 'active' },
+];
+
+const tasks = [
+    { uid: 'task-1', name: 'Active task', status: 'not_started' },
+    { uid: 'task-2', name: 'Done task', status: 'done' },
+    { uid: 'task-3', name: 'Archived task', status: 'archived' },
+];
+
+jest.mock('../../../utils/tasksService', () => ({
+    fetchTasks: jest.fn(() => Promise.resolve({ tasks })),
+}));
+
+jest.mock('../../Task/TaskList', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('../AreaModal', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('../../../store/useStore', () => ({
+    useStore: (selector: any) =>
+        selector({
+            areasStore: {
+                areas: [area],
+                isLoading: false,
+                loadAreas: jest.fn(),
+            },
+            projectsStore: {
+                projects: [],
+                hasLoaded: true,
+                isLoading: false,
+                loadProjects: jest.fn(),
+            },
+            tasksStore: {
+                tasks: [],
+                setTasks: jest.fn(),
+            },
+            goalsStore: {
+                goals,
+                hasLoaded: true,
+                isLoading: false,
+                loadGoals: jest.fn(),
+                setGoals: jest.fn(),
+            },
+        }),
+}));
+
+const renderPage = () =>
+    render(
+        <MemoryRouter initialEntries={['/area/areauid1-work']}>
+            <Routes>
+                <Route path="/area/:uidSlug" element={<AreaDetails />} />
+            </Routes>
+        </MemoryRouter>
+    );
+
+describe('AreaDetails header stats', () => {
+    it('shows the total task count (active + completed), matching the tasks list below', async () => {
+        renderPage();
+
+        await waitFor(() => {
+            expect(screen.getByText('3 tasks')).toBeInTheDocument();
+        });
+
+        expect(screen.getByText('2 goals')).toBeInTheDocument();
+    });
+});

--- a/frontend/components/Areas.tsx
+++ b/frontend/components/Areas.tsx
@@ -22,12 +22,7 @@ const Areas: React.FC = () => {
     const { t } = useTranslation();
 
     // Use global store for consistency
-    const {
-        areas,
-        isLoading: loading,
-        hasLoaded,
-        loadAreas,
-    } = useStore((state: any) => state.areasStore);
+    const { areas, loadAreas } = useStore((state: any) => state.areasStore);
 
     const [isAreaModalOpen, setIsAreaModalOpen] = useState<boolean>(false);
     const [selectedArea, setSelectedArea] = useState<Area | null>(null);
@@ -40,10 +35,10 @@ const Areas: React.FC = () => {
     const dropdownRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
-        if (!hasLoaded && !loading) {
-            loadAreas();
-        }
-    }, [hasLoaded, loading, loadAreas]);
+        // Force a fresh fetch on every visit so the goal/task/project counts
+        // shown on the cards don't go stale after edits made elsewhere in the app.
+        loadAreas(true);
+    }, [loadAreas]);
 
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {

--- a/frontend/components/__tests__/Areas.test.tsx
+++ b/frontend/components/__tests__/Areas.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Areas from '../Areas';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string, fallback?: string) => fallback ?? key,
+    }),
+}));
+
+jest.mock('../Area/AreaModal', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('../Shared/ConfirmDialog', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+const loadAreas = jest.fn();
+
+jest.mock('../../store/useStore', () => {
+    const mockUseStore: any = (selector: any) =>
+        selector({ areasStore: { areas: [], loadAreas } });
+    mockUseStore.getState = () => ({
+        areasStore: {
+            areas: [],
+            setAreas: jest.fn(),
+            setLoading: jest.fn(),
+            setError: jest.fn(),
+            loadAreas,
+        },
+    });
+    return { useStore: mockUseStore };
+});
+
+describe('Areas overview page', () => {
+    it('forces a fresh reload of areas on mount so card counts do not go stale', () => {
+        render(<Areas />);
+
+        expect(loadAreas).toHaveBeenCalledWith(true);
+    });
+});

--- a/frontend/store/useStore.ts
+++ b/frontend/store/useStore.ts
@@ -26,7 +26,7 @@ interface AreasStore {
     setAreas: (areas: Area[]) => void;
     setLoading: (isLoading: boolean) => void;
     setError: (isError: boolean) => void;
-    loadAreas: () => Promise<void>;
+    loadAreas: (forceReload?: boolean) => Promise<void>;
 }
 
 interface ProjectsStore {
@@ -221,9 +221,10 @@ export const useStore = create<StoreState>((set: any) => ({
             })),
         setError: (isError) =>
             set((state) => ({ areasStore: { ...state.areasStore, isError } })),
-        loadAreas: async () => {
+        loadAreas: async (forceReload = false) => {
             const state = useStore.getState();
             if (state.areasStore.isLoading) return;
+            if (state.areasStore.hasLoaded && !forceReload) return;
 
             const { fetchAreas } = await import('../utils/areasService');
 


### PR DESCRIPTION
## Description

The Areas overview cards and the Area detail page showed different goal/task counts for the same area (e.g. overview: 0 goals / 53 tasks, detail: 2 goals / 29 tasks). Two separate bugs caused this:

1. **Goal count staleness**: the overview page fetches `GET /api/areas` (which includes `goals_count`/`tasks_count`/`projects_count`) once per session and never refreshes it. The detail page instead derives its goal count live from the goals store, which stays correct as goals are created/edited elsewhere. So the overview card could show a stale `0` while the detail page correctly showed `2`.
2. **Task count definition mismatch**: the detail page's header only counted active tasks (excluding done/archived), while the overview card's `tasks_count` counts all tasks regardless of status - matching the same convention used for goal counts and elsewhere in the app (Goals and Tags cards).

## Fix

- `areasStore.loadAreas` now supports a `forceReload` flag (matching the existing `goalsStore`/`tagsStore` pattern), and the Areas overview page forces a fresh fetch every time it's visited so the card counts don't go stale.
- The Area detail page header now shows the total task count (active + completed) instead of active-only, aligning it with the overview card and with the task list breakdown shown further down the same page.

As a side effect of adding frontend tests for this, I also fixed a pre-existing gap in the Jest setup: `TextEncoder`/`TextDecoder` weren't polyfilled for jsdom, which silently broke every test that imports `react-router-dom` (confirmed this on `main` too, e.g. `DailyAssistant.test.tsx`).

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1393

## Testing

**How did you test this?**

- Added a backend integration test asserting `GET /api/areas` returns correct `goals_count`/`tasks_count` covering multiple goal/task statuses.
- Added frontend tests: the overview page force-reloads areas on mount, and the detail page header shows the total task count.
- Ran the full frontend suite and the areas-related backend suite; verified no regressions.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] `npm run lint` / `npm run lint:fix` (0 errors)
- [x] `npm run frontend:test` (all suites pass)
- [x] `cd backend && npx jest tests/integration/areas.test.js tests/unit/models/area.test.js --runInBand` (all pass)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

A full `npm test` run showed 8 unrelated suite failures, all `beforeAll` timeouts in `tests/helpers/setup.js` during `sequelize.sync` under parallel workers (matches known backend-suite flakiness under parallel execution, none of the failing suites touch files changed in this PR). Running the affected suites serially confirms they pass cleanly.
