### PR TITLE
fix(security): close IPv6-literal SSRF guard bypass (GHSA-h72v-w7gx-hq4h)

### DIFF
--- a/backend/modules/url/ssrfGuard.js
+++ b/backend/modules/url/ssrfGuard.js
@@ -52,6 +52,63 @@ function isPrivateIpv4(ip) {
     return PRIVATE_IPV4_RANGES.some((cidr) => isIpv4InCidr(ip, cidr));
 }
 
+// Expands a colon-separated IPv6 address (with optional "::" compression)
+// into its 8 constituent 16-bit groups, or null if malformed.
+function expandIpv6Groups(address) {
+    const parts = address.split('::');
+    if (parts.length > 2) {
+        return null;
+    }
+
+    const parseGroups = (segment) => (segment === '' ? [] : segment.split(':'));
+
+    if (parts.length === 1) {
+        const groups = parseGroups(parts[0]);
+        return groups.length === 8 ? groups.map((g) => parseInt(g, 16)) : null;
+    }
+
+    const head = parseGroups(parts[0]);
+    const tail = parseGroups(parts[1]);
+    const missing = 8 - head.length - tail.length;
+    if (missing < 0) {
+        return null;
+    }
+    return [...head, ...Array(missing).fill('0'), ...tail].map((g) =>
+        parseInt(g, 16)
+    );
+}
+
+// Pulls the embedded IPv4 address out of an IPv4-mapped IPv6 address
+// (::ffff:a.b.c.d), whichever textual form it's written in. The WHATWG URL
+// parser normalizes these to pure hex groups (::ffff:127.0.0.1 becomes
+// ::ffff:7f00:1) rather than keeping the dotted form, so both must be
+// checked or that normalized form slips past the guard undetected.
+function extractEmbeddedIpv4(normalized) {
+    const dottedMatch = normalized.match(
+        /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/
+    );
+    if (dottedMatch) {
+        return dottedMatch[1];
+    }
+
+    const groups = expandIpv6Groups(normalized);
+    if (!groups || groups[5] !== 0xffff) {
+        return null;
+    }
+    if ([0, 1, 2, 3, 4].some((i) => groups[i] !== 0)) {
+        return null;
+    }
+
+    const high = groups[6];
+    const low = groups[7];
+    return [
+        (high >> 8) & 0xff,
+        high & 0xff,
+        (low >> 8) & 0xff,
+        low & 0xff,
+    ].join('.');
+}
+
 function isPrivateIpv6(ip) {
     const normalized = ip.toLowerCase();
 
@@ -59,12 +116,19 @@ function isPrivateIpv6(ip) {
         return true;
     }
 
-    // IPv4-mapped addresses (::ffff:127.0.0.1) - validate the embedded IPv4
-    const mappedMatch = normalized.match(
-        /^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/
-    );
-    if (mappedMatch) {
-        return isPrivateIpv4(mappedMatch[1]);
+    const embeddedIpv4 = extractEmbeddedIpv4(normalized);
+    if (embeddedIpv4) {
+        return isPrivateIpv4(embeddedIpv4);
+    }
+
+    // Deprecated "IPv4-compatible" addresses (the ::/96 range, written
+    // ::a.b.c.d - e.g. ::127.0.0.1 normalizes to ::7f00:1) carry no ffff
+    // marker to key off, unlike the mapped form above. The whole range is
+    // non-routable regardless of the embedded value, so block it outright
+    // rather than trying to special-case a "public-looking" embedded IPv4.
+    const groups = expandIpv6Groups(normalized);
+    if (groups && [0, 1, 2, 3, 4, 5].every((i) => groups[i] === 0)) {
+        return true;
     }
 
     // Unique local addresses fc00::/7
@@ -92,11 +156,19 @@ function isPrivateOrReservedIp(ip) {
 }
 
 async function assertPublicHostname(hostname) {
+    // URL.hostname wraps IPv6 literals in brackets (e.g. "[::1]"), which
+    // net.isIP() does not recognize - strip them before checking, otherwise
+    // the literal falls through to the DNS-lookup branch below.
+    const bareHostname =
+        hostname.startsWith('[') && hostname.endsWith(']')
+            ? hostname.slice(1, -1)
+            : hostname;
+
     // IP literal - no DNS resolution needed, and nothing to rebind.
-    if (net.isIP(hostname)) {
-        if (isPrivateOrReservedIp(hostname)) {
+    if (net.isIP(bareHostname)) {
+        if (isPrivateOrReservedIp(bareHostname)) {
             throw new UnsafeUrlError(
-                `Refusing to fetch private/reserved address: ${hostname}`
+                `Refusing to fetch private/reserved address: ${bareHostname}`
             );
         }
         return;

--- a/backend/tests/unit/modules/url/ssrfGuard.test.js
+++ b/backend/tests/unit/modules/url/ssrfGuard.test.js
@@ -33,6 +33,14 @@ describe('ssrfGuard', () => {
             ['fe80::1', true],
             ['::ffff:127.0.0.1', true],
             ['::ffff:169.254.169.254', true],
+            // Hex-group form the WHATWG URL parser normalizes mapped
+            // addresses to (::ffff:127.0.0.1 -> ::ffff:7f00:1), rather than
+            // keeping the dotted form.
+            ['::ffff:7f00:1', true],
+            ['::ffff:a9fe:a9fe', true],
+            // Deprecated IPv4-compatible form (::/96), e.g. ::127.0.0.1 ->
+            // ::7f00:1.
+            ['::7f00:1', true],
             ['2001:4860:4860::8888', false],
         ])('treats IPv6 %s as private=%s', (ip, expected) => {
             expect(isPrivateOrReservedIp(ip)).toBe(expected);
@@ -108,6 +116,49 @@ describe('ssrfGuard', () => {
             await expect(
                 assertSafeUrl('https://1.1.1.1/')
             ).resolves.toBeInstanceOf(URL);
+        });
+
+        // GHSA-h72v-w7gx-hq4h: decimal/hex/octal IPv4 literals resolve to
+        // loopback but aren't written in dotted-quad form, and bracketed
+        // IPv6 literals normalize in ways the guard previously didn't
+        // recognize as private.
+        describe('GHSA-h72v-w7gx-hq4h encoded-IP bypasses', () => {
+            it.each([
+                ['http://2130706433/', 'decimal-encoded loopback'],
+                ['http://0x7f000001/', 'hex-encoded loopback'],
+                ['http://017700000001/', 'octal-encoded loopback'],
+                ['http://127.1/', 'shorthand loopback'],
+                ['http://0177.0.0.1/', 'octal-first-octet loopback'],
+                ['http://2852039166/', 'decimal-encoded metadata endpoint'],
+            ])('rejects %s (%s)', async (url) => {
+                await expect(assertSafeUrl(url)).rejects.toThrow(
+                    UnsafeUrlError
+                );
+            });
+
+            it.each([
+                ['http://[::ffff:127.0.0.1]/', 'IPv4-mapped loopback'],
+                [
+                    'http://[::ffff:169.254.169.254]/',
+                    'IPv4-mapped metadata endpoint',
+                ],
+                [
+                    'http://[::127.0.0.1]/',
+                    'deprecated IPv4-compatible loopback',
+                ],
+                ['http://[fd00::1]/', 'unique-local literal'],
+                ['http://[::1]/', 'bracketed IPv6 loopback literal'],
+            ])('rejects %s (%s)', async (url) => {
+                await expect(assertSafeUrl(url)).rejects.toThrow(
+                    UnsafeUrlError
+                );
+            });
+
+            it('still allows a bracketed public IPv6 literal', async () => {
+                await expect(
+                    assertSafeUrl('http://[2001:4860:4860::8888]/')
+                ).resolves.toBeInstanceOf(URL);
+            });
         });
     });
 });


### PR DESCRIPTION
## Description

The SSRF guard added in #1404 (GHSA-grv4-pc37-cvw9) already normalizes decimal, hex, and octal-encoded IPv4 literals via the WHATWG URL parser before it ever sees them, so those specific bypasses in this report no longer reproduce on `main`. Verifying the report against current `main` did surface a real, related gap in the same guard's IPv6 handling though:

- `URL.hostname` wraps IPv6 literals in brackets (`[::1]`), which `net.isIP()` doesn't recognize. Bracketed literals fell through to the DNS-lookup branch instead of being checked directly. That branch happens to fail closed today (`dns.lookup` can't resolve a bracketed string), so it wasn't exploitable as-is, but it silently blocked every legitimate public IPv6 URL as a side effect.
- The IPv4-mapped-address regex only matched the dotted textual form (`::ffff:127.0.0.1`). The URL parser actually normalizes these to pure hex groups (`::ffff:7f00:1`), and the deprecated IPv4-compatible `::/96` form (`::127.0.0.1` → `::7f00:1`) wasn't handled at all. Fixing the bracket-stripping above without also fixing this would have turned the fail-closed bug into a real bypass (`http://[::ffff:127.0.0.1]/` reaching loopback).

This PR strips brackets before the `net.isIP()` check and expands IPv6 addresses into their 16-bit groups to detect an embedded IPv4 address regardless of which textual form it's written in, closing both gaps. Public IPv6 literals (e.g. `http://[2001:4860:4860::8888]/`) are now correctly allowed through again.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Addresses https://github.com/chrisvel/tududi/security/advisories/GHSA-h72v-w7gx-hq4h

## Testing

**How did you test this?**

- Manually verified `assertSafeUrl` against decimal/hex/octal IPv4 literals and every IPv6-literal bypass form (mapped, deprecated-compatible, bracketed loopback/unique-local/link-local) before and after the fix
- Added regression tests in `backend/tests/unit/modules/url/ssrfGuard.test.js` covering all of the above, plus a case confirming a public IPv6 literal is still allowed
- `npm run pre-push` passes
- Full backend suite (`npm test`): 116 suites, 1766 tests passing

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
