### PR TITLE
Fix MCP list_inbox to filter out deleted/trashed/processed items

### DIFF
--- a/backend/modules/mcp/tools/inboxTools.js
+++ b/backend/modules/mcp/tools/inboxTools.js
@@ -1,7 +1,10 @@
 'use strict';
 
+const { Op } = require('sequelize');
 const { InboxItem } = require('../../../models');
 const inboxService = require('../../inbox/service');
+
+const INACTIVE_STATUSES = ['deleted', 'trashed', 'processed'];
 
 /**
  * Register all inbox-related MCP tools
@@ -10,7 +13,8 @@ function registerInboxTools(server, context, tools) {
     // 1. list_inbox - List inbox items
     tools.push({
         name: 'list_inbox',
-        description: 'List items from inbox with pagination',
+        description:
+            'List items from inbox with pagination. Only active items (not deleted, trashed, or processed) are returned by default.',
         inputSchema: {
             type: 'object',
             properties: {
@@ -24,14 +28,26 @@ function registerInboxTools(server, context, tools) {
                     description: 'Number of items to skip',
                     default: 0,
                 },
+                status: {
+                    type: 'string',
+                    description:
+                        'Filter by a specific status (e.g. added, processed, deleted, trashed). Omit to return only active items.',
+                },
             },
         },
         handler: async (params) => {
             const limit = params.limit || 20;
             const offset = params.offset || 0;
 
+            const where = { user_id: context.userId };
+            if (params.status) {
+                where.status = params.status;
+            } else {
+                where.status = { [Op.notIn]: INACTIVE_STATUSES };
+            }
+
             const items = await InboxItem.findAll({
-                where: { user_id: context.userId },
+                where,
                 limit: limit,
                 offset: offset,
                 order: [['created_at', 'DESC']],
@@ -42,7 +58,7 @@ function registerInboxTools(server, context, tools) {
                 uid: item.uid,
                 content: item.content,
                 source: item.source,
-                processed: item.processed,
+                status: item.status,
                 created_at: item.created_at,
                 updated_at: item.updated_at,
             }));

--- a/backend/tests/integration/mcp/mcp-tools.test.js
+++ b/backend/tests/integration/mcp/mcp-tools.test.js
@@ -1056,6 +1056,72 @@ describe('MCP Tools Integration', () => {
                 expect(response.status).toBe(200);
                 const { content } = getToolContent(response);
                 expect(content.count).toBeGreaterThanOrEqual(1);
+                expect(content.items[0].status).toBe('added');
+            });
+
+            it('should exclude deleted, trashed, and processed items by default', async () => {
+                await InboxItem.create({
+                    user_id: user.id,
+                    content: 'Active item',
+                    source: 'mcp',
+                    status: 'added',
+                });
+                await InboxItem.create({
+                    user_id: user.id,
+                    content: 'Deleted item',
+                    source: 'mcp',
+                    status: 'deleted',
+                });
+                await InboxItem.create({
+                    user_id: user.id,
+                    content: 'Trashed item',
+                    source: 'mcp',
+                    status: 'trashed',
+                });
+                await InboxItem.create({
+                    user_id: user.id,
+                    content: 'Processed item',
+                    source: 'mcp',
+                    status: 'processed',
+                });
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'list_inbox',
+                    {}
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.count).toBe(1);
+                expect(content.items[0].content).toBe('Active item');
+            });
+
+            it('should return items matching an explicit status filter', async () => {
+                await InboxItem.create({
+                    user_id: user.id,
+                    content: 'Active item',
+                    source: 'mcp',
+                    status: 'added',
+                });
+                await InboxItem.create({
+                    user_id: user.id,
+                    content: 'Processed item',
+                    source: 'mcp',
+                    status: 'processed',
+                });
+
+                const response = await callMcpTool(
+                    apiTokenValue,
+                    'list_inbox',
+                    { status: 'processed' }
+                );
+
+                expect(response.status).toBe(200);
+                const { content } = getToolContent(response);
+                expect(content.count).toBe(1);
+                expect(content.items[0].content).toBe('Processed item');
+                expect(content.items[0].status).toBe('processed');
             });
         });
 

--- a/docs/14-mcp-integration.md
+++ b/docs/14-mcp-integration.md
@@ -468,13 +468,14 @@ Permanently delete a project and all its tasks (notes are orphaned).
 
 #### `list_inbox`
 
-List inbox items.
+List inbox items. Only active items (not deleted, trashed, or processed) are returned by default.
 
 **Parameters:**
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `limit` | number | No | 20 | Maximum items |
 | `offset` | number | No | 0 | Items to skip |
+| `status` | string | No | — | Filter by a specific status (e.g. `added`, `processed`, `deleted`, `trashed`). Omit to return only active items. |
 
 ---
 


### PR DESCRIPTION
## Description

The `list_inbox` MCP tool queried `InboxItem` directly with only a `user_id` filter, bypassing the inbox service/repository entirely. As a result, deleted, trashed, and processed items kept showing up in listings indefinitely, and each serialized item exposed a nonexistent `processed` field instead of the real `status` column (always `undefined`), so callers had no way to filter client-side either. This matches the reproduction in the linked issue (5/20 deleted items still listed; 15 processed items still listed right after processing).

The REST `/api/inbox` endpoint already filters correctly via `inboxRepository.findAllActive`, this fix brings the MCP tool in line with it.

**Changes:**
- `list_inbox` now defaults to excluding `deleted`, `trashed`, and `processed` items, same as the REST endpoint.
- Added an optional `status` param so a caller can explicitly request a specific status (e.g. `processed`) when needed, per the issue's suggested fix.
- Fixed serialization to return the item's real `status` instead of the nonexistent `processed` field.
- Updated `docs/14-mcp-integration.md` for the new `status` param.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1387

## Testing

**How did you test this?**

Added integration tests to `backend/tests/integration/mcp/mcp-tools.test.js` covering: default listing excludes deleted/trashed/processed items, an explicit `status` filter returns only matching items, and the returned item now carries the real `status`.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [x] Updated documentation (if needed)