### PR TITLE
fix(security): prevent SSRF in URL metadata fetching

### DIFF
--- a/backend/modules/url/service.js
+++ b/backend/modules/url/service.js
@@ -4,6 +4,9 @@ const https = require('https');
 const http = require('http');
 const { URL } = require('url');
 const { logError } = require('../../services/logService');
+const { assertSafeUrl } = require('./ssrfGuard');
+
+const MAX_REDIRECTS = 5;
 
 let nodeFetchInstance = null;
 try {
@@ -195,35 +198,63 @@ const finalizeMetadata = (metadata, sourceUrl) => {
 };
 
 async function fetchMetadataViaFetch(normalizedUrl) {
-    const response = await fetchWithTimeout(
-        normalizedUrl,
-        {
-            method: 'GET',
-            redirect: 'follow',
-            headers: {
-                'User-Agent':
-                    'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
-                Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+    let currentUrl = normalizedUrl;
+
+    for (
+        let redirectCount = 0;
+        redirectCount <= MAX_REDIRECTS;
+        redirectCount++
+    ) {
+        const response = await fetchWithTimeout(
+            currentUrl,
+            {
+                method: 'GET',
+                // Redirects are followed manually so each hop's target can be
+                // re-validated against the SSRF guard before being requested.
+                redirect: 'manual',
+                headers: {
+                    'User-Agent':
+                        'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
+                    Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                },
             },
-        },
-        7000
-    );
+            7000
+        );
 
-    if (!response || !response.ok) {
-        return null;
+        if (!response) {
+            return null;
+        }
+
+        if ([301, 302, 303, 307, 308].includes(response.status)) {
+            const location = response.headers.get('location');
+            if (!location) {
+                return null;
+            }
+
+            const redirectUrl = new URL(location, currentUrl).href;
+            await assertSafeUrl(redirectUrl);
+            currentUrl = redirectUrl;
+            continue;
+        }
+
+        if (!response.ok) {
+            return null;
+        }
+
+        const contentType = response.headers.get('content-type');
+        if (contentType && !contentType.includes('text/html')) {
+            return null;
+        }
+
+        const html = await response.text();
+        if (!html) {
+            return null;
+        }
+
+        return finalizeMetadata(extractMetadataFromHtml(html), currentUrl);
     }
 
-    const contentType = response.headers.get('content-type');
-    if (contentType && !contentType.includes('text/html')) {
-        return null;
-    }
-
-    const html = await response.text();
-    if (!html) {
-        return null;
-    }
-
-    return finalizeMetadata(extractMetadataFromHtml(html), normalizedUrl);
+    return null;
 }
 
 function fetchMetadataViaHttp(normalizedUrl, maxRedirects = 5) {
@@ -249,6 +280,16 @@ function fetchMetadataViaHttp(normalizedUrl, maxRedirects = 5) {
                 return;
             }
 
+            assertSafeUrl(currentUrl)
+                .then(() => performRequest(currentUrl, redirectCount))
+                .catch((error) => {
+                    logError('Blocked unsafe URL for metadata fetch:', error);
+                    clearTimeout(globalTimeout);
+                    fallbackResolve(null);
+                });
+        }
+
+        function performRequest(currentUrl, redirectCount) {
             try {
                 const urlObj = new URL(currentUrl);
                 const isHttps = urlObj.protocol === 'https:';
@@ -414,6 +455,13 @@ async function fetchUrlMetadata(url) {
         }
     } catch (error) {
         logError('Error parsing URL for YouTube check:', error);
+    }
+
+    try {
+        await assertSafeUrl(normalizedUrl);
+    } catch (error) {
+        logError('Blocked unsafe URL for metadata fetch:', error);
+        return null;
     }
 
     try {

--- a/backend/modules/url/ssrfGuard.js
+++ b/backend/modules/url/ssrfGuard.js
@@ -1,0 +1,148 @@
+'use strict';
+
+const dns = require('dns');
+const net = require('net');
+
+class UnsafeUrlError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'UnsafeUrlError';
+    }
+}
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+const ALLOWED_PORTS = new Set(['', '80', '443']);
+
+// Private, loopback, link-local, and other non-routable IPv4 ranges that
+// must never be reachable via a user-supplied URL (RFC 1918, RFC 5735,
+// RFC 6598, cloud metadata endpoints, etc).
+const PRIVATE_IPV4_RANGES = [
+    '0.0.0.0/8',
+    '10.0.0.0/8',
+    '100.64.0.0/10',
+    '127.0.0.0/8',
+    '169.254.0.0/16',
+    '172.16.0.0/12',
+    '192.0.0.0/24',
+    '192.0.2.0/24',
+    '192.168.0.0/16',
+    '198.18.0.0/15',
+    '198.51.100.0/24',
+    '203.0.113.0/24',
+    '224.0.0.0/4',
+    '240.0.0.0/4',
+];
+
+function ipv4ToLong(ip) {
+    return (
+        ip
+            .split('.')
+            .reduce((acc, octet) => (acc << 8) + parseInt(octet, 10), 0) >>> 0
+    );
+}
+
+function isIpv4InCidr(ip, cidr) {
+    const [range, bitsStr] = cidr.split('/');
+    const bits = parseInt(bitsStr, 10);
+    const mask = bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
+    return (ipv4ToLong(ip) & mask) === (ipv4ToLong(range) & mask);
+}
+
+function isPrivateIpv4(ip) {
+    return PRIVATE_IPV4_RANGES.some((cidr) => isIpv4InCidr(ip, cidr));
+}
+
+function isPrivateIpv6(ip) {
+    const normalized = ip.toLowerCase();
+
+    if (normalized === '::1' || normalized === '::') {
+        return true;
+    }
+
+    // IPv4-mapped addresses (::ffff:127.0.0.1) - validate the embedded IPv4
+    const mappedMatch = normalized.match(
+        /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/
+    );
+    if (mappedMatch) {
+        return isPrivateIpv4(mappedMatch[1]);
+    }
+
+    // Unique local addresses fc00::/7
+    if (/^f[cd][0-9a-f]{0,2}:/.test(normalized)) {
+        return true;
+    }
+
+    // Link-local fe80::/10
+    if (/^fe[89ab][0-9a-f]:/.test(normalized)) {
+        return true;
+    }
+
+    return false;
+}
+
+function isPrivateOrReservedIp(ip) {
+    if (net.isIPv4(ip)) {
+        return isPrivateIpv4(ip);
+    }
+    if (net.isIPv6(ip)) {
+        return isPrivateIpv6(ip);
+    }
+    // Not a recognizable IP - fail closed.
+    return true;
+}
+
+async function assertPublicHostname(hostname) {
+    // IP literal - no DNS resolution needed, and nothing to rebind.
+    if (net.isIP(hostname)) {
+        if (isPrivateOrReservedIp(hostname)) {
+            throw new UnsafeUrlError(
+                `Refusing to fetch private/reserved address: ${hostname}`
+            );
+        }
+        return;
+    }
+
+    let addresses;
+    try {
+        addresses = await dns.promises.lookup(hostname, { all: true });
+    } catch {
+        throw new UnsafeUrlError(`Could not resolve host: ${hostname}`);
+    }
+
+    if (!addresses || addresses.length === 0) {
+        throw new UnsafeUrlError(`Could not resolve host: ${hostname}`);
+    }
+
+    for (const { address } of addresses) {
+        if (isPrivateOrReservedIp(address)) {
+            throw new UnsafeUrlError(
+                `Refusing to fetch private/reserved address: ${address}`
+            );
+        }
+    }
+}
+
+// Validates a URL is safe to fetch server-side: http(s) only, standard
+// ports only, and resolves to a public (non-private/reserved) address.
+// Must be called again on every redirect hop, not just the initial URL.
+async function assertSafeUrl(urlLike) {
+    const parsed = typeof urlLike === 'string' ? new URL(urlLike) : urlLike;
+
+    if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+        throw new UnsafeUrlError(`Unsupported protocol: ${parsed.protocol}`);
+    }
+
+    if (!ALLOWED_PORTS.has(parsed.port)) {
+        throw new UnsafeUrlError(`Unsupported port: ${parsed.port}`);
+    }
+
+    await assertPublicHostname(parsed.hostname);
+
+    return parsed;
+}
+
+module.exports = {
+    UnsafeUrlError,
+    assertSafeUrl,
+    isPrivateOrReservedIp,
+};

--- a/backend/tests/integration/url.test.js
+++ b/backend/tests/integration/url.test.js
@@ -121,6 +121,37 @@ describe('URL Routes', () => {
             );
             expect(response.body.title).toBe(null);
         });
+
+        it('should block requests to the cloud metadata endpoint (SSRF)', async () => {
+            const response = await agent.get('/api/url/title').query({
+                url: 'http://169.254.169.254/latest/meta-data/iam/security-credentials/',
+            });
+
+            expect(response.status).toBe(200);
+            expect(response.body.title).toBe(null);
+            expect(response.body.error).toBe('Could not extract metadata');
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        it('should block requests to private/loopback IPs (SSRF)', async () => {
+            const response = await agent
+                .get('/api/url/title')
+                .query({ url: 'http://192.168.1.1:9000' });
+
+            expect(response.status).toBe(200);
+            expect(response.body.title).toBe(null);
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
+
+        it('should block requests to non-standard ports (SSRF)', async () => {
+            const response = await agent
+                .get('/api/url/title')
+                .query({ url: 'http://example.com:8080/' });
+
+            expect(response.status).toBe(200);
+            expect(response.body.title).toBe(null);
+            expect(global.fetch).not.toHaveBeenCalled();
+        });
     });
 
     describe('POST /api/url/extract-from-text', () => {

--- a/backend/tests/unit/modules/url/service.test.js
+++ b/backend/tests/unit/modules/url/service.test.js
@@ -1,0 +1,105 @@
+const dns = require('dns');
+const EventEmitter = require('events');
+
+jest.mock('http', () => ({ request: jest.fn() }));
+jest.mock('https', () => ({ request: jest.fn() }));
+
+const https = require('https');
+const urlService = require('../../../../modules/url/service');
+
+// Public IP - stands in for any hostname the tests use so DNS resolution
+// never depends on real network access.
+const PUBLIC_IP = '93.184.216.34';
+
+function mockHttpResponse(mod, { statusCode, headers = {}, body = '' }) {
+    mod.request.mockImplementationOnce((options, callback) => {
+        const res = new EventEmitter();
+        res.statusCode = statusCode;
+        res.headers = headers;
+        res.resume = jest.fn();
+        callback(res);
+        if (body) {
+            process.nextTick(() => res.emit('data', Buffer.from(body)));
+        }
+        process.nextTick(() => res.emit('end'));
+
+        const req = new EventEmitter();
+        req.end = jest.fn();
+        return req;
+    });
+}
+
+describe('UrlService SSRF protections', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.fetch = jest.fn();
+        jest.spyOn(dns.promises, 'lookup').mockResolvedValue([
+            { address: PUBLIC_IP, family: 4 },
+        ]);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        delete global.fetch;
+    });
+
+    it('does not follow a redirect that points at a private IP', async () => {
+        // Persists across all calls (fetch channel + proxy fallback) - never
+        // includes a request to the private target.
+        global.fetch.mockResolvedValue({
+            ok: false,
+            status: 302,
+            headers: {
+                get: (name) =>
+                    name.toLowerCase() === 'location'
+                        ? 'http://169.254.169.254/latest/meta-data/'
+                        : null,
+            },
+            text: async () => '',
+        });
+
+        mockHttpResponse(https, {
+            statusCode: 302,
+            headers: { location: 'http://169.254.169.254/latest/meta-data/' },
+        });
+
+        const result = await urlService.getTitle('https://example.com/');
+
+        // None of the requests actually made (fetch channel, proxy
+        // fallback) ever target the malicious redirect destination.
+        const requestedUrls = global.fetch.mock.calls.map((call) => call[0]);
+        expect(
+            requestedUrls.every((url) => !url.includes('169.254.169.254'))
+        ).toBe(true);
+        // The raw http/https fallback also refuses to follow the redirect -
+        // it only ever issues the initial request.
+        expect(https.request).toHaveBeenCalledTimes(1);
+        expect(result.title).toBe(null);
+    });
+
+    it('follows a redirect to a public host and extracts its metadata', async () => {
+        global.fetch.mockResolvedValueOnce({
+            ok: false,
+            status: 302,
+            headers: {
+                get: (name) =>
+                    name.toLowerCase() === 'location'
+                        ? 'https://example.com/landing'
+                        : null,
+            },
+            text: async () => '',
+        });
+        global.fetch.mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            headers: { get: () => 'text/html' },
+            text: async () =>
+                '<html><head><title>Landing Page</title></head></html>',
+        });
+
+        const result = await urlService.getTitle('https://example.com/');
+
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(result.title).toBe('Landing Page');
+    });
+});

--- a/backend/tests/unit/modules/url/ssrfGuard.test.js
+++ b/backend/tests/unit/modules/url/ssrfGuard.test.js
@@ -1,0 +1,113 @@
+const dns = require('dns');
+const {
+    assertSafeUrl,
+    isPrivateOrReservedIp,
+    UnsafeUrlError,
+} = require('../../../../modules/url/ssrfGuard');
+
+describe('ssrfGuard', () => {
+    describe('isPrivateOrReservedIp', () => {
+        it.each([
+            ['127.0.0.1', true],
+            ['127.5.5.5', true],
+            ['10.0.0.1', true],
+            ['172.16.0.1', true],
+            ['172.31.255.255', true],
+            ['192.168.1.1', true],
+            ['169.254.169.254', true], // cloud metadata endpoint
+            ['0.0.0.0', true],
+            ['100.64.0.1', true], // CGNAT
+            ['224.0.0.1', true], // multicast
+            ['240.0.0.1', true], // reserved
+            ['8.8.8.8', false],
+            ['1.1.1.1', false],
+            ['93.184.216.34', false],
+        ])('treats IPv4 %s as private=%s', (ip, expected) => {
+            expect(isPrivateOrReservedIp(ip)).toBe(expected);
+        });
+
+        it.each([
+            ['::1', true],
+            ['fc00::1', true],
+            ['fd12:3456:789a::1', true],
+            ['fe80::1', true],
+            ['::ffff:127.0.0.1', true],
+            ['::ffff:169.254.169.254', true],
+            ['2001:4860:4860::8888', false],
+        ])('treats IPv6 %s as private=%s', (ip, expected) => {
+            expect(isPrivateOrReservedIp(ip)).toBe(expected);
+        });
+    });
+
+    describe('assertSafeUrl', () => {
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('rejects non-http(s) protocols', async () => {
+            await expect(assertSafeUrl('file:///etc/passwd')).rejects.toThrow(
+                UnsafeUrlError
+            );
+        });
+
+        it('rejects non-standard ports', async () => {
+            await expect(
+                assertSafeUrl('http://example.com:8080/')
+            ).rejects.toThrow(UnsafeUrlError);
+        });
+
+        it('rejects IP-literal URLs pointing at private ranges', async () => {
+            await expect(assertSafeUrl('http://192.168.1.1/')).rejects.toThrow(
+                UnsafeUrlError
+            );
+        });
+
+        it('rejects the cloud metadata endpoint', async () => {
+            await expect(
+                assertSafeUrl('http://169.254.169.254/latest/meta-data/')
+            ).rejects.toThrow(UnsafeUrlError);
+        });
+
+        it('rejects loopback URLs', async () => {
+            await expect(assertSafeUrl('http://127.0.0.1:80/')).rejects.toThrow(
+                UnsafeUrlError
+            );
+        });
+
+        it('rejects hostnames that resolve to a private address', async () => {
+            jest.spyOn(dns.promises, 'lookup').mockResolvedValue([
+                { address: '10.0.0.5', family: 4 },
+            ]);
+
+            await expect(
+                assertSafeUrl('http://internal.example.com/')
+            ).rejects.toThrow(UnsafeUrlError);
+        });
+
+        it('rejects hostnames that fail to resolve', async () => {
+            jest.spyOn(dns.promises, 'lookup').mockRejectedValue(
+                new Error('ENOTFOUND')
+            );
+
+            await expect(
+                assertSafeUrl('http://does-not-exist.example.com/')
+            ).rejects.toThrow(UnsafeUrlError);
+        });
+
+        it('allows hostnames that resolve to a public address', async () => {
+            jest.spyOn(dns.promises, 'lookup').mockResolvedValue([
+                { address: '93.184.216.34', family: 4 },
+            ]);
+
+            await expect(
+                assertSafeUrl('https://example.com/')
+            ).resolves.toBeInstanceOf(URL);
+        });
+
+        it('allows default https port on a public IP literal', async () => {
+            await expect(
+                assertSafeUrl('https://1.1.1.1/')
+            ).resolves.toBeInstanceOf(URL);
+        });
+    });
+});


### PR DESCRIPTION
## Description

Fixes a Server-Side Request Forgery (SSRF) vulnerability in the URL metadata fetching endpoints (`GET /api/url/title` and `POST /api/url/extract-from-text`), reported as [GHSA-grv4-pc37-cvw9](https://github.com/chrisvel/tududi/security/advisories/GHSA-grv4-pc37-cvw9).

Both endpoints accept a user-supplied URL and fetch it server-side (across three fallback channels: `fetch`, raw `http`/`https`, and a third-party proxy) to extract Open Graph metadata for link previews. There was no restriction on target host, port, or protocol, and redirects were followed automatically without re-validating each hop. An authenticated user could point the server at an internal/private address, including cloud metadata endpoints (`169.254.169.254`), and read the response content back through the `title`/`description` fields.

**Fix:** added a `ssrfGuard` module that:
- only allows `http`/`https` protocols and standard ports (80/443)
- resolves the target hostname and rejects private/loopback/link-local/reserved IP ranges (RFC 1918, RFC 5737, link-local, CGNAT, IPv4-mapped IPv6, etc.), for both IPv4 and IPv6
- is enforced before the initial request, and re-checked on **every redirect hop** in both the `fetch`-based channel (switched from `redirect: 'follow'` to manual redirect handling) and the raw `http`/`https` fallback channel, closing the redirect-based bypass described in the advisory

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Addresses GHSA-grv4-pc37-cvw9 (private security advisory, no public issue number).

## Testing

**How did you test this?**

Added unit and integration tests covering: direct requests to the cloud metadata endpoint, private/loopback IPs, non-standard ports, DNS resolution to a private address, and a redirect chain into a private IP (verifying it's never requested on either the `fetch` or raw `http`/`https` channel). Also verified existing URL-title/extract-from-text tests still pass unmodified.

**Commands run:**

- [x] `npm run pre-push` (linting + formatting + tests)
- [ ] Tested manually in browser
- [ ] Tested on mobile (if UI changes)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Code follows project style guidelines
- [x] Self-reviewed my own code
- [x] Added/updated tests (if applicable)
- [ ] Updated documentation (if needed)
- [ ] Database migrations included and tested (if applicable)
- [ ] Translation keys added and synced (if applicable)