### PR TITLE
Add recurrence fields to MCP task create/update tools

### DIFF
--- a/backend/modules/mcp/tools/taskTools.js
+++ b/backend/modules/mcp/tools/taskTools.js
@@ -5,7 +5,8 @@ const {
     serializeTask,
     serializeTasks,
 } = require('../../tasks/core/serializers');
-const { buildTaskAttributes } = require('../../tasks/core/builders');
+const { calculateInitialDueDate } = require('../../tasks/core/builders');
+const { handleRecurrenceUpdate } = require('../../tasks/operations/recurring');
 const { Op } = require('sequelize');
 const { Task, Project, Tag } = require('../../../models');
 const {
@@ -17,6 +18,71 @@ const {
     processDeferUntilForStorage,
 } = require('../../../utils/timezone-utils');
 const permissionsService = require('../../../services/permissionsService');
+
+const RECURRENCE_TYPES = [
+    'none',
+    'daily',
+    'weekly',
+    'monthly',
+    'monthly_weekday',
+    'monthly_last_day',
+];
+
+const RECURRENCE_FIELDS = [
+    'recurrence_type',
+    'recurrence_interval',
+    'recurrence_end_date',
+    'recurrence_weekday',
+    'recurrence_weekdays',
+    'recurrence_month_day',
+    'recurrence_week_of_month',
+    'completion_based',
+];
+
+const recurrenceInputSchemaProperties = {
+    recurrence_type: {
+        type: 'string',
+        enum: RECURRENCE_TYPES,
+        description:
+            'Recurrence pattern for the task ("none" for a one-off task)',
+    },
+    recurrence_interval: {
+        type: 'number',
+        description:
+            'Repeat every N days/weeks/months, depending on recurrence_type (default 1)',
+    },
+    recurrence_weekday: {
+        type: 'number',
+        description:
+            'Weekday for "weekly" (single day) or "monthly_weekday" recurrence, 0=Sunday..6=Saturday',
+    },
+    recurrence_weekdays: {
+        type: 'array',
+        items: { type: 'number' },
+        description:
+            'Multiple weekdays for "weekly" recurrence (0=Sunday..6=Saturday); alternative to recurrence_weekday',
+    },
+    recurrence_month_day: {
+        type: 'number',
+        description:
+            'Day of month for "monthly" recurrence (1-31, or -1 for the last day of the month)',
+    },
+    recurrence_week_of_month: {
+        type: 'number',
+        description:
+            'Week of month for "monthly_weekday" recurrence (1-5, or -1 for the last)',
+    },
+    recurrence_end_date: {
+        type: 'string',
+        description:
+            'Optional end date for the recurrence (ISO 8601 format); omit for indefinite recurrence',
+    },
+    completion_based: {
+        type: 'boolean',
+        description:
+            'If true, the next occurrence is scheduled from the completion date instead of the fixed schedule',
+    },
+};
 
 async function findTaskByIdentifier(identifier) {
     const isNumeric = !isNaN(identifier);
@@ -241,6 +307,7 @@ function registerTaskTools(server, context, tools) {
                     items: { type: 'string' },
                     description: 'Array of tag names',
                 },
+                ...recurrenceInputSchemaProperties,
             },
             required: ['name'],
         },
@@ -252,7 +319,18 @@ function registerTaskTools(server, context, tools) {
                 ? await validateProjectAccess(params.project_id, context.userId)
                 : null;
 
-            const dueDate = params.due_date || null;
+            const recurrenceType = params.recurrence_type || 'none';
+            let dueDate = params.due_date || null;
+            if (recurrenceType !== 'none' && !dueDate) {
+                // Calculate the first occurrence based on the recurrence pattern,
+                // matching the behavior of POST /api/task
+                dueDate = calculateInitialDueDate({
+                    recurrence_type: recurrenceType,
+                    recurrence_month_day: params.recurrence_month_day,
+                    recurrence_weekday: params.recurrence_weekday,
+                    recurrence_weekdays: params.recurrence_weekdays,
+                });
+            }
             const deferUntil = processDeferUntilForStorage(
                 params.defer_until,
                 context.user.timezone
@@ -269,6 +347,26 @@ function registerTaskTools(server, context, tools) {
                 due_date: dueDate,
                 defer_until: deferUntil,
                 project_id: resolvedProjectId,
+                recurrence_type: recurrenceType,
+                recurrence_interval: params.recurrence_interval ?? null,
+                recurrence_end_date: params.recurrence_end_date || null,
+                recurrence_weekday:
+                    params.recurrence_weekday !== undefined
+                        ? params.recurrence_weekday
+                        : null,
+                recurrence_weekdays:
+                    params.recurrence_weekdays !== undefined
+                        ? params.recurrence_weekdays
+                        : null,
+                recurrence_month_day:
+                    params.recurrence_month_day !== undefined
+                        ? params.recurrence_month_day
+                        : null,
+                recurrence_week_of_month:
+                    params.recurrence_week_of_month !== undefined
+                        ? params.recurrence_week_of_month
+                        : null,
+                completion_based: params.completion_based || false,
             };
 
             const task = await taskRepository.create(taskData);
@@ -366,6 +464,7 @@ function registerTaskTools(server, context, tools) {
             description:
                 'Array of tag names to assign (replaces existing tags)',
         },
+        ...recurrenceInputSchemaProperties,
     };
 
     tools.push({
@@ -444,6 +543,53 @@ function registerTaskTools(server, context, tools) {
             }
             if (params.today !== undefined) updates.today = params.today;
 
+            if (params.recurrence_type !== undefined)
+                updates.recurrence_type = params.recurrence_type;
+            if (params.recurrence_interval !== undefined)
+                updates.recurrence_interval = params.recurrence_interval;
+            if (params.recurrence_end_date !== undefined)
+                updates.recurrence_end_date = params.recurrence_end_date;
+            if (params.recurrence_weekday !== undefined)
+                updates.recurrence_weekday = params.recurrence_weekday;
+            if (params.recurrence_weekdays !== undefined)
+                updates.recurrence_weekdays = params.recurrence_weekdays;
+            if (params.recurrence_month_day !== undefined)
+                updates.recurrence_month_day = params.recurrence_month_day;
+            if (params.recurrence_week_of_month !== undefined)
+                updates.recurrence_week_of_month =
+                    params.recurrence_week_of_month;
+            if (params.completion_based !== undefined)
+                updates.completion_based = params.completion_based;
+
+            const isAddingRecurrence =
+                params.recurrence_type !== undefined &&
+                params.recurrence_type !== 'none' &&
+                (task.recurrence_type === 'none' || !task.recurrence_type);
+
+            if (
+                updates.due_date === undefined &&
+                isAddingRecurrence &&
+                (!task.due_date || task.due_date === '')
+            ) {
+                // Calculate the first occurrence based on the recurrence pattern,
+                // matching the behavior of PATCH /api/task/:uid
+                updates.due_date = calculateInitialDueDate({
+                    recurrence_type: updates.recurrence_type,
+                    recurrence_month_day:
+                        updates.recurrence_month_day !== undefined
+                            ? updates.recurrence_month_day
+                            : task.recurrence_month_day,
+                    recurrence_weekday:
+                        updates.recurrence_weekday !== undefined
+                            ? updates.recurrence_weekday
+                            : task.recurrence_weekday,
+                    recurrence_weekdays:
+                        updates.recurrence_weekdays !== undefined
+                            ? updates.recurrence_weekdays
+                            : task.recurrence_weekdays,
+                });
+            }
+
             if (
                 updates.due_date !== undefined ||
                 updates.defer_until !== undefined
@@ -466,6 +612,10 @@ function registerTaskTools(server, context, tools) {
                     recurringParentEndDate
                 );
             }
+
+            // Detect recurrence/template changes before applying the update so
+            // future recurring instances get regenerated, matching PATCH /api/task/:uid
+            await handleRecurrenceUpdate(task, RECURRENCE_FIELDS, params);
 
             await task.update(updates);
 

--- a/backend/tests/integration/mcp/mcp-tools.test.js
+++ b/backend/tests/integration/mcp/mcp-tools.test.js
@@ -404,6 +404,62 @@ describe('MCP Tools Integration', () => {
                 });
                 expect(created).toBeNull();
             });
+
+            it('should create a recurring task with recurrence fields', async () => {
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'create_task',
+                    {
+                        name: 'Weekly Recurring Task',
+                        recurrence_type: 'weekly',
+                        recurrence_interval: 2,
+                        recurrence_weekday: 3,
+                        recurrence_end_date: '2030-01-01',
+                        completion_based: true,
+                    }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.task.recurrence_type).toBe('weekly');
+                expect(content.task.recurrence_interval).toBe(2);
+                expect(content.task.recurrence_weekday).toBe(3);
+                expect(content.task.recurrence_end_date).toBeDefined();
+                expect(content.task.completion_based).toBe(true);
+                // No due date was given, so one should be computed from the pattern
+                expect(content.task.due_date).toBeDefined();
+            });
+
+            it('should create a recurring task with multiple weekdays', async () => {
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'create_task',
+                    {
+                        name: 'Multi-Weekday Recurring Task',
+                        recurrence_type: 'weekly',
+                        recurrence_weekdays: [1, 3, 5],
+                    }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.task.recurrence_type).toBe('weekly');
+                expect(content.task.recurrence_weekdays).toEqual([1, 3, 5]);
+            });
+
+            it('should default recurrence_type to none when omitted', async () => {
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'create_task',
+                    {
+                        name: 'Plain Task',
+                    }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.task.recurrence_type).toBe('none');
+            });
         });
 
         describe('get_task', () => {
@@ -619,8 +675,7 @@ describe('MCP Tools Integration', () => {
                     {
                         id: task.id,
                         name: 'Should Not Apply',
-                        recurrence_type: 'daily',
-                        recurrence_interval: 1,
+                        nonexistent_field: 'bogus',
                     }
                 );
 
@@ -628,11 +683,65 @@ describe('MCP Tools Integration', () => {
                 const jsonRpc = parseSseResponse(response.text);
                 expect(jsonRpc.result.isError).toBe(true);
                 const { content } = getToolContent(response);
-                expect(content._rawError).toContain('recurrence_type');
-                expect(content._rawError).toContain('recurrence_interval');
+                expect(content._rawError).toContain('nonexistent_field');
 
                 await task.reload();
                 expect(task.name).toBe('Untouched');
+            });
+
+            it('should update recurrence fields on an existing task', async () => {
+                const task = await Task.create({
+                    user_id: user.id,
+                    name: 'Recurrence Update Task',
+                    status: 0,
+                    recurrence_type: 'daily',
+                    recurrence_interval: 1,
+                });
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'update_task',
+                    {
+                        id: task.id,
+                        recurrence_type: 'monthly',
+                        recurrence_interval: 3,
+                        recurrence_month_day: 15,
+                    }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.task.recurrence_type).toBe('monthly');
+                expect(content.task.recurrence_interval).toBe(3);
+                expect(content.task.recurrence_month_day).toBe(15);
+
+                await task.reload();
+                expect(task.recurrence_type).toBe('monthly');
+                expect(task.recurrence_interval).toBe(3);
+                expect(task.recurrence_month_day).toBe(15);
+            });
+
+            it('should compute a due date when recurrence is newly added without one', async () => {
+                const task = await Task.create({
+                    user_id: user.id,
+                    name: 'No Due Date Task',
+                    status: 0,
+                });
+                expect(task.due_date).toBeFalsy();
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'update_task',
+                    {
+                        id: task.id,
+                        recurrence_type: 'daily',
+                    }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.task.recurrence_type).toBe('daily');
+                expect(content.task.due_date).toBeDefined();
             });
         });
 

--- a/docs/14-mcp-integration.md
+++ b/docs/14-mcp-integration.md
@@ -242,6 +242,14 @@ Create a new task.
 | `defer_until` | string | No | ISO 8601 date/time; task is hidden from view until this point |
 | `project_id` | number | No | Assign to a project |
 | `tags` | string[] | No | Array of tag names to apply |
+| `recurrence_type` | string | No | `none`, `daily`, `weekly`, `monthly`, `monthly_weekday`, or `monthly_last_day` |
+| `recurrence_interval` | number | No | Repeat every N days/weeks/months (default: 1) |
+| `recurrence_weekday` | number | No | Weekday for `weekly`/`monthly_weekday` recurrence (0=Sunday..6=Saturday) |
+| `recurrence_weekdays` | number[] | No | Multiple weekdays for `weekly` recurrence, alternative to `recurrence_weekday` |
+| `recurrence_month_day` | number | No | Day of month for `monthly` recurrence (1-31, or -1 for last day) |
+| `recurrence_week_of_month` | number | No | Week of month for `monthly_weekday` recurrence (1-5, or -1 for last) |
+| `recurrence_end_date` | string | No | Optional end date for the recurrence (ISO 8601); omit for indefinite recurrence |
+| `completion_based` | boolean | No | If true, the next occurrence is scheduled from the completion date instead of the fixed schedule |
 
 **Example:**
 
@@ -252,6 +260,17 @@ Create a new task.
     "priority": "high",
     "due_date": "2026-04-27T17:00:00Z",
     "tags": ["code-review", "urgent"]
+}
+```
+
+**Recurring task example:**
+
+```json
+{
+    "name": "Take out the trash",
+    "recurrence_type": "weekly",
+    "recurrence_weekday": 2,
+    "recurrence_interval": 1
 }
 ```
 
@@ -274,6 +293,14 @@ Update an existing task.
 | `project_id` | number | No | Reassign to a project (`null` to remove) |
 | `today` | boolean | No | Add to Today list |
 | `tags` | string[] | No | Array of tag names (replaces existing tags) |
+| `recurrence_type` | string | No | `none`, `daily`, `weekly`, `monthly`, `monthly_weekday`, or `monthly_last_day` |
+| `recurrence_interval` | number | No | Repeat every N days/weeks/months |
+| `recurrence_weekday` | number | No | Weekday for `weekly`/`monthly_weekday` recurrence (0=Sunday..6=Saturday) |
+| `recurrence_weekdays` | number[] | No | Multiple weekdays for `weekly` recurrence, alternative to `recurrence_weekday` |
+| `recurrence_month_day` | number | No | Day of month for `monthly` recurrence (1-31, or -1 for last day) |
+| `recurrence_week_of_month` | number | No | Week of month for `monthly_weekday` recurrence (1-5, or -1 for last) |
+| `recurrence_end_date` | string | No | Optional end date for the recurrence (ISO 8601) |
+| `completion_based` | boolean | No | If true, the next occurrence is scheduled from the completion date instead of the fixed schedule |
 
 Any parameter not in the table above is rejected with an error rather than silently ignored.
 
@@ -286,6 +313,8 @@ Any parameter not in the table above is rejected with an error rather than silen
     "status": "in_progress"
 }
 ```
+
+Changing recurrence fields on a task that already has future recurring instances regenerates those instances, the same way `PATCH /api/task/:uid` does.
 
 ---
 


### PR DESCRIPTION
## Description

The MCP server's `create_task` and `update_task` tools only exposed a narrow field set (name, description, due_date, priority, project_id, tags, status, today), with no way to set fine-grained recurrence. This PR adds the same recurrence fields the REST API (`PATCH /api/task/:uid`) and the app's "Recurrence Settings" UI already support: `recurrence_type`, `recurrence_interval`, `recurrence_weekday`, `recurrence_weekdays`, `recurrence_month_day`, `recurrence_week_of_month`, `recurrence_end_date`, and `completion_based`.

- `create_task` accepts the new fields and, when a recurrence is set without an explicit `due_date`, computes the first occurrence from the pattern (mirroring `POST /api/task`).
- `update_task` applies the same fields, computes a due date when recurrence is newly added to a task without one, and regenerates future recurring instances when recurrence or template fields change (mirroring `PATCH /api/task/:uid`'s `handleRecurrenceUpdate`).
- `docs/14-mcp-integration.md` documents the new parameters for both tools.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1388

## Testing

**How did you test this?**

Added integration tests covering creating a recurring task (single weekday, multiple weekdays, default `recurrence_type: none`) and updating an existing task's recurrence fields, including auto-computed due dates when recurrence is newly added.

**Commands run:**

- [x] `npm run lint:fix` then `npm run lint` (zero errors)
- [x] `npx jest tests/integration/mcp/mcp-tools.test.js tests/unit/models/task.test.js` (98 passed)
- [ ] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [x] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

Scope is limited to the MCP tool layer (`backend/modules/mcp/tools/taskTools.js`); no REST API, model, or frontend changes were needed since the underlying fields, validation, and recurrence logic already existed.
