### PR TITLE
Polish sidebar: consistent alignment, expandable People, unified active/hover styles

### DIFF
--- a/frontend/Layout.tsx
+++ b/frontend/Layout.tsx
@@ -9,15 +9,18 @@ import ProjectModal from './components/Project/ProjectModal';
 import NoteModal from './components/Note/NoteModal';
 import AreaModal from './components/Area/AreaModal';
 import TagModal from './components/Tag/TagModal';
+import PersonModal from './components/People/PersonModal';
 import { Note } from './entities/Note';
 import { Area } from './entities/Area';
 import { Tag } from './entities/Tag';
+import { Person } from './entities/Person';
 import { Project } from './entities/Project';
 import { User } from './entities/User';
 import { useStore } from './store/useStore';
 import { createNote, updateNote } from './utils/notesService';
 import { createArea, updateArea } from './utils/areasService';
 import { createTag, updateTag } from './utils/tagsService';
+import { createPerson, updatePerson } from './utils/peopleService';
 import {
     fetchProjects,
     createProject,
@@ -56,10 +59,12 @@ const Layout: React.FC<LayoutProps> = ({
     const [isNoteModalOpen, setIsNoteModalOpen] = useState(false);
     const [isAreaModalOpen, setIsAreaModalOpen] = useState(false);
     const [isTagModalOpen, setIsTagModalOpen] = useState(false);
+    const [isPersonModalOpen, setIsPersonModalOpen] = useState(false);
 
     const [selectedNote, setSelectedNote] = useState<Note | null>(null);
     const [selectedArea, setSelectedArea] = useState<Area | null>(null);
     const [selectedTag, setSelectedTag] = useState<Tag | null>(null);
+    const [selectedPerson, setSelectedPerson] = useState<Person | null>(null);
     const [keyboardShortcuts, setKeyboardShortcuts] = useState<KeyboardShortcutsConfig | null>(null);
 
     // Fetch keyboard shortcuts from profile
@@ -215,6 +220,16 @@ const Layout: React.FC<LayoutProps> = ({
         setSelectedTag(null);
     };
 
+    const openPersonModal = (person: Person | null = null) => {
+        setSelectedPerson(person);
+        setIsPersonModalOpen(true);
+    };
+
+    const closePersonModal = () => {
+        setIsPersonModalOpen(false);
+        setSelectedPerson(null);
+    };
+
     const handleSaveNote = async (noteData: Note) => {
         try {
             let result: Note;
@@ -346,6 +361,45 @@ const Layout: React.FC<LayoutProps> = ({
         }
     };
 
+    const handleSavePerson = async (personData: Partial<Person>) => {
+        try {
+            const currentPeople = useStore.getState().peopleStore.people;
+            if (selectedPerson?.uid) {
+                const { person: result } = await updatePerson(
+                    selectedPerson.uid,
+                    personData
+                );
+                // Update existing person in global store
+                useStore
+                    .getState()
+                    .peopleStore.setPeople(
+                        currentPeople.map((person) =>
+                            person.uid === result.uid ? result : person
+                        )
+                    );
+            } else {
+                const { person: result } = await createPerson(
+                    personData as Omit<
+                        Person,
+                        'id' | 'uid' | 'user_id' | 'created_at' | 'updated_at'
+                    >
+                );
+                // Add new person to global store
+                useStore
+                    .getState()
+                    .peopleStore.setPeople([...currentPeople, result]);
+            }
+            closePersonModal();
+        } catch (error: any) {
+            console.error('Error saving person:', error);
+            // Don't close modal if there's an auth error (user will be redirected)
+            if (isAuthError(error)) {
+                return;
+            }
+            closePersonModal();
+        }
+    };
+
     const mainContentMarginLeft = isSidebarOpen ? 'ml-sidebar' : 'ml-0';
 
     const isLoading =
@@ -383,6 +437,7 @@ const Layout: React.FC<LayoutProps> = ({
                     openNoteModal={openNoteModal}
                     openAreaModal={openAreaModal}
                     openTagModal={openTagModal}
+                    openPersonModal={openPersonModal}
                     openNewHabit={openNewHabit}
                     notes={notes}
                     areas={areas}
@@ -422,6 +477,7 @@ const Layout: React.FC<LayoutProps> = ({
                     openNoteModal={openNoteModal}
                     openAreaModal={openAreaModal}
                     openTagModal={openTagModal}
+                    openPersonModal={openPersonModal}
                     openNewHabit={openNewHabit}
                     notes={notes}
                     areas={areas}
@@ -461,6 +517,7 @@ const Layout: React.FC<LayoutProps> = ({
                     openNoteModal={openNoteModal}
                     openAreaModal={openAreaModal}
                     openTagModal={openTagModal}
+                    openPersonModal={openPersonModal}
                     openNewHabit={openNewHabit}
                     notes={notes}
                     areas={areas}
@@ -556,6 +613,14 @@ const Layout: React.FC<LayoutProps> = ({
                         onClose={closeTagModal}
                         onSave={handleSaveTag}
                         tag={selectedTag}
+                    />
+                )}
+
+                {isPersonModalOpen && (
+                    <PersonModal
+                        person={selectedPerson}
+                        onSave={handleSavePerson}
+                        onClose={closePersonModal}
                     />
                 )}
 

--- a/frontend/components/Notes.tsx
+++ b/frontend/components/Notes.tsx
@@ -7,7 +7,6 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useDebouncedCallback } from 'use-debounce';
-import { MagnifyingGlassIcon, PlusIcon } from '@heroicons/react/24/solid';
 import {
     PencilIcon,
     TrashIcon,
@@ -21,18 +20,17 @@ import {
 import PushPinIcon from './Shared/Icons/PushPinIcon';
 import { useToast } from './Shared/ToastContext';
 import { Link, useParams, useNavigate } from 'react-router-dom';
-import { SortOption } from './Shared/SortFilterButton';
 import NoteModal from './Note/NoteModal';
 import ConfirmDialog from './Shared/ConfirmDialog';
 import DiscardChangesDialog from './Shared/DiscardChangesDialog';
 import MarkdownRenderer from './Shared/MarkdownRenderer';
-import IconSortDropdown from './Shared/IconSortDropdown';
 import TagInput from './Tag/TagInput';
 import { Note } from '../entities/Note';
 import { createNote, updateNote } from '../utils/notesService';
 import { deleteNoteWithStoreUpdate } from '../utils/noteDeleteUtils';
 import { useStore } from '../store/useStore';
 import { createProject } from '../utils/projectsService';
+import { sortNotesByOrder } from '../utils/notesTreeUtils';
 import { ENABLE_NOTE_COLOR } from '../config/featureFlags';
 import { COLORS } from './Shared/ColorPicker';
 import NoteFocusMode from './Note/NoteFocusMode';
@@ -64,8 +62,10 @@ const Notes: React.FC = () => {
     const [isNoteModalOpen, setIsNoteModalOpen] = useState(false);
     const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
     const [noteToDelete, setNoteToDelete] = useState<Note | null>(null);
-    const [searchQuery, setSearchQuery] = useState('');
-    const [orderBy, setOrderBy] = useState<string>('created_at:desc');
+    // Notes are browsed via the sidebar's folder tree now, not a list on
+    // this page - this page is the editor/preview pane only. `orderBy`
+    // still picks which note auto-selects first on load.
+    const orderBy = 'updated_at:desc';
     const [showProjectDropdown, setShowProjectDropdown] = useState(false);
     const [showTagsInput, setShowTagsInput] = useState(false);
     const [showDiscardDialog, setShowDiscardDialog] = useState(false);
@@ -141,16 +141,6 @@ const Notes: React.FC = () => {
         },
         [editingNote, debouncedSave]
     );
-
-    const sortOptions: SortOption[] = [
-        { value: 'created_at:desc', label: t('sort.created_at', 'Created At') },
-        { value: 'title:asc', label: t('sort.name', 'Title') },
-        { value: 'updated_at:desc', label: t('common.updated', 'Updated') },
-    ];
-
-    const handleSortChange = (newOrderBy: string) => {
-        setOrderBy(newOrderBy);
-    };
 
     const handleSelectNote = async (note: Note | null) => {
         if (isEditing && editingNote) {
@@ -232,14 +222,6 @@ const Notes: React.FC = () => {
         });
         setIsEditing(true);
         setSaveStatus('saved');
-    };
-
-    const handleNewNote = () => {
-        setIsEditing(true);
-        setEditingNote({ title: '', content: '', tags: [] });
-        setPreviewNote(null);
-        setSaveStatus('saved');
-        navigate('/notes', { replace: true });
     };
 
     const handleSaveInlineNote = async () => {
@@ -390,51 +372,10 @@ const Notes: React.FC = () => {
         }
     };
 
-    const filteredNotes = useMemo(() => {
-        return notes.filter(
-            (note) =>
-                note.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-                note.content.toLowerCase().includes(searchQuery.toLowerCase())
-        );
-    }, [notes, searchQuery]);
-
-    const sortedNotes = useMemo(() => {
-        return [...filteredNotes].sort((a, b) => {
-            const [field, direction] = orderBy.split(':');
-            const isAsc = direction === 'asc';
-
-            let valueA: string | number;
-            let valueB: string | number;
-
-            switch (field) {
-                case 'title':
-                    valueA = a.title?.toLowerCase() || '';
-                    valueB = b.title?.toLowerCase() || '';
-                    break;
-                case 'updated_at':
-                    valueA = a.updated_at
-                        ? new Date(a.updated_at).getTime()
-                        : 0;
-                    valueB = b.updated_at
-                        ? new Date(b.updated_at).getTime()
-                        : 0;
-                    break;
-                case 'created_at':
-                default:
-                    valueA = a.created_at
-                        ? new Date(a.created_at).getTime()
-                        : 0;
-                    valueB = b.created_at
-                        ? new Date(b.created_at).getTime()
-                        : 0;
-                    break;
-            }
-
-            if (valueA < valueB) return isAsc ? -1 : 1;
-            if (valueA > valueB) return isAsc ? 1 : -1;
-            return 0;
-        });
-    }, [filteredNotes, orderBy]);
+    const sortedNotes = useMemo(
+        () => sortNotesByOrder(notes, orderBy),
+        [notes, orderBy]
+    );
 
     useEffect(() => {
         hasAutoSelected.current = false;
@@ -522,108 +463,9 @@ const Notes: React.FC = () => {
     return (
         <div className="flex flex-col h-[calc(100vh-6rem)] overflow-hidden">
             <div className="flex-1 flex flex-col min-h-0 overflow-hidden pt-2">
-                <div className="flex flex-col md:flex-row flex-1 min-h-0 overflow-hidden">
+                <div className="flex flex-1 min-h-0 overflow-hidden">
                     <div
-                        className={`${previewNote || isEditing ? 'hidden md:flex' : 'flex'} flex-col md:w-80 w-full h-full md:h-auto flex-shrink-0 min-h-0`}
-                    >
-                        <div className="flex items-center justify-between mb-2 mx-3 flex-shrink-0">
-                            <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                                {t('notes.title')}
-                            </h3>
-                            <div className="flex items-center gap-2">
-                                <IconSortDropdown
-                                    options={sortOptions}
-                                    value={orderBy}
-                                    onChange={handleSortChange}
-                                    ariaLabel={t(
-                                        'notes.sortNotes',
-                                        'Sort notes'
-                                    )}
-                                    title={t('notes.sortNotes', 'Sort notes')}
-                                    dropdownLabel={t('notes.sortBy', 'Sort by')}
-                                />
-                                <button
-                                    onClick={handleNewNote}
-                                    className="p-1 text-gray-600 dark:text-gray-400 hover:text-blue-600 dark:hover:text-blue-400 focus:outline-none transition-colors"
-                                    aria-label={t('notes.addNote', 'Add Note')}
-                                >
-                                    <PlusIcon className="h-5 w-5" />
-                                </button>
-                            </div>
-                        </div>
-
-                        <div className="mb-2 mx-4 flex-shrink-0">
-                            <div className="flex items-center bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md p-2">
-                                <MagnifyingGlassIcon className="h-4 w-4 text-gray-500 dark:text-gray-400 mr-2" />
-                                <input
-                                    type="text"
-                                    placeholder={t('notes.searchPlaceholder')}
-                                    value={searchQuery}
-                                    onChange={(e) =>
-                                        setSearchQuery(e.target.value)
-                                    }
-                                    className="w-full bg-transparent border-none focus:ring-0 focus:outline-none dark:text-white text-sm"
-                                />
-                            </div>
-                        </div>
-
-                        <div className="space-y-0 overflow-y-auto flex-1 min-h-0">
-                            {sortedNotes.length === 0 ? (
-                                <div className="flex items-center justify-center h-full p-4">
-                                    <p className="text-gray-500 dark:text-gray-400 text-sm text-center">
-                                        {t('notes.noNotesFound')}
-                                    </p>
-                                </div>
-                            ) : (
-                                sortedNotes.map((note, index) => (
-                                    <div
-                                        key={note.uid}
-                                        onClick={() => handleSelectNote(note)}
-                                        className={`relative p-5 cursor-pointer ${
-                                            previewNote?.uid === note.uid
-                                                ? 'bg-white dark:bg-gray-900 border-b border-transparent mx-4 rounded-lg'
-                                                : index !==
-                                                    sortedNotes.length - 1
-                                                  ? 'border-b border-gray-200/30 dark:border-gray-700/30 hover:bg-gray-50 dark:hover:bg-gray-800 mx-4'
-                                                  : 'border-b border-transparent hover:bg-gray-50 dark:hover:bg-gray-800 mx-4'
-                                        }`}
-                                    >
-                                        <div className="flex items-center gap-2 mb-1 min-w-0">
-                                            {note.color && (
-                                                <span
-                                                    className="w-2.5 h-2.5 rounded-full flex-shrink-0 ring-1 ring-black/30 dark:ring-white/30"
-                                                    style={{ backgroundColor: note.color }}
-                                                />
-                                            )}
-                                            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">
-                                                {note.title ||
-                                                    t(
-                                                        'notes.untitled',
-                                                        'Untitled Note'
-                                                    )}
-                                            </h3>
-                                        </div>
-                                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">
-                                            {note.content.substring(0, 100)}
-                                            {note.content.length > 100
-                                                ? '...'
-                                                : ''}
-                                        </p>
-                                        <div className="text-xs text-gray-400 dark:text-gray-500 mt-2">
-                                            {new Date(
-                                                note.updated_at ||
-                                                    note.created_at ||
-                                                    ''
-                                            ).toLocaleDateString()}
-                                        </div>
-                                    </div>
-                                ))
-                            )}
-                        </div>
-                    </div>
-
-                    <div
-                        className={`${previewNote || isEditing ? 'flex' : 'hidden md:flex'} flex-1 flex-col overflow-hidden h-full rounded-md md:h-auto ${activeNoteColor ? '' : 'bg-white dark:bg-gray-900'}`}
+                        className={`flex flex-1 flex-col overflow-hidden h-full rounded-md ${activeNoteColor ? '' : 'bg-white dark:bg-gray-900'}`}
                         style={{
                             backgroundColor: activeNoteColor || undefined,
                         }}
@@ -632,18 +474,6 @@ const Notes: React.FC = () => {
                             <div className="flex-1 flex flex-col overflow-hidden">
                                 <div className="flex items-start justify-between mb-3 flex-shrink-0 px-6 md:px-8 pt-5">
                                     <div className="flex-1">
-                                        <button
-                                            onClick={() => {
-                                                if (editingNote.title) {
-                                                    handleSaveInlineNote();
-                                                } else {
-                                                    setShowDiscardDialog(true);
-                                                }
-                                            }}
-                                            className="md:hidden mb-2 text-blue-600 dark:text-blue-400 hover:underline text-sm"
-                                        >
-                                            ← {t('common.back', 'Back to list')}
-                                        </button>
                                         <input
                                             type="text"
                                             value={editingNote.title || ''}
@@ -1018,14 +848,6 @@ const Notes: React.FC = () => {
                             <div className="flex-1 flex flex-col overflow-hidden">
                                 <div className="flex items-start justify-between mb-3 flex-shrink-0 px-6 md:px-8 pt-5">
                                     <div className="flex-1">
-                                        <button
-                                            onClick={() =>
-                                                handleSelectNote(null)
-                                            }
-                                            className="md:hidden mb-2 text-blue-600 dark:text-blue-400 hover:underline text-sm"
-                                        >
-                                            ← {t('common.back', 'Back to list')}
-                                        </button>
                                         <h1
                                             onClick={() =>
                                                 handleEditNote(previewNote)

--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { Area } from '../entities/Area';
 import { Note } from '../entities/Note';
 import { Tag } from '../entities/Tag';
+import { Person } from '../entities/Person';
 import SidebarAreas from './Sidebar/SidebarAreas';
 import SidebarFooter from './Sidebar/SidebarFooter';
 import SidebarNav from './Sidebar/SidebarNav';
@@ -31,6 +32,7 @@ interface SidebarProps {
     openNoteModal: (note: Note | null) => void;
     openAreaModal: (area: Area | null) => void;
     openTagModal: (tag: Tag | null) => void;
+    openPersonModal: (person: Person | null) => void;
     openNewHabit: () => void;
     notes: Note[];
     areas: Area[];
@@ -49,6 +51,7 @@ const Sidebar: React.FC<SidebarProps> = ({
     openNoteModal,
     openAreaModal,
     openTagModal,
+    openPersonModal,
     openNewHabit,
     notes,
     areas,
@@ -143,6 +146,7 @@ const Sidebar: React.FC<SidebarProps> = ({
                             <SidebarPeople
                                 handleNavClick={handleNavClick}
                                 location={location}
+                                openPersonModal={openPersonModal}
                             />
                         </div>
                         {habitsEnabled && (

--- a/frontend/components/Sidebar/SidebarAdmin.tsx
+++ b/frontend/components/Sidebar/SidebarAdmin.tsx
@@ -18,9 +18,9 @@ const SidebarAdmin: React.FC<SidebarAdminProps> = ({ handleNavClick, location, c
 
     const linkClass = (path: string) => {
         const isActive = location.pathname.startsWith(path);
-        return `flex items-center rounded-[8px] px-[10px] py-[5px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] hover:text-gray-900 dark:hover:text-white ${
+        return `flex items-center rounded-[8px] px-[10px] py-[4px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] hover:text-gray-900 dark:hover:text-white ${
             isActive
-                ? 'text-gray-900 dark:text-[oklch(88%_0.004_95)]'
+                ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)] text-gray-900 dark:text-white'
                 : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]'
         }`;
     };
@@ -32,7 +32,7 @@ const SidebarAdmin: React.FC<SidebarAdminProps> = ({ handleNavClick, location, c
                     className={linkClass('/templates')}
                     onClick={() => handleNavClick('/templates', t('navigation.templates', 'Templates'))}
                 >
-                    <RectangleStackIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
+                    <RectangleStackIcon className="h-[14px] w-[14px] mr-[6px] shrink-0" />
                     {t('navigation.templates', 'Templates')}
                 </li>
             )}
@@ -41,7 +41,7 @@ const SidebarAdmin: React.FC<SidebarAdminProps> = ({ handleNavClick, location, c
                     className={linkClass('/admin')}
                     onClick={() => handleNavClick('/admin/users', t('admin.userManagement', 'User Management'))}
                 >
-                    <UsersIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
+                    <UsersIcon className="h-[14px] w-[14px] mr-[6px] shrink-0" />
                     {t('admin.userManagement', 'User Management')}
                 </li>
             )}

--- a/frontend/components/Sidebar/SidebarAreas.tsx
+++ b/frontend/components/Sidebar/SidebarAreas.tsx
@@ -39,17 +39,13 @@ const SidebarAreas: React.FC<SidebarAreasProps> = ({
         }
     }, [location.pathname, areas.length]);
 
-    const isActiveArea = (path: string) => {
-        return location.pathname === path
-            ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
-            : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]';
-    };
+    const isAreasPageActive = location.pathname === '/areas';
 
     const itemClass = (path: string) =>
-        `group flex justify-between items-center rounded-[8px] px-[10px] py-1 text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
+        `group flex justify-between items-center rounded-[8px] pl-[30px] pr-[10px] py-[4px] text-[13.5px] cursor-pointer text-gray-500 dark:text-[oklch(82%_0.006_95)] hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
             location.pathname === path
-                ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
-                : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]'
+                ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)]'
+                : ''
         }`;
 
     const navigate = (area: Area) =>
@@ -62,19 +58,26 @@ const SidebarAreas: React.FC<SidebarAreasProps> = ({
     return (
         <ul className="flex flex-col">
             <li
-                className={`group flex justify-between items-center px-[10px] py-[5px] rounded-[8px] cursor-pointer hover:bg-gray-100 dark:hover:bg-white/5 ${isActiveArea(
-                    '/areas'
-                )}`}
-                onClick={() =>
+                className={`group flex justify-between items-center px-[10px] py-[4px] rounded-[8px] cursor-pointer hover:bg-gray-100 dark:hover:bg-white/5 ${
+                    isAreasPageActive ? 'bg-gray-100 dark:bg-white/5' : ''
+                }`}
+                onClick={() => {
+                    setIsExpanded(true);
                     handleNavClick(
                         '/areas',
                         'Areas',
                         <Squares2X2Icon className="h-5 w-5 mr-2" />
-                    )
-                }
+                    );
+                }}
             >
-                <span className="flex items-center text-[10.5px] tracking-[0.01em] font-semibold uppercase hover:text-gray-900 dark:hover:text-white">
-                    <Squares2X2Icon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
+                <span
+                    className={`flex items-center text-[10.5px] tracking-[0.01em] font-semibold uppercase hover:text-gray-900 dark:hover:text-white ${
+                        isAreasPageActive
+                            ? 'text-gray-900 dark:text-white'
+                            : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]'
+                    }`}
+                >
+                    <Squares2X2Icon className="h-[14px] w-[14px] mr-[6px] shrink-0" />
                     {t('sidebar.areas')}
                 </span>
                 <div className="flex items-center gap-1">
@@ -119,17 +122,8 @@ const SidebarAreas: React.FC<SidebarAreasProps> = ({
                                 className={itemClass(getAreaPath(area))}
                                 onClick={() => navigate(area)}
                             >
-                                <span className="flex items-center gap-2 min-w-0">
-                                    <span
-                                        className="w-1.5 h-[14px] rounded-full flex-shrink-0"
-                                        style={{
-                                            backgroundColor:
-                                                area.color || '#9ca3af',
-                                        }}
-                                    />
-                                    <span className="truncate">
-                                        {area.name}
-                                    </span>
+                                <span className="truncate min-w-0">
+                                    {area.name}
                                 </span>
                             </div>
                         ))}

--- a/frontend/components/Sidebar/SidebarAreas.tsx
+++ b/frontend/components/Sidebar/SidebarAreas.tsx
@@ -1,5 +1,9 @@
-import React from 'react';
-import { Squares2X2Icon } from '@heroicons/react/24/outline';
+import React, { useState, useEffect } from 'react';
+import {
+    Squares2X2Icon,
+    ChevronRightIcon,
+    PlusIcon,
+} from '@heroicons/react/24/outline';
 import { Location } from 'react-router-dom';
 import { Area } from '../../entities/Area';
 import { useTranslation } from 'react-i18next';
@@ -12,37 +16,127 @@ interface SidebarAreasProps {
     areas: Area[];
 }
 
+const getAreaPath = (area: Area) => {
+    const slug = area.name
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+    return `/area/${area.uid}-${slug}`;
+};
+
 const SidebarAreas: React.FC<SidebarAreasProps> = ({
     handleNavClick,
     location,
+    openAreaModal,
+    areas,
 }) => {
     const { t } = useTranslation();
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    useEffect(() => {
+        if (areas.some((area) => getAreaPath(area) === location.pathname)) {
+            setIsExpanded(true);
+        }
+    }, [location.pathname, areas.length]);
+
     const isActiveArea = (path: string) => {
         return location.pathname === path
             ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
             : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]';
     };
 
+    const itemClass = (path: string) =>
+        `group flex justify-between items-center rounded-[8px] px-[10px] py-1 text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
+            location.pathname === path
+                ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
+                : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]'
+        }`;
+
+    const navigate = (area: Area) =>
+        handleNavClick(
+            getAreaPath(area),
+            area.name,
+            <Squares2X2Icon className="h-4 w-4 mr-2" />
+        );
+
     return (
-        <>
-            <ul className="flex flex-col">
-                <li
-                    className={`group flex items-center px-[10px] py-[5px] rounded-[8px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:bg-gray-100 dark:hover:bg-white/5 hover:text-gray-900 dark:hover:text-white ${isActiveArea(
-                        '/areas'
-                    )}`}
-                    onClick={() =>
-                        handleNavClick(
-                            '/areas',
-                            'Areas',
-                            <Squares2X2Icon className="h-5 w-5 mr-2" />
-                        )
-                    }
-                >
+        <ul className="flex flex-col">
+            <li
+                className={`group flex justify-between items-center px-[10px] py-[5px] rounded-[8px] cursor-pointer hover:bg-gray-100 dark:hover:bg-white/5 ${isActiveArea(
+                    '/areas'
+                )}`}
+                onClick={() =>
+                    handleNavClick(
+                        '/areas',
+                        'Areas',
+                        <Squares2X2Icon className="h-5 w-5 mr-2" />
+                    )
+                }
+            >
+                <span className="flex items-center text-[10.5px] tracking-[0.01em] font-semibold uppercase hover:text-gray-900 dark:hover:text-white">
                     <Squares2X2Icon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
                     {t('sidebar.areas')}
+                </span>
+                <div className="flex items-center gap-1">
+                    <button
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            openAreaModal(null);
+                        }}
+                        className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        aria-label={t('areas.addArea', 'Add Area')}
+                        title={t('areas.addArea', 'Add Area')}
+                    >
+                        <PlusIcon className="h-3.5 w-3.5" />
+                    </button>
+                    {areas.length > 0 && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                setIsExpanded((v) => !v);
+                            }}
+                            className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        >
+                            <ChevronRightIcon
+                                className="h-3 w-3 transition-transform duration-150"
+                                style={{
+                                    transform: isExpanded
+                                        ? 'rotate(90deg)'
+                                        : 'none',
+                                }}
+                            />
+                        </button>
+                    )}
+                </div>
+            </li>
+
+            {isExpanded && (
+                <li className="p-0 list-none">
+                    <div className="max-h-[168px] overflow-y-auto overscroll-y-contain flex flex-col gap-0.5 mb-1.5">
+                        {areas.map((area) => (
+                            <div
+                                key={area.uid}
+                                className={itemClass(getAreaPath(area))}
+                                onClick={() => navigate(area)}
+                            >
+                                <span className="flex items-center gap-2 min-w-0">
+                                    <span
+                                        className="w-1.5 h-[14px] rounded-full flex-shrink-0"
+                                        style={{
+                                            backgroundColor:
+                                                area.color || '#9ca3af',
+                                        }}
+                                    />
+                                    <span className="truncate">
+                                        {area.name}
+                                    </span>
+                                </span>
+                            </div>
+                        ))}
+                    </div>
                 </li>
-            </ul>
-        </>
+            )}
+        </ul>
     );
 };
 

--- a/frontend/components/Sidebar/SidebarBoards.tsx
+++ b/frontend/components/Sidebar/SidebarBoards.tsx
@@ -32,7 +32,7 @@ const SidebarBoards: React.FC<SidebarBoardsProps> = ({ handleNavClick, location 
 
     const isActive = (path: string) =>
         location.pathname === path
-            ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
+            ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)] text-gray-500 dark:text-[oklch(82%_0.006_95)]'
             : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]';
 
     const boards = [
@@ -50,17 +50,20 @@ const SidebarBoards: React.FC<SidebarBoardsProps> = ({ handleNavClick, location 
 
     return (
         <ul className="flex flex-col">
-            <li className="flex justify-between items-center px-2.5 py-1 rounded-md">
-                <span className="flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-gray-900 dark:hover:text-white text-gray-400 dark:text-[oklch(58%_0.006_95)]" onClick={toggleCollapsed}>
-                    <RectangleGroupIcon className="h-3.5 w-3.5" />
+            <li className="flex justify-between items-center px-[10px] py-[4px] rounded-md">
+                <span className="flex items-center gap-[6px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-gray-900 dark:hover:text-white text-gray-400 dark:text-[oklch(58%_0.006_95)]" onClick={toggleCollapsed}>
+                    <RectangleGroupIcon className="h-[14px] w-[14px]" />
                     {t('sidebar.boards', 'Boards')}
                 </span>
-                <button onClick={toggleCollapsed} className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none">
-                    <ChevronRightIcon
-                        className="h-3 w-3 transition-transform duration-150"
-                        style={{ transform: !isCollapsed ? 'rotate(90deg)' : 'none' }}
-                    />
-                </button>
+                <div className="flex items-center gap-1">
+                    <span className="h-3.5 w-3.5" aria-hidden="true" />
+                    <button onClick={toggleCollapsed} className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none">
+                        <ChevronRightIcon
+                            className="h-3 w-3 transition-transform duration-150"
+                            style={{ transform: !isCollapsed ? 'rotate(90deg)' : 'none' }}
+                        />
+                    </button>
+                </div>
             </li>
             {!isCollapsed && (
                 <li className="p-0 list-none">
@@ -68,7 +71,7 @@ const SidebarBoards: React.FC<SidebarBoardsProps> = ({ handleNavClick, location 
                         {boards.map((board) => (
                             <div
                                 key={board.path}
-                                className={`flex items-center gap-2 rounded-[8px] px-[10px] py-1 text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${isActive(board.path)}`}
+                                className={`flex items-center gap-[4px] rounded-[8px] px-[10px] py-[4px] text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${isActive(board.path)}`}
                                 onClick={() => handleNavClick(board.path, board.title, board.icon)}
                             >
                                 {board.icon}

--- a/frontend/components/Sidebar/SidebarBookmarks.tsx
+++ b/frontend/components/Sidebar/SidebarBookmarks.tsx
@@ -77,10 +77,8 @@ const SidebarBookmarks: React.FC<SidebarBookmarksProps> = ({
     const isActive = (path: string) => location.pathname === path;
 
     const itemClass = (path: string) =>
-        `group flex justify-between items-center rounded-[8px] px-[10px] py-1 text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
-            isActive(path)
-                ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
-                : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]'
+        `group flex justify-between items-center rounded-[8px] pl-[30px] pr-[10px] py-[4px] text-[13.5px] cursor-pointer text-gray-500 dark:text-[oklch(82%_0.006_95)] hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
+            isActive(path) ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)]' : ''
         }`;
 
     const unpinProject = async (project: Project, e: React.MouseEvent) => {
@@ -135,26 +133,29 @@ const SidebarBookmarks: React.FC<SidebarBookmarksProps> = ({
     return (
         <div className="flex flex-col">
             <div
-                className="flex justify-between items-center px-2.5 py-1 rounded-md cursor-pointer"
+                className="flex justify-between items-center px-[10px] py-[4px] rounded-md cursor-pointer"
                 onClick={() => {
                     const next = !isExpanded;
                     setIsExpanded(next);
                     localStorage.setItem('bookmarksSidebarCollapsed', String(!next));
                 }}
             >
-                <span className="flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase text-gray-400 dark:text-[oklch(58%_0.006_95)] hover:text-gray-900 dark:hover:text-white">
-                    <PushPinIcon className="h-3.5 w-3.5" />
+                <span className="flex items-center gap-[6px] text-[10.5px] tracking-[0.01em] font-semibold uppercase text-gray-400 dark:text-[oklch(58%_0.006_95)] hover:text-gray-900 dark:hover:text-white">
+                    <PushPinIcon className="h-[14px] w-[14px]" />
                     {t('sidebar.bookmarks', 'Favorites')}
                 </span>
-                <button
-                    className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
-                    aria-label={isExpanded ? 'Collapse favorites' : 'Expand favorites'}
-                >
-                    <ChevronRightIcon
-                        className="h-3 w-3 transition-transform duration-150"
-                        style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
-                    />
-                </button>
+                <div className="flex items-center gap-1">
+                    <span className="h-3.5 w-3.5" aria-hidden="true" />
+                    <button
+                        className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        aria-label={isExpanded ? 'Collapse favorites' : 'Expand favorites'}
+                    >
+                        <ChevronRightIcon
+                            className="h-3 w-3 transition-transform duration-150"
+                            style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
+                        />
+                    </button>
+                </div>
             </div>
 
             {isExpanded && (
@@ -171,12 +172,8 @@ const SidebarBookmarks: React.FC<SidebarBookmarksProps> = ({
                                 )
                             }
                         >
-                            <span className="flex items-center gap-2 min-w-0">
-                                <span
-                                    className="w-1.5 h-[14px] rounded-full flex-shrink-0"
-                                    style={{ backgroundColor: project.color || '#9ca3af' }}
-                                />
-                                <span className="truncate">{project.name}</span>
+                            <span className="truncate min-w-0">
+                                {project.name}
                             </span>
                             <button
                                 onClick={(e) => unpinProject(project, e)}
@@ -201,12 +198,8 @@ const SidebarBookmarks: React.FC<SidebarBookmarksProps> = ({
                                 )
                             }
                         >
-                            <span className="flex items-center gap-2 min-w-0">
-                                <span
-                                    className="w-1.5 h-[14px] rounded-full flex-shrink-0"
-                                    style={{ backgroundColor: note.color || '#9ca3af' }}
-                                />
-                                <span className="truncate">{note.title}</span>
+                            <span className="truncate min-w-0">
+                                {note.title}
                             </span>
                             <button
                                 onClick={(e) => unpinNote(note, e)}
@@ -231,12 +224,8 @@ const SidebarBookmarks: React.FC<SidebarBookmarksProps> = ({
                                 )
                             }
                         >
-                            <span className="flex items-center gap-2 min-w-0">
-                                <span
-                                    className="w-1.5 h-[14px] rounded-full flex-shrink-0"
-                                    style={{ backgroundColor: tag.color || '#9ca3af' }}
-                                />
-                                <span className="truncate">{tag.name}</span>
+                            <span className="truncate min-w-0">
+                                {tag.name}
                             </span>
                             <button
                                 onClick={(e) => unpinTag(tag, e)}

--- a/frontend/components/Sidebar/SidebarGoals.tsx
+++ b/frontend/components/Sidebar/SidebarGoals.tsx
@@ -3,6 +3,7 @@ import { Location } from 'react-router-dom';
 import {
     FlagIcon,
     ChevronRightIcon,
+    PlusIcon,
 } from '@heroicons/react/24/outline';
 import { Goal } from '../../entities/Goal';
 import { useTranslation } from 'react-i18next';
@@ -51,7 +52,7 @@ const SidebarGoals: React.FC<SidebarGoalsProps> = ({
 
     return (
         <div className="flex flex-col">
-            <div className="flex justify-between items-center px-2.5 py-1 rounded-md">
+            <div className="group flex justify-between items-center px-2.5 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-white/5">
                 <span
                     className={`flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
                         location.pathname === '/goals'
@@ -65,20 +66,37 @@ const SidebarGoals: React.FC<SidebarGoalsProps> = ({
                     <FlagIcon className="h-3.5 w-3.5" />
                     {t('sidebar.goals', 'Goals')}
                 </span>
-                {activeGoals.length > 0 && (
+                <div className="flex items-center gap-1">
                     <button
                         onClick={(e) => {
                             e.stopPropagation();
-                            setIsExpanded((v) => !v);
+                            handleNavClick(
+                                '/goal/new',
+                                t('goals.newGoal', 'New Goal'),
+                                <FlagIcon className="h-4 w-4 mr-2" />
+                            );
                         }}
-                        className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        aria-label={t('goals.addGoal', 'Add Goal')}
+                        title={t('goals.addGoal', 'Add Goal')}
                     >
-                        <ChevronRightIcon
-                            className="h-3 w-3 transition-transform duration-150"
-                            style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
-                        />
+                        <PlusIcon className="h-3.5 w-3.5" />
                     </button>
-                )}
+                    {activeGoals.length > 0 && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                setIsExpanded((v) => !v);
+                            }}
+                            className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        >
+                            <ChevronRightIcon
+                                className="h-3 w-3 transition-transform duration-150"
+                                style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
+                            />
+                        </button>
+                    )}
+                </div>
             </div>
 
             {isExpanded && (

--- a/frontend/components/Sidebar/SidebarGoals.tsx
+++ b/frontend/components/Sidebar/SidebarGoals.tsx
@@ -33,10 +33,8 @@ const SidebarGoals: React.FC<SidebarGoalsProps> = ({
     const isActive = (path: string) => location.pathname === path;
 
     const itemClass = (path: string) =>
-        `group flex justify-between items-center rounded-[8px] px-[10px] py-1 text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
-            isActive(path)
-                ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
-                : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]'
+        `group flex justify-between items-center rounded-[8px] pl-[30px] pr-[10px] py-[4px] text-[13.5px] cursor-pointer text-gray-500 dark:text-[oklch(82%_0.006_95)] hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
+            isActive(path) ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)]' : ''
         }`;
 
     const activeGoals = goals.filter((g: Goal) => g.status === 'active');
@@ -52,18 +50,25 @@ const SidebarGoals: React.FC<SidebarGoalsProps> = ({
 
     return (
         <div className="flex flex-col">
-            <div className="group flex justify-between items-center px-2.5 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-white/5">
+            <div
+                className={`group flex justify-between items-center px-[10px] py-[4px] rounded-md hover:bg-gray-100 dark:hover:bg-white/5 ${
+                    location.pathname === '/goals'
+                        ? 'bg-gray-100 dark:bg-white/5'
+                        : ''
+                }`}
+            >
                 <span
-                    className={`flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
+                    className={`flex items-center gap-[6px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
                         location.pathname === '/goals'
-                            ? 'text-gray-900 dark:text-white'
+                            ? 'text-black dark:text-white'
                             : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]'
                     }`}
-                    onClick={() =>
-                        handleNavClick('/goals', t('sidebar.goals', 'Goals'), <FlagIcon className="h-4 w-4 mr-2" />)
-                    }
+                    onClick={() => {
+                        setIsExpanded(true);
+                        handleNavClick('/goals', t('sidebar.goals', 'Goals'), <FlagIcon className="h-4 w-4 mr-2" />);
+                    }}
                 >
-                    <FlagIcon className="h-3.5 w-3.5" />
+                    <FlagIcon className="h-[14px] w-[14px]" />
                     {t('sidebar.goals', 'Goals')}
                 </span>
                 <div className="flex items-center gap-1">
@@ -111,12 +116,8 @@ const SidebarGoals: React.FC<SidebarGoalsProps> = ({
                                     handleNavClick(goalPath, goal.title, <FlagIcon className="h-4 w-4 mr-2" />)
                                 }
                             >
-                                <span className="flex items-center gap-2 min-w-0">
-                                    <span
-                                        className="w-1.5 h-[14px] rounded-full flex-shrink-0"
-                                        style={{ backgroundColor: goal.color || '#9ca3af' }}
-                                    />
-                                    <span className="truncate">{goal.title}</span>
+                                <span className="truncate min-w-0">
+                                    {goal.title}
                                 </span>
                             </div>
                         );

--- a/frontend/components/Sidebar/SidebarHabits.tsx
+++ b/frontend/components/Sidebar/SidebarHabits.tsx
@@ -17,7 +17,7 @@ const SidebarHabits: React.FC<SidebarHabitsProps> = ({
     const { t } = useTranslation();
     const isActiveHabit = (path: string) => {
         return location.pathname.startsWith(path)
-            ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
+            ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)] text-gray-900 dark:text-white'
             : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]';
     };
 
@@ -25,7 +25,7 @@ const SidebarHabits: React.FC<SidebarHabitsProps> = ({
         <>
             <ul className="flex flex-col">
                 <li
-                    className={`group flex items-center rounded-[8px] px-[10px] py-[5px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] hover:text-gray-900 dark:hover:text-white ${isActiveHabit(
+                    className={`group flex items-center rounded-[8px] px-[10px] py-[4px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] hover:text-gray-900 dark:hover:text-white ${isActiveHabit(
                         '/habits'
                     )}`}
                     onClick={() =>
@@ -36,7 +36,7 @@ const SidebarHabits: React.FC<SidebarHabitsProps> = ({
                         )
                     }
                 >
-                    <FireIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
+                    <FireIcon className="h-[14px] w-[14px] mr-[6px] shrink-0" />
                     {t('sidebar.habits', 'Habits')}
                 </li>
             </ul>

--- a/frontend/components/Sidebar/SidebarInsights.tsx
+++ b/frontend/components/Sidebar/SidebarInsights.tsx
@@ -26,7 +26,7 @@ const SidebarInsights: React.FC<SidebarInsightsProps> = ({ handleNavClick, locat
 
     const isActive = (path: string) =>
         location.pathname === path
-            ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
+            ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)] text-gray-500 dark:text-[oklch(82%_0.006_95)]'
             : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]';
 
     const links = [
@@ -44,17 +44,20 @@ const SidebarInsights: React.FC<SidebarInsightsProps> = ({ handleNavClick, locat
 
     return (
         <ul className="flex flex-col">
-            <li className="flex justify-between items-center px-2.5 py-1 rounded-md">
-                <span className="flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-gray-900 dark:hover:text-white text-gray-400 dark:text-[oklch(58%_0.006_95)]" onClick={toggleCollapsed}>
-                    <ChartBarIcon className="h-3.5 w-3.5" />
+            <li className="flex justify-between items-center px-[10px] py-[4px] rounded-md">
+                <span className="flex items-center gap-[6px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-gray-900 dark:hover:text-white text-gray-400 dark:text-[oklch(58%_0.006_95)]" onClick={toggleCollapsed}>
+                    <ChartBarIcon className="h-[14px] w-[14px]" />
                     {t('sidebar.insights', 'Insights')}
                 </span>
-                <button onClick={toggleCollapsed} className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none">
-                    <ChevronRightIcon
-                        className="h-3 w-3 transition-transform duration-150"
-                        style={{ transform: !isCollapsed ? 'rotate(90deg)' : 'none' }}
-                    />
-                </button>
+                <div className="flex items-center gap-1">
+                    <span className="h-3.5 w-3.5" aria-hidden="true" />
+                    <button onClick={toggleCollapsed} className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none">
+                        <ChevronRightIcon
+                            className="h-3 w-3 transition-transform duration-150"
+                            style={{ transform: !isCollapsed ? 'rotate(90deg)' : 'none' }}
+                        />
+                    </button>
+                </div>
             </li>
             {!isCollapsed && (
                 <li className="p-0 list-none">
@@ -62,7 +65,7 @@ const SidebarInsights: React.FC<SidebarInsightsProps> = ({ handleNavClick, locat
                         {links.map((link) => (
                             <div
                                 key={link.path}
-                                className={`flex items-center gap-2 rounded-[8px] px-[10px] py-1 text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${isActive(link.path)}`}
+                                className={`flex items-center gap-[4px] rounded-[8px] px-[10px] py-[4px] text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${isActive(link.path)}`}
                                 onClick={() => handleNavClick(link.path, link.title, link.icon)}
                             >
                                 {link.icon}

--- a/frontend/components/Sidebar/SidebarNav.tsx
+++ b/frontend/components/Sidebar/SidebarNav.tsx
@@ -97,7 +97,7 @@ const SidebarNav: React.FC<SidebarNavProps> = ({
                     <button
                         onClick={() => handleNavClick(link.path, link.title, link.icon)}
                         data-testid={`sidebar-nav-${link.path.replace(/^\//, '').replace(/\?.*$/, '')}`}
-                        className={`w-full flex items-center gap-[10px] px-[10px] py-[4px] rounded-[8px] transition-colors duration-150 ${isActive(link.path, link.query)}`}
+                        className={`w-full flex items-center gap-[5px] px-[10px] py-[4px] rounded-[8px] transition-colors duration-150 ${isActive(link.path, link.query)}`}
                     >
                         <span className={`flex-shrink-0 ${isActiveLink(link.path, link.query) ? 'text-blue-600 dark:text-[oklch(68%_0.14_250)]' : 'text-gray-400 dark:text-[oklch(55%_0.006_95)]'}`}>
                             {link.icon}

--- a/frontend/components/Sidebar/SidebarNotes.tsx
+++ b/frontend/components/Sidebar/SidebarNotes.tsx
@@ -50,18 +50,25 @@ const SidebarNotes: React.FC<SidebarNotesProps> = ({
 
     return (
         <div className="flex flex-col">
-            <div className="group flex justify-between items-center px-2.5 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-white/5">
+            <div
+                className={`group flex justify-between items-center px-[10px] py-[4px] rounded-md hover:bg-gray-100 dark:hover:bg-white/5 ${
+                    location.pathname.startsWith('/notes')
+                        ? 'bg-gray-100 dark:bg-white/5'
+                        : ''
+                }`}
+            >
                 <span
-                    className={`flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
+                    className={`flex items-center gap-[6px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
                         location.pathname.startsWith('/notes')
-                            ? 'text-gray-900 dark:text-white'
+                            ? 'text-black dark:text-white'
                             : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]'
                     }`}
-                    onClick={() =>
-                        handleNavClick('/notes', t('sidebar.notes'), <BookOpenIcon className="h-4 w-4 mr-2" />)
-                    }
+                    onClick={() => {
+                        setIsExpanded(true);
+                        handleNavClick('/notes', t('sidebar.notes'), <BookOpenIcon className="h-4 w-4 mr-2" />);
+                    }}
                 >
-                    <BookOpenIcon className="h-3.5 w-3.5" />
+                    <BookOpenIcon className="h-[14px] w-[14px]" />
                     {t('sidebar.notes')}
                 </span>
                 <div className="flex items-center gap-1">

--- a/frontend/components/Sidebar/SidebarNotes.tsx
+++ b/frontend/components/Sidebar/SidebarNotes.tsx
@@ -3,11 +3,12 @@ import { Location } from 'react-router-dom';
 import {
     BookOpenIcon,
     ChevronRightIcon,
+    PlusIcon,
 } from '@heroicons/react/24/outline';
 import { Note } from '../../entities/Note';
 import { useTranslation } from 'react-i18next';
 import { useStore } from '../../store/useStore';
-import { createNoteUrl } from '../../utils/slugUtils';
+import SidebarNotesTree from './SidebarNotesTree';
 
 interface SidebarNotesProps {
     handleNavClick: (path: string, title: string, icon: JSX.Element) => void;
@@ -20,6 +21,7 @@ interface SidebarNotesProps {
 const SidebarNotes: React.FC<SidebarNotesProps> = ({
     handleNavClick,
     location,
+    openNoteModal,
 }) => {
     const { t } = useTranslation();
     const [isExpanded, setIsExpanded] = useState(false);
@@ -28,35 +30,27 @@ const SidebarNotes: React.FC<SidebarNotesProps> = ({
     const hasLoaded = useStore((state) => state.notesStore.hasLoaded);
     const loadNotes = useStore((state) => state.notesStore.loadNotes);
 
+    const projects = useStore((state) => state.projectsStore.projects);
+    const projectsHasLoaded = useStore(
+        (state) => state.projectsStore.hasLoaded
+    );
+    const loadProjects = useStore((state) => state.projectsStore.loadProjects);
+
     useEffect(() => {
         if (!hasLoaded) {
             loadNotes();
         }
     }, [hasLoaded, loadNotes]);
 
-    const isActive = (path: string) => location.pathname.startsWith(path);
-
-    const itemClass = (path: string) =>
-        `flex items-center rounded-[8px] px-[10px] py-1 text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
-            isActive(path)
-                ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
-                : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]'
-        }`;
-
-    const getNotePath = (note: Note) => {
-        try {
-            return createNoteUrl(note);
-        } catch {
-            return '/notes';
+    useEffect(() => {
+        if (!projectsHasLoaded) {
+            loadProjects();
         }
-    };
-
-    const navigate = (note: Note) =>
-        handleNavClick(getNotePath(note), note.title, <BookOpenIcon className="h-4 w-4 mr-2" />);
+    }, [projectsHasLoaded, loadProjects]);
 
     return (
         <div className="flex flex-col">
-            <div className="flex justify-between items-center px-2.5 py-1 rounded-md">
+            <div className="group flex justify-between items-center px-2.5 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-white/5">
                 <span
                     className={`flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
                         location.pathname.startsWith('/notes')
@@ -70,40 +64,42 @@ const SidebarNotes: React.FC<SidebarNotesProps> = ({
                     <BookOpenIcon className="h-3.5 w-3.5" />
                     {t('sidebar.notes')}
                 </span>
-                {notes.length > 0 && (
+                <div className="flex items-center gap-1">
                     <button
                         onClick={(e) => {
                             e.stopPropagation();
-                            setIsExpanded((v) => !v);
+                            openNoteModal(null);
                         }}
-                        className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        aria-label={t('notes.addNote', 'Add Note')}
+                        title={t('notes.addNote', 'Add Note')}
                     >
-                        <ChevronRightIcon
-                            className="h-3 w-3 transition-transform duration-150"
-                            style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
-                        />
+                        <PlusIcon className="h-3.5 w-3.5" />
                     </button>
-                )}
+                    {notes.length > 0 && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                setIsExpanded((v) => !v);
+                            }}
+                            className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        >
+                            <ChevronRightIcon
+                                className="h-3 w-3 transition-transform duration-150"
+                                style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
+                            />
+                        </button>
+                    )}
+                </div>
             </div>
 
             {isExpanded && (
-                <div className="max-h-[168px] overflow-y-auto overscroll-y-contain flex flex-col gap-0.5 mb-1.5">
-                    {notes.map((note) => (
-                        <div
-                            key={note.uid || note.id}
-                            className={itemClass(getNotePath(note))}
-                            onClick={() => navigate(note)}
-                        >
-                            <span className="flex items-center gap-2 min-w-0">
-                                <span
-                                    className="w-1.5 h-[14px] rounded-full flex-shrink-0"
-                                    style={{ backgroundColor: note.color || '#9ca3af' }}
-                                />
-                                <span className="truncate">{note.title}</span>
-                            </span>
-                        </div>
-                    ))}
-                </div>
+                <SidebarNotesTree
+                    notes={notes}
+                    projects={projects}
+                    location={location}
+                    handleNavClick={handleNavClick}
+                />
             )}
         </div>
     );

--- a/frontend/components/Sidebar/SidebarNotesTree.tsx
+++ b/frontend/components/Sidebar/SidebarNotesTree.tsx
@@ -1,0 +1,142 @@
+import React, { useMemo } from 'react';
+import { Location } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { BookOpenIcon } from '@heroicons/react/24/outline';
+import { Note } from '../../entities/Note';
+import { Project } from '../../entities/Project';
+import { createNoteUrl } from '../../utils/slugUtils';
+import { useNotesTreeExpansion } from '../../hooks/useNotesTreeExpansion';
+import {
+    buildNotesTree,
+    flattenVisibleRows,
+    getActiveFolderKeys,
+} from '../../utils/notesTreeUtils';
+
+interface SidebarNotesTreeProps {
+    notes: Note[];
+    projects: Project[];
+    location: Location;
+    handleNavClick: (path: string, title: string, icon: JSX.Element) => void;
+}
+
+const BASE_PADDING_PX = 10;
+const INDENT_PX = 12;
+
+const getNotePath = (note: Note) => {
+    try {
+        return createNoteUrl(note);
+    } catch {
+        return '/notes';
+    }
+};
+
+const SidebarNotesTree: React.FC<SidebarNotesTreeProps> = ({
+    notes,
+    projects,
+    location,
+    handleNavClick,
+}) => {
+    const { t } = useTranslation();
+
+    const tree = useMemo(
+        () => buildNotesTree(notes, projects, 'updated_at:desc'),
+        [notes, projects]
+    );
+
+    const activeNote = useMemo(
+        () => notes.find((note) => getNotePath(note) === location.pathname),
+        [notes, location.pathname]
+    );
+
+    const initialActiveKeys = useMemo(
+        () => getActiveFolderKeys(activeNote),
+        [activeNote]
+    );
+
+    const { expanded, toggle } = useNotesTreeExpansion(initialActiveKeys);
+
+    // The "NOTES" header directly above already labels this section, so the
+    // tree's own "Folders" section-header row would just be redundant noise
+    // in this small peek box.
+    const rows = flattenVisibleRows({
+        tree,
+        expanded,
+        forceExpandAll: false,
+        labels: { folders: '' },
+    }).filter((row) => row.type !== 'section-header');
+
+    const itemClass = (isActive: boolean) =>
+        `flex justify-between items-center gap-2 rounded-[8px] py-1 pr-[10px] text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
+            isActive
+                ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
+                : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]'
+        }`;
+
+    return (
+        <div className="flex flex-col gap-0.5 mb-1.5">
+            {rows.map((row) => {
+                const indent = BASE_PADDING_PX + row.depth * INDENT_PX;
+
+                if (row.type === 'folder') {
+                    return (
+                        <div
+                            key={row.key}
+                            onClick={() => toggle(row.key)}
+                            style={{ paddingLeft: indent }}
+                            className={itemClass(false)}
+                        >
+                            <span className="flex items-center gap-2 min-w-0">
+                                <span
+                                    className="w-1.5 h-[14px] rounded-full flex-shrink-0"
+                                    style={{
+                                        backgroundColor:
+                                            row.color || '#9ca3af',
+                                    }}
+                                />
+                                <span className="truncate">{row.label}</span>
+                            </span>
+                            <span className="flex-shrink-0 flex items-center gap-1 text-gray-400 dark:text-gray-500">
+                                <span className="text-[9px]">
+                                    {row.expanded ? '▾' : '▸'}
+                                </span>
+                                {row.count}
+                            </span>
+                        </div>
+                    );
+                }
+
+                const path = getNotePath(row.note);
+                return (
+                    <div
+                        key={row.key}
+                        onClick={() =>
+                            handleNavClick(
+                                path,
+                                row.note.title,
+                                <BookOpenIcon className="h-4 w-4 mr-2" />
+                            )
+                        }
+                        style={{ paddingLeft: indent }}
+                        className={itemClass(location.pathname === path)}
+                    >
+                        <span className="flex items-center gap-2 min-w-0">
+                            <span
+                                className="w-1.5 h-[14px] rounded-full flex-shrink-0"
+                                style={{
+                                    backgroundColor:
+                                        row.note.color || '#9ca3af',
+                                }}
+                            />
+                            <span className="truncate">
+                                {row.note.title ||
+                                    t('notes.untitled', 'Untitled Note')}
+                            </span>
+                        </span>
+                    </div>
+                );
+            })}
+        </div>
+    );
+};
+
+export default SidebarNotesTree;

--- a/frontend/components/Sidebar/SidebarNotesTree.tsx
+++ b/frontend/components/Sidebar/SidebarNotesTree.tsx
@@ -19,7 +19,7 @@ interface SidebarNotesTreeProps {
     handleNavClick: (path: string, title: string, icon: JSX.Element) => void;
 }
 
-const BASE_PADDING_PX = 10;
+const BASE_PADDING_PX = 30;
 const INDENT_PX = 12;
 
 const getNotePath = (note: Note) => {
@@ -66,10 +66,8 @@ const SidebarNotesTree: React.FC<SidebarNotesTreeProps> = ({
     }).filter((row) => row.type !== 'section-header');
 
     const itemClass = (isActive: boolean) =>
-        `flex justify-between items-center gap-2 rounded-[8px] py-1 pr-[10px] text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
-            isActive
-                ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
-                : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]'
+        `flex justify-between items-center gap-2 rounded-[8px] py-[4px] pr-[10px] text-[13.5px] cursor-pointer text-gray-500 dark:text-[oklch(82%_0.006_95)] hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
+            isActive ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)]' : ''
         }`;
 
     return (
@@ -85,15 +83,8 @@ const SidebarNotesTree: React.FC<SidebarNotesTreeProps> = ({
                             style={{ paddingLeft: indent }}
                             className={itemClass(false)}
                         >
-                            <span className="flex items-center gap-2 min-w-0">
-                                <span
-                                    className="w-1.5 h-[14px] rounded-full flex-shrink-0"
-                                    style={{
-                                        backgroundColor:
-                                            row.color || '#9ca3af',
-                                    }}
-                                />
-                                <span className="truncate">{row.label}</span>
+                            <span className="truncate min-w-0">
+                                {row.label}
                             </span>
                             <span className="flex-shrink-0 flex items-center gap-1 text-gray-400 dark:text-gray-500">
                                 <span className="text-[9px]">
@@ -119,18 +110,9 @@ const SidebarNotesTree: React.FC<SidebarNotesTreeProps> = ({
                         style={{ paddingLeft: indent }}
                         className={itemClass(location.pathname === path)}
                     >
-                        <span className="flex items-center gap-2 min-w-0">
-                            <span
-                                className="w-1.5 h-[14px] rounded-full flex-shrink-0"
-                                style={{
-                                    backgroundColor:
-                                        row.note.color || '#9ca3af',
-                                }}
-                            />
-                            <span className="truncate">
-                                {row.note.title ||
-                                    t('notes.untitled', 'Untitled Note')}
-                            </span>
+                        <span className="truncate min-w-0">
+                            {row.note.title ||
+                                t('notes.untitled', 'Untitled Note')}
                         </span>
                     </div>
                 );

--- a/frontend/components/Sidebar/SidebarPeople.tsx
+++ b/frontend/components/Sidebar/SidebarPeople.tsx
@@ -1,33 +1,137 @@
-import React from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Location } from 'react-router-dom';
-import { UserGroupIcon } from '@heroicons/react/24/outline';
+import {
+    UserGroupIcon,
+    ChevronRightIcon,
+    PlusIcon,
+} from '@heroicons/react/24/outline';
+import { Person } from '../../entities/Person';
+import { useStore } from '../../store/useStore';
 
 interface SidebarPeopleProps {
     handleNavClick: (path: string, title: string, icon: JSX.Element) => void;
     location: Location;
+    openPersonModal: (person: Person | null) => void;
 }
 
-const SidebarPeople: React.FC<SidebarPeopleProps> = ({ handleNavClick, location }) => {
-    const isActive = () =>
-        location.pathname.startsWith('/people') || location.pathname.startsWith('/person/')
-            ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
-            : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]';
+const getPersonPath = (person: Person) => `/person/${person.uid}`;
+
+const SidebarPeople: React.FC<SidebarPeopleProps> = ({
+    handleNavClick,
+    location,
+    openPersonModal,
+}) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    const people = useStore((state) => state.peopleStore.people);
+    const hasLoaded = useStore((state) => state.peopleStore.hasLoaded);
+    const loadPeople = useStore((state) => state.peopleStore.loadPeople);
+
+    useEffect(() => {
+        if (!hasLoaded) {
+            loadPeople();
+        }
+    }, [hasLoaded, loadPeople]);
+
+    const sortedPeople = useMemo(
+        () => [...people].sort((a, b) => a.name.localeCompare(b.name)),
+        [people]
+    );
+
+    useEffect(() => {
+        if (sortedPeople.some((person) => getPersonPath(person) === location.pathname)) {
+            setIsExpanded(true);
+        }
+    }, [location.pathname, sortedPeople.length]);
+
+    const isPeoplePageActive =
+        location.pathname === '/people' || location.pathname.startsWith('/person/');
+
+    const isActive = (path: string) => location.pathname === path;
+
+    const itemClass = (path: string) =>
+        `group flex justify-between items-center rounded-[8px] pl-[30px] pr-[10px] py-[4px] text-[13.5px] cursor-pointer text-gray-500 dark:text-[oklch(82%_0.006_95)] hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
+            isActive(path) ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)]' : ''
+        }`;
+
+    const navigate = (person: Person) =>
+        handleNavClick(
+            getPersonPath(person),
+            person.name,
+            <UserGroupIcon className="h-4 w-4 mr-2" />
+        );
 
     return (
         <ul className="flex flex-col">
             <li
-                className={`flex items-center rounded-[8px] px-[10px] py-[5px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] hover:text-gray-900 dark:hover:text-white ${isActive()}`}
-                onClick={() =>
-                    handleNavClick(
-                        '/people',
-                        'People',
-                        <UserGroupIcon className="h-5 w-5 mr-2" />
-                    )
-                }
+                className={`group flex justify-between items-center px-[10px] py-[4px] rounded-md hover:bg-gray-100 dark:hover:bg-white/5 ${
+                    isPeoplePageActive ? 'bg-gray-100 dark:bg-white/5' : ''
+                }`}
             >
-                <UserGroupIcon className="h-3.5 w-3.5 mr-1.5 shrink-0" />
-                People
+                <span
+                    className={`flex items-center gap-[6px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
+                        isPeoplePageActive
+                            ? 'text-black dark:text-white'
+                            : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]'
+                    }`}
+                    onClick={() => {
+                        setIsExpanded(true);
+                        handleNavClick(
+                            '/people',
+                            'People',
+                            <UserGroupIcon className="h-4 w-4 mr-2" />
+                        );
+                    }}
+                >
+                    <UserGroupIcon className="h-[14px] w-[14px]" />
+                    People
+                </span>
+                <div className="flex items-center gap-1">
+                    <button
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            openPersonModal(null);
+                        }}
+                        className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        aria-label="Add Person"
+                        title="Add Person"
+                    >
+                        <PlusIcon className="h-3.5 w-3.5" />
+                    </button>
+                    {sortedPeople.length > 0 && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                setIsExpanded((v) => !v);
+                            }}
+                            className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        >
+                            <ChevronRightIcon
+                                className="h-3 w-3 transition-transform duration-150"
+                                style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
+                            />
+                        </button>
+                    )}
+                </div>
             </li>
+
+            {isExpanded && (
+                <li className="p-0 list-none">
+                    <div className="max-h-[168px] overflow-y-auto overscroll-y-contain flex flex-col gap-0.5 mb-1.5">
+                        {sortedPeople.map((person) => (
+                            <div
+                                key={person.uid}
+                                className={itemClass(getPersonPath(person))}
+                                onClick={() => navigate(person)}
+                            >
+                                <span className="truncate min-w-0">
+                                    {person.name}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                </li>
+            )}
         </ul>
     );
 };

--- a/frontend/components/Sidebar/SidebarProjects.tsx
+++ b/frontend/components/Sidebar/SidebarProjects.tsx
@@ -3,6 +3,7 @@ import { Location } from 'react-router-dom';
 import {
     FolderIcon,
     ChevronRightIcon,
+    PlusIcon,
 } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 import { useStore } from '../../store/useStore';
@@ -26,6 +27,7 @@ const getProjectPath = (project: Project) => {
 const SidebarProjects: React.FC<SidebarProjectsProps> = ({
     handleNavClick,
     location,
+    openProjectModal,
 }) => {
     const { t } = useTranslation();
     const [isExpanded, setIsExpanded] = useState(false);
@@ -68,7 +70,7 @@ const SidebarProjects: React.FC<SidebarProjectsProps> = ({
 
     return (
         <ul className="flex flex-col">
-            <li className="flex justify-between items-center px-2.5 py-1 rounded-md">
+            <li className="group flex justify-between items-center px-2.5 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-white/5">
                 <span
                     className={`flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
                         location.pathname === '/projects'
@@ -82,20 +84,33 @@ const SidebarProjects: React.FC<SidebarProjectsProps> = ({
                     <FolderIcon className="h-3.5 w-3.5" />
                     {t('sidebar.projects')}
                 </span>
-                {activeProjects.length > 0 && (
+                <div className="flex items-center gap-1">
                     <button
                         onClick={(e) => {
                             e.stopPropagation();
-                            setIsExpanded((v) => !v);
+                            openProjectModal();
                         }}
-                        className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        aria-label={t('projects.addProject', 'Add Project')}
+                        title={t('projects.addProject', 'Add Project')}
                     >
-                        <ChevronRightIcon
-                            className="h-3 w-3 transition-transform duration-150"
-                            style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
-                        />
+                        <PlusIcon className="h-3.5 w-3.5" />
                     </button>
-                )}
+                    {activeProjects.length > 0 && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                setIsExpanded((v) => !v);
+                            }}
+                            className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        >
+                            <ChevronRightIcon
+                                className="h-3 w-3 transition-transform duration-150"
+                                style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
+                            />
+                        </button>
+                    )}
+                </div>
             </li>
 
             {isExpanded && (

--- a/frontend/components/Sidebar/SidebarProjects.tsx
+++ b/frontend/components/Sidebar/SidebarProjects.tsx
@@ -55,10 +55,8 @@ const SidebarProjects: React.FC<SidebarProjectsProps> = ({
     const isActive = (path: string) => location.pathname === path;
 
     const itemClass = (path: string) =>
-        `group flex justify-between items-center rounded-[8px] px-[10px] py-1 text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
-            isActive(path)
-                ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
-                : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]'
+        `group flex justify-between items-center rounded-[8px] pl-[30px] pr-[10px] py-[4px] text-[13.5px] cursor-pointer text-gray-500 dark:text-[oklch(82%_0.006_95)] hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
+            isActive(path) ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)]' : ''
         }`;
 
     const navigate = (project: Project) =>
@@ -70,18 +68,25 @@ const SidebarProjects: React.FC<SidebarProjectsProps> = ({
 
     return (
         <ul className="flex flex-col">
-            <li className="group flex justify-between items-center px-2.5 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-white/5">
+            <li
+                className={`group flex justify-between items-center px-[10px] py-[4px] rounded-md hover:bg-gray-100 dark:hover:bg-white/5 ${
+                    location.pathname === '/projects'
+                        ? 'bg-gray-100 dark:bg-white/5'
+                        : ''
+                }`}
+            >
                 <span
-                    className={`flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
+                    className={`flex items-center gap-[6px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
                         location.pathname === '/projects'
-                            ? 'text-gray-900 dark:text-white'
+                            ? 'text-black dark:text-white'
                             : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]'
                     }`}
-                    onClick={() =>
-                        handleNavClick('/projects', t('sidebar.projects'), <FolderIcon className="h-4 w-4 mr-2" />)
-                    }
+                    onClick={() => {
+                        setIsExpanded(true);
+                        handleNavClick('/projects', t('sidebar.projects'), <FolderIcon className="h-4 w-4 mr-2" />);
+                    }}
                 >
-                    <FolderIcon className="h-3.5 w-3.5" />
+                    <FolderIcon className="h-[14px] w-[14px]" />
                     {t('sidebar.projects')}
                 </span>
                 <div className="flex items-center gap-1">
@@ -122,12 +127,8 @@ const SidebarProjects: React.FC<SidebarProjectsProps> = ({
                                 className={itemClass(getProjectPath(project))}
                                 onClick={() => navigate(project)}
                             >
-                                <span className="flex items-center gap-2 min-w-0">
-                                    <span
-                                        className="w-1.5 h-[14px] rounded-full flex-shrink-0"
-                                        style={{ backgroundColor: project.color || '#9ca3af' }}
-                                    />
-                                    <span className="truncate">{project.name}</span>
+                                <span className="truncate min-w-0">
+                                    {project.name}
                                 </span>
                             </div>
                         ))}

--- a/frontend/components/Sidebar/SidebarTags.tsx
+++ b/frontend/components/Sidebar/SidebarTags.tsx
@@ -39,10 +39,8 @@ const SidebarTags: React.FC<SidebarTagsProps> = ({
     const isActive = (path: string) => location.pathname === path;
 
     const itemClass = (path: string) =>
-        `group flex justify-between items-center rounded-[8px] px-[10px] py-1 text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
-            isActive(path)
-                ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
-                : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]'
+        `group flex justify-between items-center rounded-[8px] pl-[30px] pr-[10px] py-[4px] text-[13.5px] cursor-pointer text-gray-500 dark:text-[oklch(82%_0.006_95)] hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
+            isActive(path) ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)]' : ''
         }`;
 
     const getTagPath = (tag: Tag) => {
@@ -58,18 +56,25 @@ const SidebarTags: React.FC<SidebarTagsProps> = ({
 
     return (
         <div className="flex flex-col">
-            <div className="group flex justify-between items-center px-2.5 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-white/5">
+            <div
+                className={`group flex justify-between items-center px-[10px] py-[4px] rounded-md hover:bg-gray-100 dark:hover:bg-white/5 ${
+                    location.pathname === '/tags'
+                        ? 'bg-gray-100 dark:bg-white/5'
+                        : ''
+                }`}
+            >
                 <span
-                    className={`flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
+                    className={`flex items-center gap-[6px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
                         location.pathname === '/tags'
-                            ? 'text-gray-900 dark:text-white'
+                            ? 'text-black dark:text-white'
                             : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]'
                     }`}
-                    onClick={() =>
-                        handleNavClick('/tags', t('sidebar.tags'), <TagIcon className="h-4 w-4 mr-2" />)
-                    }
+                    onClick={() => {
+                        setIsExpanded(true);
+                        handleNavClick('/tags', t('sidebar.tags'), <TagIcon className="h-4 w-4 mr-2" />);
+                    }}
                 >
-                    <TagIcon className="h-3.5 w-3.5" />
+                    <TagIcon className="h-[14px] w-[14px]" />
                     {t('sidebar.tags')}
                 </span>
                 <div className="flex items-center gap-1">
@@ -109,12 +114,8 @@ const SidebarTags: React.FC<SidebarTagsProps> = ({
                             className={itemClass(getTagPath(tag))}
                             onClick={() => navigate(tag)}
                         >
-                            <span className="flex items-center gap-2 min-w-0">
-                                <span
-                                    className="w-1.5 h-[14px] rounded-full flex-shrink-0"
-                                    style={{ backgroundColor: tag.color || '#9ca3af' }}
-                                />
-                                <span className="truncate">{tag.name}</span>
+                            <span className="truncate min-w-0">
+                                {tag.name}
                             </span>
                         </div>
                     ))}

--- a/frontend/components/Sidebar/SidebarTags.tsx
+++ b/frontend/components/Sidebar/SidebarTags.tsx
@@ -3,6 +3,7 @@ import { Location } from 'react-router-dom';
 import {
     TagIcon,
     ChevronRightIcon,
+    PlusIcon,
 } from '@heroicons/react/24/outline';
 import { Tag } from '../../entities/Tag';
 import { useTranslation } from 'react-i18next';
@@ -20,6 +21,7 @@ interface SidebarTagsProps {
 const SidebarTags: React.FC<SidebarTagsProps> = ({
     handleNavClick,
     location,
+    openTagModal,
 }) => {
     const { t } = useTranslation();
     const [isExpanded, setIsExpanded] = useState(false);
@@ -56,7 +58,7 @@ const SidebarTags: React.FC<SidebarTagsProps> = ({
 
     return (
         <div className="flex flex-col">
-            <div className="flex justify-between items-center px-2.5 py-1 rounded-md">
+            <div className="group flex justify-between items-center px-2.5 py-1 rounded-md hover:bg-gray-100 dark:hover:bg-white/5">
                 <span
                     className={`flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
                         location.pathname === '/tags'
@@ -70,20 +72,33 @@ const SidebarTags: React.FC<SidebarTagsProps> = ({
                     <TagIcon className="h-3.5 w-3.5" />
                     {t('sidebar.tags')}
                 </span>
-                {tags.length > 0 && (
+                <div className="flex items-center gap-1">
                     <button
                         onClick={(e) => {
                             e.stopPropagation();
-                            setIsExpanded((v) => !v);
+                            openTagModal(null);
                         }}
-                        className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition-opacity text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        aria-label={t('tags.addTag', 'Add Tag')}
+                        title={t('tags.addTag', 'Add Tag')}
                     >
-                        <ChevronRightIcon
-                            className="h-3 w-3 transition-transform duration-150"
-                            style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
-                        />
+                        <PlusIcon className="h-3.5 w-3.5" />
                     </button>
-                )}
+                    {tags.length > 0 && (
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                setIsExpanded((v) => !v);
+                            }}
+                            className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                        >
+                            <ChevronRightIcon
+                                className="h-3 w-3 transition-transform duration-150"
+                                style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
+                            />
+                        </button>
+                    )}
+                </div>
             </div>
 
             {isExpanded && (

--- a/frontend/components/Sidebar/SidebarViews.tsx
+++ b/frontend/components/Sidebar/SidebarViews.tsx
@@ -79,19 +79,14 @@ const SortableViewItem: React.FC<SortableViewItemProps> = ({
         <li
             ref={setNodeRef}
             style={style}
-            className={`group flex justify-between items-center rounded-[8px] px-[10px] py-1 text-[13.5px] cursor-pointer hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
-                isActive
-                    ? 'bg-gray-100 dark:bg-[oklch(27%_0.02_250)] text-gray-900 dark:text-[oklch(88%_0.004_95)] font-medium'
-                    : 'text-gray-500 dark:text-[oklch(82%_0.006_95)]'
+            className={`group flex justify-between items-center rounded-[8px] pl-[30px] pr-[10px] py-[4px] text-[13.5px] cursor-pointer text-gray-500 dark:text-[oklch(82%_0.006_95)] hover:bg-gray-100 dark:hover:bg-[oklch(24%_0.015_250)] ${
+                isActive ? 'bg-gray-100 dark:bg-[oklch(24%_0.015_250)]' : ''
             } ${isDragging ? 'opacity-50' : ''}`}
             onClick={handleClick}
             {...listeners}
             {...attributes}
         >
-            <span className="flex items-center gap-2 min-w-0">
-                <span className="w-1.5 h-[14px] rounded-full flex-shrink-0 bg-gray-400 dark:bg-gray-500" />
-                <span className="truncate">{view.name}</span>
-            </span>
+            <span className="truncate min-w-0">{view.name}</span>
             <button
                 onClick={onTogglePin}
                 className="opacity-0 group-hover:opacity-100 transition-opacity text-yellow-500 hover:text-yellow-600 dark:hover:text-yellow-400 focus:outline-none flex-shrink-0"
@@ -266,38 +261,42 @@ const SidebarViews: React.FC<SidebarViewsProps> = ({
 
     return (
         <ul className="flex flex-col">
-            <li className="flex justify-between items-center px-2.5 py-1 rounded-md">
+            <li className="flex justify-between items-center px-[10px] py-[4px] rounded-md">
                 <span
-                    className={`flex items-center gap-1.5 text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
+                    className={`flex items-center gap-[6px] text-[10.5px] tracking-[0.01em] font-semibold uppercase cursor-pointer hover:text-black dark:hover:text-white ${
                         isActiveView('/views')
-                            ? 'text-gray-900 dark:text-white'
+                            ? 'text-black dark:text-white'
                             : 'text-gray-400 dark:text-[oklch(58%_0.006_95)]'
                     }`}
-                    onClick={() =>
+                    onClick={() => {
+                        setIsExpanded(true);
                         handleNavClick(
                             '/views',
                             t('sidebar.views'),
                             <QueueListIcon className="h-5 w-5 mr-2" />
-                        )
-                    }
+                        );
+                    }}
                 >
-                    <QueueListIcon className="h-3.5 w-3.5" />
+                    <QueueListIcon className="h-[14px] w-[14px]" />
                     {t('sidebar.views')}
                 </span>
                 {orderedViews.length > 0 && (
-                    <button
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            setIsExpanded((v) => !v);
-                        }}
-                        className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
-                        aria-label={isExpanded ? 'Collapse views list' : 'Expand views list'}
-                    >
-                        <ChevronRightIcon
-                            className="h-3 w-3 transition-transform duration-150"
-                            style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
-                        />
-                    </button>
+                    <div className="flex items-center gap-1">
+                        <span className="h-3.5 w-3.5" aria-hidden="true" />
+                        <button
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                setIsExpanded((v) => !v);
+                            }}
+                            className="text-gray-400 dark:text-gray-500 hover:text-black dark:hover:text-white focus:outline-none"
+                            aria-label={isExpanded ? 'Collapse views list' : 'Expand views list'}
+                        >
+                            <ChevronRightIcon
+                                className="h-3 w-3 transition-transform duration-150"
+                                style={{ transform: isExpanded ? 'rotate(90deg)' : 'none' }}
+                            />
+                        </button>
+                    </div>
                 )}
             </li>
 

--- a/frontend/hooks/useNotesTreeExpansion.ts
+++ b/frontend/hooks/useNotesTreeExpansion.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const STORAGE_KEY = 'notesTreeExpanded';
+
+const readStoredExpanded = (): Record<string, boolean> | null => {
+    try {
+        const raw = localStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+        const parsed = JSON.parse(raw);
+        return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch (error) {
+        console.error('Error parsing persisted notes tree state:', error);
+        return null;
+    }
+};
+
+const persistExpanded = (expanded: Record<string, boolean>) => {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(expanded));
+    } catch (error) {
+        console.error('Error persisting notes tree state:', error);
+    }
+};
+
+/**
+ * Persisted expand/collapse state for the notes tree, keyed by node id
+ * (`area:<uid>`, `project:<uid>`, `tag:<uid>`). The first time this hook
+ * runs with no persisted state yet, it seeds the map with `initialActiveKeys`
+ * (the folder chain around the currently open note) so that branch starts
+ * expanded while everything else starts collapsed. Once seeded (or once a
+ * persisted state already exists), it never overrides the user's own
+ * expand/collapse choices again.
+ */
+export const useNotesTreeExpansion = (initialActiveKeys: string[]) => {
+    const hasSeeded = useRef(false);
+    const [expanded, setExpanded] = useState<Record<string, boolean>>(
+        () => readStoredExpanded() || {}
+    );
+
+    useEffect(() => {
+        if (hasSeeded.current) return;
+        if (readStoredExpanded()) {
+            hasSeeded.current = true;
+            return;
+        }
+        if (initialActiveKeys.length === 0) return;
+
+        hasSeeded.current = true;
+        setExpanded((prev) => {
+            const next = { ...prev };
+            initialActiveKeys.forEach((key) => {
+                next[key] = true;
+            });
+            persistExpanded(next);
+            return next;
+        });
+    }, [initialActiveKeys]);
+
+    const toggle = useCallback((key: string) => {
+        setExpanded((prev) => {
+            const next = { ...prev, [key]: !prev[key] };
+            persistExpanded(next);
+            return next;
+        });
+    }, []);
+
+    return { expanded, toggle };
+};

--- a/frontend/store/useStore.ts
+++ b/frontend/store/useStore.ts
@@ -6,6 +6,7 @@ import { Task } from '../entities/Task';
 import { Tag } from '../entities/Tag';
 import { InboxItem } from '../entities/InboxItem';
 import { Goal } from '../entities/Goal';
+import { Person } from '../entities/Person';
 
 interface NotesStore {
     notes: Note[];
@@ -133,6 +134,17 @@ interface GoalsStore {
     loadGoals: (forceReload?: boolean) => Promise<void>;
 }
 
+interface PeopleStore {
+    people: Person[];
+    isLoading: boolean;
+    isError: boolean;
+    hasLoaded: boolean;
+    setPeople: (people: Person[]) => void;
+    setLoading: (isLoading: boolean) => void;
+    setError: (isError: boolean) => void;
+    loadPeople: (forceReload?: boolean) => Promise<void>;
+}
+
 interface HabitsStore {
     habits: Task[];
     isLoading: boolean;
@@ -151,6 +163,7 @@ interface StoreState {
     goalsStore: GoalsStore;
     projectsStore: ProjectsStore;
     tagsStore: TagsStore;
+    peopleStore: PeopleStore;
     tasksStore: TasksStore;
     inboxStore: InboxStore;
     habitsStore: HabitsStore;
@@ -459,6 +472,61 @@ export const useStore = create<StoreState>((set: any) => ({
                         console.error('addNewTags: Failed to refresh tags:', e)
                     );
             }, 0);
+        },
+    },
+    peopleStore: {
+        people: [],
+        isLoading: false,
+        isError: false,
+        hasLoaded: false,
+        setPeople: (people) =>
+            set((state) => ({
+                peopleStore: { ...state.peopleStore, people },
+            })),
+        setLoading: (isLoading) =>
+            set((state) => ({
+                peopleStore: { ...state.peopleStore, isLoading },
+            })),
+        setError: (isError) =>
+            set((state) => ({
+                peopleStore: { ...state.peopleStore, isError },
+            })),
+        loadPeople: async (forceReload = false) => {
+            const state = useStore.getState();
+            if (state.peopleStore.isLoading) return;
+            if (state.peopleStore.hasLoaded && !forceReload) return;
+
+            const { fetchPeople } = await import('../utils/peopleService');
+
+            set((state) => ({
+                peopleStore: {
+                    ...state.peopleStore,
+                    isLoading: true,
+                    isError: false,
+                },
+            }));
+
+            try {
+                const people = await fetchPeople();
+                set((state) => ({
+                    peopleStore: {
+                        ...state.peopleStore,
+                        people,
+                        isLoading: false,
+                        hasLoaded: true,
+                    },
+                }));
+            } catch (error) {
+                console.error('loadPeople: Failed to load people:', error);
+                set((state) => ({
+                    peopleStore: {
+                        ...state.peopleStore,
+                        isError: true,
+                        isLoading: false,
+                        hasLoaded: true,
+                    },
+                }));
+            }
         },
     },
     tasksStore: {

--- a/frontend/utils/notesTreeUtils.test.ts
+++ b/frontend/utils/notesTreeUtils.test.ts
@@ -1,0 +1,239 @@
+import {
+    buildNotesTree,
+    flattenVisibleRows,
+    getActiveFolderKeys,
+    sortNotesByOrder,
+} from './notesTreeUtils';
+import { Note } from '../entities/Note';
+import { Project } from '../entities/Project';
+
+const makeNote = (overrides: Partial<Note>): Note => ({
+    uid: 'note-uid',
+    title: 'Untitled',
+    content: '',
+    ...overrides,
+});
+
+const makeProject = (overrides: Partial<Project>): Project => ({
+    uid: 'project-uid',
+    name: 'Project',
+    ...overrides,
+});
+
+describe('sortNotesByOrder', () => {
+    const notes = [
+        makeNote({ uid: 'b', title: 'Banana', created_at: '2026-01-02' }),
+        makeNote({ uid: 'a', title: 'Apple', created_at: '2026-01-03' }),
+        makeNote({ uid: 'c', title: 'Cherry', created_at: '2026-01-01' }),
+    ];
+
+    it('sorts by title ascending', () => {
+        const sorted = sortNotesByOrder(notes, 'title:asc');
+        expect(sorted.map((n) => n.uid)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('sorts by created_at descending (default)', () => {
+        const sorted = sortNotesByOrder(notes, 'created_at:desc');
+        expect(sorted.map((n) => n.uid)).toEqual(['a', 'b', 'c']);
+    });
+});
+
+describe('buildNotesTree', () => {
+    const area = { uid: 'area-1', name: 'Work', color: '#4287f5' };
+    const projectInArea = makeProject({
+        uid: 'proj-1',
+        name: 'Website Redesign',
+        color: '#f5a442',
+        area,
+    });
+    const projectNoArea = makeProject({ uid: 'proj-2', name: 'Blog' });
+    const emptyProject = makeProject({ uid: 'proj-3', name: 'No Notes Here' });
+    const projects = [projectInArea, projectNoArea, emptyProject];
+
+    it('puts projects as flat top-level folders, ignoring their area', () => {
+        const notes = [
+            makeNote({ uid: 'n1', project_uid: 'proj-1' }),
+            makeNote({ uid: 'n2', project_uid: 'proj-1' }),
+        ];
+
+        const tree = buildNotesTree(notes, projects, 'created_at:desc');
+
+        expect(tree.rootFolders).toHaveLength(1);
+        const projectFolder = tree.rootFolders[0];
+        expect(projectFolder.kind).toBe('project');
+        expect(projectFolder.name).toBe('Website Redesign');
+        expect(projectFolder.count).toBe(2);
+    });
+
+    it('carries the project color onto its folder node', () => {
+        const notes = [makeNote({ uid: 'n1', project_uid: 'proj-1' })];
+
+        const tree = buildNotesTree(notes, projects, 'created_at:desc');
+
+        expect(tree.rootFolders[0].color).toBe('#f5a442');
+    });
+
+    it('sorts project folders alphabetically regardless of area', () => {
+        const notes = [
+            makeNote({ uid: 'n1', project_uid: 'proj-1' }),
+            makeNote({ uid: 'n2', project_uid: 'proj-2' }),
+        ];
+
+        const tree = buildNotesTree(notes, projects, 'created_at:desc');
+
+        expect(tree.rootFolders.map((f) => f.name)).toEqual([
+            'Blog',
+            'Website Redesign',
+        ]);
+    });
+
+    it('resolves the project name even when Sequelize returns it under the capitalized `Area` key', () => {
+        // Project.belongsTo(Area) has no `as` alias, so the API can return
+        // the association as `Area` (Sequelize default) instead of `area`.
+        // Area grouping no longer matters, but the project itself must
+        // still resolve correctly regardless of that casing.
+        const projectWithCapitalizedArea = makeProject({
+            uid: 'proj-4',
+            name: 'Legacy Migration',
+        }) as Project & { Area?: typeof area };
+        projectWithCapitalizedArea.Area = area;
+        delete projectWithCapitalizedArea.area;
+
+        const notes = [makeNote({ uid: 'n1', project_uid: 'proj-4' })];
+
+        const tree = buildNotesTree(
+            notes,
+            [projectWithCapitalizedArea],
+            'created_at:desc'
+        );
+
+        expect(tree.rootFolders).toHaveLength(1);
+        expect(tree.rootFolders[0].kind).toBe('project');
+        expect(tree.rootFolders[0].name).toBe('Legacy Migration');
+    });
+
+    it('omits projects that have no notes', () => {
+        const notes = [makeNote({ uid: 'n1', project_uid: 'proj-2' })];
+
+        const tree = buildNotesTree(notes, projects, 'created_at:desc');
+
+        const names = tree.rootFolders.map((f) => f.name);
+        expect(names).toEqual(['Blog']);
+        expect(names).not.toContain('No Notes Here');
+    });
+
+    it('puts notes with no project at the tree root as leaves', () => {
+        const notes = [makeNote({ uid: 'n1', project_uid: undefined })];
+
+        const tree = buildNotesTree(notes, projects, 'created_at:desc');
+
+        expect(tree.rootFolders).toHaveLength(0);
+        expect(tree.rootNotes.map((n) => n.uid)).toEqual(['n1']);
+    });
+});
+
+describe('flattenVisibleRows', () => {
+    const labels = { folders: 'Folders' };
+
+    it('shows only top-level folder rows when nothing is expanded', () => {
+        const notes = [makeNote({ uid: 'n1', project_uid: 'proj-2' })];
+        const projects = [makeProject({ uid: 'proj-2', name: 'Blog' })];
+        const tree = buildNotesTree(notes, projects, 'created_at:desc');
+
+        const rows = flattenVisibleRows({
+            tree,
+            expanded: {},
+            forceExpandAll: false,
+            labels,
+        });
+
+        expect(rows.map((r) => r.type)).toEqual(['section-header', 'folder']);
+    });
+
+    it('carries the folder color through onto the flattened row', () => {
+        const notes = [makeNote({ uid: 'n1', project_uid: 'proj-2' })];
+        const projects = [
+            makeProject({ uid: 'proj-2', name: 'Blog', color: '#123abc' }),
+        ];
+        const tree = buildNotesTree(notes, projects, 'created_at:desc');
+
+        const rows = flattenVisibleRows({
+            tree,
+            expanded: {},
+            forceExpandAll: false,
+            labels,
+        });
+
+        const folderRow = rows.find((r) => r.type === 'folder');
+        expect(folderRow && 'color' in folderRow && folderRow.color).toBe(
+            '#123abc'
+        );
+    });
+
+    it('reveals leaf notes once a folder is expanded', () => {
+        const notes = [makeNote({ uid: 'n1', project_uid: 'proj-2' })];
+        const projects = [makeProject({ uid: 'proj-2', name: 'Blog' })];
+        const tree = buildNotesTree(notes, projects, 'created_at:desc');
+
+        const rows = flattenVisibleRows({
+            tree,
+            expanded: { 'project:proj-2': true },
+            forceExpandAll: false,
+            labels,
+        });
+
+        expect(rows.map((r) => r.type)).toEqual([
+            'section-header',
+            'folder',
+            'note',
+        ]);
+    });
+
+    it('force-expands every folder while a search is active', () => {
+        const notes = [makeNote({ uid: 'n1', project_uid: 'proj-2' })];
+        const projects = [makeProject({ uid: 'proj-2', name: 'Blog' })];
+        const tree = buildNotesTree(notes, projects, 'created_at:desc');
+
+        const rows = flattenVisibleRows({
+            tree,
+            expanded: {},
+            forceExpandAll: true,
+            labels,
+        });
+
+        expect(rows.map((r) => r.type)).toEqual([
+            'section-header',
+            'folder',
+            'note',
+        ]);
+    });
+
+    it('returns no rows when the tree is empty', () => {
+        const tree = buildNotesTree([], [], 'created_at:desc');
+
+        const rows = flattenVisibleRows({
+            tree,
+            expanded: {},
+            forceExpandAll: false,
+            labels,
+        });
+
+        expect(rows).toEqual([]);
+    });
+});
+
+describe('getActiveFolderKeys', () => {
+    it('returns the project key for a note in a project', () => {
+        const note = makeNote({ uid: 'n1', project_uid: 'proj-1' });
+
+        expect(getActiveFolderKeys(note)).toEqual(['project:proj-1']);
+    });
+
+    it('returns no keys for a note with no project', () => {
+        expect(getActiveFolderKeys(makeNote({ uid: 'n1' }))).toEqual([]);
+    });
+
+    it('returns no keys when there is no active note', () => {
+        expect(getActiveFolderKeys(null)).toEqual([]);
+    });
+});

--- a/frontend/utils/notesTreeUtils.ts
+++ b/frontend/utils/notesTreeUtils.ts
@@ -1,0 +1,215 @@
+import { Note } from '../entities/Note';
+import { Project } from '../entities/Project';
+
+export interface ProjectFolderNode {
+    kind: 'project';
+    key: string;
+    uid: string;
+    name: string;
+    color?: string;
+    notes: Note[];
+    count: number;
+}
+
+export interface NotesTreeData {
+    rootFolders: ProjectFolderNode[];
+    rootNotes: Note[];
+}
+
+export type TreeRow =
+    | { type: 'section-header'; key: string; label: string }
+    | {
+          type: 'folder';
+          key: string;
+          label: string;
+          color?: string;
+          count: number;
+          depth: number;
+          expanded: boolean;
+      }
+    | { type: 'note'; key: string; note: Note; depth: number };
+
+const getNoteProject = (note: Note) => note.project || note.Project;
+const getNoteProjectUid = (note: Note): string | undefined =>
+    getNoteProject(note)?.uid || note.project_uid;
+
+const compareLabels = (a: string, b: string) =>
+    a.localeCompare(b, undefined, { sensitivity: 'base' });
+
+export const sortNotesByOrder = (notes: Note[], orderBy: string): Note[] => {
+    const [field, direction] = orderBy.split(':');
+    const isAsc = direction === 'asc';
+
+    return [...notes].sort((a, b) => {
+        let valueA: string | number;
+        let valueB: string | number;
+
+        switch (field) {
+            case 'title':
+                valueA = a.title?.toLowerCase() || '';
+                valueB = b.title?.toLowerCase() || '';
+                break;
+            case 'updated_at':
+                valueA = a.updated_at ? new Date(a.updated_at).getTime() : 0;
+                valueB = b.updated_at ? new Date(b.updated_at).getTime() : 0;
+                break;
+            case 'created_at':
+            default:
+                valueA = a.created_at ? new Date(a.created_at).getTime() : 0;
+                valueB = b.created_at ? new Date(b.created_at).getTime() : 0;
+                break;
+        }
+
+        if (valueA < valueB) return isAsc ? -1 : 1;
+        if (valueA > valueB) return isAsc ? 1 : -1;
+        return 0;
+    });
+};
+
+/**
+ * Builds the flat Project-folder / rootless-note structure for the notes
+ * tree from data already available in the frontend stores. Projects are a
+ * flat top level (no Area grouping) - a project only appears if it has at
+ * least one note, so empty folders don't clutter what is a notes browser,
+ * not a project browser.
+ */
+export const buildNotesTree = (
+    notes: Note[],
+    projects: Project[],
+    orderBy: string
+): NotesTreeData => {
+    const projectsByUid = new Map<string, Project>();
+    projects.forEach((project) => {
+        if (project.uid) projectsByUid.set(project.uid, project);
+    });
+
+    const notesByProjectUid = new Map<string, Note[]>();
+    const rootNotes: Note[] = [];
+
+    notes.forEach((note) => {
+        const projectUid = getNoteProjectUid(note);
+        if (!projectUid) {
+            rootNotes.push(note);
+            return;
+        }
+        const list = notesByProjectUid.get(projectUid);
+        if (list) {
+            list.push(note);
+        } else {
+            notesByProjectUid.set(projectUid, [note]);
+        }
+    });
+
+    const rootFolders: ProjectFolderNode[] = [];
+
+    notesByProjectUid.forEach((projectNotes, projectUid) => {
+        const project = projectsByUid.get(projectUid);
+        const fallbackProject = getNoteProject(projectNotes[0]);
+        const name = project?.name || fallbackProject?.name || projectUid;
+
+        rootFolders.push({
+            kind: 'project',
+            key: `project:${projectUid}`,
+            uid: projectUid,
+            name,
+            color: project?.color,
+            notes: sortNotesByOrder(projectNotes, orderBy),
+            count: projectNotes.length,
+        });
+    });
+
+    rootFolders.sort((a, b) => compareLabels(a.name, b.name));
+
+    return {
+        rootFolders,
+        rootNotes: sortNotesByOrder(rootNotes, orderBy),
+    };
+};
+
+interface FlattenParams {
+    tree: NotesTreeData;
+    expanded: Record<string, boolean>;
+    forceExpandAll: boolean;
+    labels: { folders: string };
+}
+
+const isExpanded = (
+    key: string,
+    expanded: Record<string, boolean>,
+    forceExpandAll: boolean
+) => (forceExpandAll ? true : !!expanded[key]);
+
+/**
+ * Turns the tree + current expand-state into the flat row array the
+ * virtualized list renders. When `forceExpandAll` is set (an active search
+ * query), every folder is shown expanded regardless of persisted state - the
+ * tree passed in has already been filtered to matching notes only, so every
+ * folder present here necessarily contains a match.
+ */
+export const flattenVisibleRows = ({
+    tree,
+    expanded,
+    forceExpandAll,
+    labels,
+}: FlattenParams): TreeRow[] => {
+    const rows: TreeRow[] = [];
+
+    if (tree.rootFolders.length === 0 && tree.rootNotes.length === 0) {
+        return rows;
+    }
+
+    rows.push({
+        type: 'section-header',
+        key: 'section:folders',
+        label: labels.folders,
+    });
+
+    tree.rootFolders.forEach((folder) => {
+        const folderExpanded = isExpanded(folder.key, expanded, forceExpandAll);
+        rows.push({
+            type: 'folder',
+            key: folder.key,
+            label: folder.name,
+            color: folder.color,
+            count: folder.count,
+            depth: 0,
+            expanded: folderExpanded,
+        });
+
+        if (!folderExpanded) return;
+
+        folder.notes.forEach((note) => {
+            rows.push({
+                type: 'note',
+                key: `note:${note.uid}`,
+                note,
+                depth: 1,
+            });
+        });
+    });
+
+    tree.rootNotes.forEach((note) => {
+        rows.push({
+            type: 'note',
+            key: `root-note:${note.uid}`,
+            note,
+            depth: 0,
+        });
+    });
+
+    return rows;
+};
+
+/**
+ * Expand-state key for the folder containing a given note, used to seed the
+ * tree's default expand state around the currently active note.
+ */
+export const getActiveFolderKeys = (
+    note: Note | null | undefined
+): string[] => {
+    if (!note) return [];
+    const projectUid = getNoteProjectUid(note);
+    if (!projectUid) return [];
+
+    return [`project:${projectUid}`];
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tududi",
-  "version": "v1.4.0-rc.2",
+  "version": "v1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tududi",
-      "version": "v1.4.0-rc.2",
+      "version": "v1.4.0",
       "license": "ISC",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.106.0",
@@ -20537,6 +20537,24 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/tapable": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1063,6 +1063,7 @@
     "placeholder": "Add a subtask..."
   },
   "projects": {
+    "addProject": "Add Project",
     "loading": "Loading projects...",
     "error": "Error loading projects",
     "searchPlaceholder": "Search projects...",
@@ -1169,6 +1170,7 @@
     "horizonYear": "Year"
   },
   "notes": {
+    "addNote": "Add Note",
     "loading": "Loading notes...",
     "error": "Error loading notes",
     "searchPlaceholder": "Search notes...",
@@ -1187,9 +1189,13 @@
     "contentPlaceholderMarkdown": "Write your content using Markdown formatting...\n\nExamples:\n# Heading\n**Bold text**\n*Italic text*\n- List item\n```code```",
     "pinToSidebar": "Pin to sidebar",
     "unpinFromSidebar": "Unpin from sidebar",
-    "save": "Save"
+    "save": "Save",
+    "tree": {
+      "folders": "Folders"
+    }
   },
   "tags": {
+    "addTag": "Add Tag",
     "loading": "Loading tags...",
     "searchPlaceholder": "Search tags...",
     "title": "Tags",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,7 +8,7 @@ module.exports = {
   theme: {
     extend: {
       spacing: {
-        sidebar: '20rem',
+        sidebar: '22rem',
       },
       keyframes: {
         'scale-in': {


### PR DESCRIPTION
## Description

Polish pass on the sidebar (Areas, Projects, Goals, Notes, Tags, People, Favorites, Views, Boards, Insights):

- Removed the per-item colored dot/pill from subitems across all sections
- Fixed subitem/title text misalignment: the app's root font-size is scaled to 90%, so `rem`-based Tailwind classes (padding, gaps, icon sizes) rendered smaller than literal `px` values used elsewhere, causing headers and subitems to visibly drift out of alignment. Converted every affected sidebar row to literal pixel values so they're immune to that scaling.
- Widened the sidebar (`20rem` → `22rem`)
- Clicking a section title (Projects, Areas, Goals, Notes, Tags, Views) now expands the section in addition to navigating, instead of requiring a separate click on the chevron
- Turned People into a full collapsible section like Areas/Projects/Goals/Tags/Notes: new `peopleStore` in the Zustand store, `PersonModal` wired through `Layout`/`Sidebar`, sorted subitem list with a hover-reveal add button
- Reserved chevron-toggle spacing in sections without an add button (Favorites, Views, Boards, Insights) so their chevrons align with the ones that sit next to a "+" button
- Normalized "active" (current page) row styling to reuse the exact hover classes instead of a separate, stronger background/font-weight combo
- Normalized all row vertical padding to a literal `py-[4px]` — some rows had a hardcoded `py-[5px]`, others the rem-based `py-1`, causing visibly uneven row heights

## Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Testing

**How did you test this?**

Verified visually with Playwright against the running dev server (logged in as the seeded dev user), screenshotting the sidebar in several states (collapsed, all sections expanded, People section populated) and measuring rendered text-start pixel positions directly to confirm alignment, row height, and chevron position across sections.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [x] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

Builds on the notes-tree-column work already on this branch.
