### PR TITLE
fix: set response_format.json_schema.strict to true for Anthropic compatibility

### DIFF
--- a/backend/modules/ai-assistant/service.js
+++ b/backend/modules/ai-assistant/service.js
@@ -89,10 +89,16 @@ function extractMessageContent(message) {
     }
 }
 
+// strict: true is required by Anthropic's OpenAI-compatible endpoint (it
+// rejects strict: false with a 400) and is also OpenAI's recommended mode
+// for schema-following output. It does mean every schema below must be
+// strict-mode compliant: every property listed in "properties" must also be
+// listed in "required", and every object level needs
+// additionalProperties: false.
 function buildResponseFormat(name, schema) {
     return {
         type: 'json_schema',
-        json_schema: { name, strict: false, schema },
+        json_schema: { name, strict: true, schema },
     };
 }
 
@@ -381,10 +387,14 @@ Rules:
                             reason: { type: 'string' },
                             suggestion: { type: 'string' },
                         },
+                        required: ['action', 'project', 'reason', 'suggestion'],
+                        additionalProperties: false,
                     },
                 },
                 watch_out: { type: 'array', items: { type: 'string' } },
             },
+            required: ['overview', 'focus', 'priority_actions', 'watch_out'],
+            additionalProperties: false,
         }),
     });
 
@@ -613,10 +623,20 @@ Rules:
                             label: { type: 'string' },
                             url: { type: 'string' },
                         },
+                        required: ['label', 'url'],
+                        additionalProperties: false,
                     },
                 },
-                watch_out: { type: 'string' },
+                watch_out: { type: ['string', 'null'] },
             },
+            required: [
+                'insight',
+                'next_step',
+                'breakdown',
+                'links',
+                'watch_out',
+            ],
+            additionalProperties: false,
         }),
     });
 
@@ -754,8 +774,10 @@ Rules:
                 insight: { type: 'string' },
                 next_action: { type: 'string' },
                 health: { type: 'string' },
-                watch_out: { type: 'string' },
+                watch_out: { type: ['string', 'null'] },
             },
+            required: ['insight', 'next_action', 'health', 'watch_out'],
+            additionalProperties: false,
         }),
     });
 


### PR DESCRIPTION
## Description

Anthropic's OpenAI-compatible chat completions endpoint rejects `response_format.json_schema.strict: false` with a 400. `buildResponseFormat()` always set `strict: false`, so every AI Assistant request (Daily Brief, Task Insights, Project Insights) against an Anthropic-backed `LLM_BASE_URL` failed on the first attempt and only succeeded because `callWithFallback()` silently retries without `response_format`, disabling schema validation entirely.

This PR sets `strict: true` and brings all three JSON schemas (`daily_brief`, `task_insights`, `project_insights`) into strict-mode compliance: every property in `properties` is now listed in `required`, and every object level sets `additionalProperties: false`. Fields that can legitimately be absent (`watch_out` in task/project insights) use `type: ['string', 'null']` instead of being optional, since strict mode doesn't support optional keys. This makes the fix correct for both Anthropic (which requires `strict: true`) and OpenAI itself (whose strict mode enforces the same schema shape), rather than just flipping the flag and relying on the 400-and-retry fallback for one provider or the other.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1383

## Testing

**How did you test this?**

Verified the schema changes compile and are consistent with the existing parsing logic (nullable `watch_out` handling in `generateTaskInsights`/`generateProjectInsights`, string-literal `"null"` handling for `project` in `generateDailyBrief`). Ran the full backend unit suite and the AI-assistant-specific tests.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [ ] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [ ] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)

## Additional Notes

No test suite exercises the actual OpenAI SDK request payload for this module (existing `ai-assistant` tests only cover max-tokens env parsing and the not-configured path), so I didn't have an existing pattern to extend with a schema-shape assertion. Happy to add one if there's a preferred way to mock the OpenAI client in this codebase.
