### PR TITLE
chore: trim PR template checkboxes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@ Before submitting:
 1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
 2. Run: npm run pre-push (linting, formatting, tests)
 3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
-4. Delete sections that don't apply to your PR
+4. Delete sections that don't apply
 -->
 
 ## Description
@@ -32,11 +32,7 @@ Fixes #
 
 <!-- Describe your testing steps -->
 
-**Commands run:**
-
-- [ ] `npm run pre-push` (linting + formatting + tests)
-- [ ] Tested manually in browser
-- [ ] Tested on mobile (if UI changes)
+- [ ] `npm run pre-push` passes
 
 ## Screenshots
 
@@ -46,12 +42,8 @@ Fixes #
 ## Checklist
 
 - [ ] This is not an AI slop crap, I know what I am doing
-- [ ] Code follows project style guidelines
-- [ ] Self-reviewed my own code
-- [ ] Added/updated tests (if applicable)
-- [ ] Updated documentation (if needed)
-- [ ] Database migrations included and tested (if applicable)
-- [ ] Translation keys added and synced (if applicable)
+- [ ] Self-reviewed my own code, follows project style guidelines
+- [ ] Tests, docs, migrations, and translations updated (if applicable)
 
 ## Additional Notes
 

--- a/docs/MEMORY.md
+++ b/docs/MEMORY.md
@@ -7,15 +7,16 @@ This document contains preferences, patterns, and memory items specific to worki
 ## Pull Request Preferences
 
 ### PR Template
-- **ALWAYS use** the PR template from `.github/pull_request_template.md`
+- **ALWAYS use** the PR template from `.github/pull_request_template.md` (trimmed 2026-08-18: all original sections kept, only the checkbox counts were cut down)
 - **Do NOT add** the "🤖 Generated with [Claude Code](https://claude.com/claude-code)" footer to pull requests
 - **Do NOT use emojis** in PR titles, descriptions, or comments (e.g., ✅, 🎉, 📦, ⚠️, 🚀)
-- Required sections:
+- Sections (all present, in order):
   - **Description**: What does this PR do? Why is this change needed?
   - **Type of Change**: Bug fix / New feature / Breaking change / Documentation
   - **Related Issues**: Link issues using "Fixes #123"
-  - **Testing**: Describe testing steps and commands run
-  - **Checklist**: Mark all applicable items (including "This is not AI slop crap")
+  - **Testing**: Describe testing steps, plus a single `npm run pre-push` checkbox
+  - **Screenshots**: If UI changes; delete section if not applicable
+  - **Checklist**: 3 items only (not AI slop, self-reviewed, tests/docs/migrations/translations updated if applicable)
   - **Additional Notes**: Any other context for reviewers
 
 ### PR Creation Workflow
@@ -104,5 +105,5 @@ This document contains preferences, patterns, and memory items specific to worki
 
 ---
 
-**Last Updated:** 2026-04-20
+**Last Updated:** 2026-08-18
 **Maintained by:** Claude Code sessions - update as new patterns emerge


### PR DESCRIPTION
## Description

Trims the number of checkboxes in `.github/pull_request_template.md` without removing any sections. Testing goes from 3 checkboxes to 1 (`npm run pre-push`); the Checklist goes from 7 items to 3 (AI-slop check, self-review, and a combined tests/docs/migrations/translations line). Type of Change, Related Issues, Screenshots, and Additional Notes are unchanged. Also updates `docs/MEMORY.md` to match.

## Type of Change

- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [x] Documentation/Translation update

## Related Issues

N/A (no linked issue, process change)

## Testing

**How did you test this?**

Reviewed the rendered template by eye; ran the standard pre-push checks.

- [x] `npm run pre-push` passes

## Screenshots

N/A (no UI changes)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)

## Additional Notes

Follow-up to the first pass on this PR, which stripped whole sections. Kept per user feedback: reduce checkbox count, don't remove sections.