### PR TITLE
fix(security): enforce per-resource access control on uploads static route (GHSA-49fc-pf7x-cj8x)

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -211,15 +211,25 @@ if (serveFromDist) {
 
 // Authentication middleware
 const { requireAuth } = require('./middleware/auth');
+const { uploadsAccessControl } = require('./middleware/uploadsAccess');
 
 // Serve uploaded files - requires authentication so attachments (which may
 // include private task/project data) aren't readable by anyone who guesses
-// or obtains a URL (GHSA-x24w-9w59-wqhq).
+// or obtains a URL (GHSA-x24w-9w59-wqhq), and requires the requesting user
+// to have read access to the specific task/project the file belongs to, so
+// one authenticated user can't read another user's files by guessing a
+// filename (GHSA-49fc-pf7x-cj8x). nosniff stops the browser from ignoring
+// the declared Content-Type and guessing a different one to render.
 const registerUploadsStatic = (basePath) => {
     app.use(
         `${basePath}/uploads`,
         requireAuth,
-        express.static(config.uploadPath)
+        uploadsAccessControl,
+        express.static(config.uploadPath, {
+            setHeaders: (res) => {
+                res.setHeader('X-Content-Type-Options', 'nosniff');
+            },
+        })
     );
 };
 

--- a/backend/middleware/uploadsAccess.js
+++ b/backend/middleware/uploadsAccess.js
@@ -1,0 +1,73 @@
+const { TaskAttachment, Task, Project } = require('../models');
+const permissionsService = require('../services/permissionsService');
+const { getAuthenticatedUserId } = require('../utils/request-utils');
+
+const LEVELS = { none: 0, ro: 1, rw: 2, admin: 3 };
+
+// Categories that are intentionally readable by any authenticated user once
+// requireAuth has run, because they aren't scoped to a single task/project
+// (e.g. avatars are shown to any collaborator across shared projects).
+const PUBLIC_TO_AUTHENTICATED_USERS = new Set(['avatars']);
+
+const hasReadAccess = async (userId, resourceType, resourceUid) => {
+    const access = await permissionsService.getAccess(
+        userId,
+        resourceType,
+        resourceUid
+    );
+    return LEVELS[access] >= LEVELS.ro;
+};
+
+const canAccessTaskFile = async (userId, filename) => {
+    const attachment = await TaskAttachment.findOne({
+        where: { stored_filename: filename },
+        include: [{ model: Task, required: true }],
+    });
+    if (!attachment) return false;
+    return hasReadAccess(userId, 'task', attachment.Task.uid);
+};
+
+const canAccessProjectFile = async (userId, filename) => {
+    const project = await Project.findOne({
+        where: { image_url: `/api/uploads/projects/${filename}` },
+        attributes: ['uid'],
+    });
+    if (!project) return false;
+    return hasReadAccess(userId, 'project', project.uid);
+};
+
+// Uploaded files (task attachments, project images) may belong to a
+// different user than the one making the request. Being logged in is not
+// enough to read them - access must be scoped to the resource the file
+// belongs to, matching the checks the /attachments/:uid/download endpoint
+// already performs (GHSA-49fc-pf7x-cj8x).
+const uploadsAccessControl = async (req, res, next) => {
+    try {
+        const userId = getAuthenticatedUserId(req);
+        const segments = req.path.split('/').filter(Boolean);
+        const [category, filename] = segments;
+
+        if (PUBLIC_TO_AUTHENTICATED_USERS.has(category)) {
+            return next();
+        }
+
+        let allowed = false;
+        if (category === 'tasks' && filename) {
+            allowed = await canAccessTaskFile(userId, filename);
+        } else if (category === 'projects' && filename) {
+            allowed = await canAccessProjectFile(userId, filename);
+        }
+
+        if (!allowed) {
+            return res
+                .status(403)
+                .json({ error: 'Not authorized to access this file' });
+        }
+
+        return next();
+    } catch (error) {
+        return next(error);
+    }
+};
+
+module.exports = { uploadsAccessControl };

--- a/backend/tests/integration/uploads-static.test.js
+++ b/backend/tests/integration/uploads-static.test.js
@@ -1,0 +1,215 @@
+const request = require('supertest');
+const app = require('../../app');
+const path = require('path');
+const fs = require('fs').promises;
+const { Task, TaskAttachment, Project } = require('../../models');
+const { createTestUser } = require('../helpers/testUtils');
+
+describe('GET /api/uploads/:category/:filename', () => {
+    const uploadsDir = path.join(__dirname, '../../uploads');
+
+    let owner, ownerAgent, task;
+
+    beforeEach(async () => {
+        owner = await createTestUser({
+            email: `uploads-owner_${Date.now()}@test.com`,
+        });
+
+        ownerAgent = request.agent(app);
+        await ownerAgent
+            .post('/api/login')
+            .send({ email: owner.email, password: 'password123' });
+
+        task = await Task.create({
+            name: 'Task with a private attachment',
+            user_id: owner.id,
+        });
+    });
+
+    describe('task attachments', () => {
+        const taskUploadDir = path.join(uploadsDir, 'tasks');
+        let attachment;
+
+        beforeEach(async () => {
+            await fs.mkdir(taskUploadDir, { recursive: true });
+            await fs.writeFile(
+                path.join(taskUploadDir, 'task-static-test.pdf'),
+                'private file content'
+            );
+
+            attachment = await TaskAttachment.create({
+                task_id: task.id,
+                user_id: owner.id,
+                original_filename: 'private.pdf',
+                stored_filename: 'task-static-test.pdf',
+                file_size: 1024,
+                mime_type: 'application/pdf',
+                file_path: 'tasks/task-static-test.pdf',
+            });
+        });
+
+        afterEach(async () => {
+            await fs.rm(taskUploadDir, { recursive: true, force: true });
+        });
+
+        it('should require authentication', async () => {
+            const response = await request(app).get(
+                `/api/uploads/tasks/${attachment.stored_filename}`
+            );
+
+            expect(response.status).toBe(401);
+        });
+
+        it('should allow the owner to fetch their own attachment', async () => {
+            const response = await ownerAgent.get(
+                `/api/uploads/tasks/${attachment.stored_filename}`
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.headers['x-content-type-options']).toBe('nosniff');
+        });
+
+        it("should allow a user shared on the task's project to fetch the attachment", async () => {
+            // Tasks don't support direct sharing - they inherit access from
+            // their parent project, so re-parent the task under a shared project.
+            const project = await Project.create({
+                name: 'Project for shared task attachment',
+                user_id: owner.id,
+            });
+            await task.update({ project_id: project.id });
+
+            const sharedUser = await createTestUser({
+                email: `uploads-shared_${Date.now()}@test.com`,
+            });
+            const sharedAgent = request.agent(app);
+            await sharedAgent
+                .post('/api/login')
+                .send({ email: sharedUser.email, password: 'password123' });
+
+            await ownerAgent.post('/api/shares').send({
+                resource_type: 'project',
+                resource_uid: project.uid,
+                target_user_email: sharedUser.email,
+                access_level: 'ro',
+            });
+
+            const response = await sharedAgent.get(
+                `/api/uploads/tasks/${attachment.stored_filename}`
+            );
+
+            expect(response.status).toBe(200);
+        });
+
+        it('should reject an authenticated user with no access to the task (GHSA-49fc-pf7x-cj8x)', async () => {
+            const otherUser = await createTestUser({
+                email: `uploads-other_${Date.now()}@test.com`,
+            });
+            const otherAgent = request.agent(app);
+            await otherAgent
+                .post('/api/login')
+                .send({ email: otherUser.email, password: 'password123' });
+
+            const response = await otherAgent.get(
+                `/api/uploads/tasks/${attachment.stored_filename}`
+            );
+
+            expect(response.status).toBe(403);
+        });
+
+        it('should reject a request for a filename with no matching attachment record', async () => {
+            const response = await ownerAgent.get(
+                '/api/uploads/tasks/does-not-exist.pdf'
+            );
+
+            expect(response.status).toBe(403);
+        });
+    });
+
+    describe('project images', () => {
+        const projectUploadDir = path.join(uploadsDir, 'projects');
+
+        beforeEach(async () => {
+            await fs.mkdir(projectUploadDir, { recursive: true });
+            await fs.writeFile(
+                path.join(projectUploadDir, 'project-static-test.png'),
+                'private banner content'
+            );
+
+            await Project.create({
+                name: 'Project with a private banner',
+                user_id: owner.id,
+                image_url: '/api/uploads/projects/project-static-test.png',
+            });
+        });
+
+        afterEach(async () => {
+            await fs.rm(projectUploadDir, { recursive: true, force: true });
+        });
+
+        it('should allow the owner to fetch their project image', async () => {
+            const response = await ownerAgent.get(
+                '/api/uploads/projects/project-static-test.png'
+            );
+
+            expect(response.status).toBe(200);
+        });
+
+        it('should reject a user with no access to the project', async () => {
+            const otherUser = await createTestUser({
+                email: `uploads-other-proj_${Date.now()}@test.com`,
+            });
+            const otherAgent = request.agent(app);
+            await otherAgent
+                .post('/api/login')
+                .send({ email: otherUser.email, password: 'password123' });
+
+            const response = await otherAgent.get(
+                '/api/uploads/projects/project-static-test.png'
+            );
+
+            expect(response.status).toBe(403);
+        });
+    });
+
+    describe('avatars', () => {
+        const avatarUploadDir = path.join(uploadsDir, 'avatars');
+
+        beforeEach(async () => {
+            await fs.mkdir(avatarUploadDir, { recursive: true });
+            await fs.writeFile(
+                path.join(avatarUploadDir, 'avatar-static-test.png'),
+                'avatar content'
+            );
+        });
+
+        afterEach(async () => {
+            await fs.rm(avatarUploadDir, { recursive: true, force: true });
+        });
+
+        it('should allow any authenticated user to fetch an avatar', async () => {
+            const otherUser = await createTestUser({
+                email: `uploads-other-avatar_${Date.now()}@test.com`,
+            });
+            const otherAgent = request.agent(app);
+            await otherAgent
+                .post('/api/login')
+                .send({ email: otherUser.email, password: 'password123' });
+
+            const response = await otherAgent.get(
+                '/api/uploads/avatars/avatar-static-test.png'
+            );
+
+            expect(response.status).toBe(200);
+        });
+    });
+
+    describe('unrecognized categories', () => {
+        it('should deny by default for a category with no permission mapping', async () => {
+            const response = await ownerAgent.get(
+                '/api/uploads/something-unexpected/file.txt'
+            );
+
+            expect(response.status).toBe(403);
+        });
+    });
+});


### PR DESCRIPTION
## Description

`/api/uploads` (used to serve task attachments, project images, and avatars) only checked that the requester was logged in, not that they actually had access to the specific task or project the file belongs to. Any authenticated user who obtained or guessed an uploaded file's URL (e.g. `/api/uploads/tasks/task-<timestamp>-<random>.pdf`) could read another user's private task attachments or project images.

This adds `uploadsAccessControl` middleware that maps a requested file back to its owning task or project and runs it through the same `permissionsService.getAccess()` read check the authenticated `/attachments/:uid/download` endpoint already uses. Avatars stay readable by any authenticated user, since they're intentionally shown across the app to collaborators on shared projects. Unrecognized subpaths are denied by default. Also sets `X-Content-Type-Options: nosniff` on served uploads as defense in depth.

The SVG stored-XSS part of this advisory (CWE-79) was already fixed by GHSA-x24w-9w59-wqhq (SVG removed from the attachment allow-list). This PR closes the remaining CWE-306 unauthorized-access gap.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes GHSA-49fc-pf7x-cj8x

## Testing

**How did you test this?**

- Added `backend/tests/integration/uploads-static.test.js`: owner can fetch own task attachment/project image, a user shared on the parent project can fetch a task attachment, an unrelated authenticated user gets 403 for task attachments and project images, any authenticated user can fetch avatars, unrecognized categories are denied by default.
- Ran the full backend suite (1716 tests) and the full lint suite; both pass clean.
- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
