### PR TITLE
fix(security): force download disposition on uploads, clean up attachments on task delete (GHSA-43p8-ch4p-gqg4)

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -212,6 +212,7 @@ if (serveFromDist) {
 // Authentication middleware
 const { requireAuth } = require('./middleware/auth');
 const { uploadsAccessControl } = require('./middleware/uploadsAccess');
+const { INLINE_SAFE_EXTENSIONS } = require('./utils/attachment-utils');
 
 // Serve uploaded files - requires authentication so attachments (which may
 // include private task/project data) aren't readable by anyone who guesses
@@ -220,14 +221,23 @@ const { uploadsAccessControl } = require('./middleware/uploadsAccess');
 // one authenticated user can't read another user's files by guessing a
 // filename (GHSA-49fc-pf7x-cj8x). nosniff stops the browser from ignoring
 // the declared Content-Type and guessing a different one to render.
+// Files whose extension isn't in the inline-safe allowlist are forced to
+// download rather than render, so a browser navigating directly to a file
+// can't execute it as a top-level document - this covers any file whose
+// extension predates a MIME allow-list change, regardless of what the DB
+// thinks its type is (GHSA-43p8-ch4p-gqg4).
 const registerUploadsStatic = (basePath) => {
     app.use(
         `${basePath}/uploads`,
         requireAuth,
         uploadsAccessControl,
         express.static(config.uploadPath, {
-            setHeaders: (res) => {
+            setHeaders: (res, filePath) => {
                 res.setHeader('X-Content-Type-Options', 'nosniff');
+                const ext = path.extname(filePath).toLowerCase();
+                if (!INLINE_SAFE_EXTENSIONS.has(ext)) {
+                    res.setHeader('Content-Disposition', 'attachment');
+                }
             },
         })
     );

--- a/backend/modules/projects/repository.js
+++ b/backend/modules/projects/repository.js
@@ -15,7 +15,10 @@ const {
     sequelize,
 } = require('../../models');
 const { Op } = require('sequelize');
-const { deleteFileFromDisk } = require('../../utils/attachment-utils');
+const {
+    deleteFileFromDisk,
+    deleteAttachmentFiles,
+} = require('../../utils/attachment-utils');
 const path = require('path');
 const { getConfig } = require('../../config/config');
 const { logError } = require('../../services/logService');
@@ -295,12 +298,8 @@ class ProjectsRepository extends BaseRepository {
                 // Helper function to delete attachments for a task
                 const deleteTaskAttachments = async (task) => {
                     if (task.Attachments && task.Attachments.length > 0) {
+                        await deleteAttachmentFiles(task.Attachments);
                         for (const attachment of task.Attachments) {
-                            const filePath = path.join(
-                                config.uploadPath,
-                                attachment.file_path
-                            );
-                            await deleteFileFromDisk(filePath);
                             await attachment.destroy({ transaction });
                         }
                     }

--- a/backend/modules/tasks/repository.js
+++ b/backend/modules/tasks/repository.js
@@ -1,4 +1,5 @@
-const { Task } = require('../../models');
+const { Task, TaskAttachment } = require('../../models');
+const { deleteAttachmentFiles } = require('../../utils/attachment-utils');
 
 class TaskRepository {
     constructor() {
@@ -62,10 +63,17 @@ class TaskRepository {
     }
 
     async delete(id, userId) {
-        const task = await this.findByIdAndUser(id, userId);
+        const task = await this.findByIdAndUser(id, userId, {
+            include: [{ model: TaskAttachment, as: 'Attachments' }],
+        });
         if (!task) {
             return null;
         }
+        // Unlink attachment files from disk before destroying rows, so a
+        // dangling file never outlives the record that gated its access
+        // (GHSA-43p8-ch4p-gqg4).
+        await deleteAttachmentFiles(task.Attachments);
+        await TaskAttachment.destroy({ where: { task_id: task.id } });
         await task.destroy();
         return task;
     }

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -8,11 +8,13 @@ const eventsRouter = require('./events');
 const {
     Task,
     TaskEvent,
+    TaskAttachment,
     RecurringCompletion,
     Project,
     sequelize,
 } = require('../../models');
 const taskRepository = require('./repository');
+const { deleteAttachmentFiles } = require('../../utils/attachment-utils');
 const {
     resetQueryCounter,
     getQueryStats,
@@ -918,7 +920,9 @@ router.patch('/task/:uid', requireTaskWriteAccess, async (req, res) => {
 
 router.delete('/task/:uid', requireTaskWriteAccess, async (req, res) => {
     try {
-        const task = await taskRepository.findByUid(req.params.uid);
+        const task = await taskRepository.findByUid(req.params.uid, {
+            include: [{ model: TaskAttachment, as: 'Attachments' }],
+        });
 
         if (!task) {
             return res.status(404).json({ error: 'Task not found.' });
@@ -984,6 +988,15 @@ router.delete('/task/:uid', requireTaskWriteAccess, async (req, res) => {
             });
 
             await taskRepository.clearRecurringParent(taskId);
+
+            // Unlink attachment files from disk before destroying rows, so a
+            // dangling file never outlives the record that gated its access
+            // (GHSA-43p8-ch4p-gqg4).
+            await deleteAttachmentFiles(task.Attachments);
+            await TaskAttachment.destroy({
+                where: { task_id: taskId },
+                force: true,
+            });
 
             await task.destroy({ force: true });
         } finally {

--- a/backend/tests/integration/tasks.test.js
+++ b/backend/tests/integration/tasks.test.js
@@ -1,7 +1,10 @@
 const request = require('supertest');
 const app = require('../../app');
-const { Task, User } = require('../../models');
+const path = require('path');
+const fs = require('fs').promises;
+const { Task, User, TaskAttachment } = require('../../models');
 const { createTestUser } = require('../helpers/testUtils');
+const { getConfig } = require('../../config/config');
 
 describe('Tasks Routes', () => {
     let user, agent;
@@ -287,6 +290,39 @@ describe('Tasks Routes', () => {
             expect(response.status).toBe(401);
             expect(response.body.error).toBe('Authentication required');
         });
+
+        it('should delete attachment files and rows along with the task (GHSA-43p8-ch4p-gqg4)', async () => {
+            const config = getConfig();
+            const taskUploadDir = path.join(config.uploadPath, 'tasks');
+            const storedFilename = `task-delete-test-${task.id}.pdf`;
+            const filePath = path.join(taskUploadDir, storedFilename);
+
+            await fs.mkdir(taskUploadDir, { recursive: true });
+            await fs.writeFile(filePath, 'attachment content');
+
+            const attachment = await TaskAttachment.create({
+                task_id: task.id,
+                user_id: user.id,
+                original_filename: 'attachment.pdf',
+                stored_filename: storedFilename,
+                file_size: 1024,
+                mime_type: 'application/pdf',
+                file_path: `tasks/${storedFilename}`,
+            });
+
+            try {
+                const response = await agent.delete(`/api/task/${task.uid}`);
+
+                expect(response.status).toBe(200);
+
+                await expect(fs.access(filePath)).rejects.toThrow();
+
+                const remaining = await TaskAttachment.findByPk(attachment.id);
+                expect(remaining).toBeNull();
+            } finally {
+                await fs.rm(filePath, { force: true });
+            }
+        }, 10000);
     });
 
     describe('Task with tags', () => {

--- a/backend/tests/integration/uploads-static.test.js
+++ b/backend/tests/integration/uploads-static.test.js
@@ -125,6 +125,116 @@ describe('GET /api/uploads/:category/:filename', () => {
         });
     });
 
+    describe('Content-Disposition (GHSA-43p8-ch4p-gqg4)', () => {
+        const taskUploadDir = path.join(uploadsDir, 'tasks');
+
+        afterEach(async () => {
+            await fs.rm(taskUploadDir, { recursive: true, force: true });
+        });
+
+        const createAttachment = async (
+            storedFilename,
+            mimeType,
+            content = 'file content'
+        ) => {
+            await fs.mkdir(taskUploadDir, { recursive: true });
+            await fs.writeFile(
+                path.join(taskUploadDir, storedFilename),
+                content
+            );
+
+            return TaskAttachment.create({
+                task_id: task.id,
+                user_id: owner.id,
+                original_filename: storedFilename,
+                stored_filename: storedFilename,
+                file_size: content.length,
+                mime_type: mimeType,
+                file_path: `tasks/${storedFilename}`,
+            });
+        };
+
+        it.each([
+            [
+                'docx-test.docx',
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            ],
+            ['txt-test.txt', 'text/plain'],
+            ['csv-test.csv', 'text/csv'],
+            ['zip-test.zip', 'application/zip'],
+            [
+                'xlsx-test.xlsx',
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            ],
+        ])(
+            'should force Content-Disposition: attachment for %s',
+            async (storedFilename, mimeType) => {
+                const attachment = await createAttachment(
+                    storedFilename,
+                    mimeType
+                );
+
+                const response = await ownerAgent.get(
+                    `/api/uploads/tasks/${attachment.stored_filename}`
+                );
+
+                expect(response.status).toBe(200);
+                expect(response.headers['content-disposition']).toBe(
+                    'attachment'
+                );
+            }
+        );
+
+        it('should not force Content-Disposition for a pdf attachment', async () => {
+            const attachment = await createAttachment(
+                'pdf-test.pdf',
+                'application/pdf'
+            );
+
+            const response = await ownerAgent.get(
+                `/api/uploads/tasks/${attachment.stored_filename}`
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.headers['content-disposition']).toBeUndefined();
+        });
+
+        it('should not force Content-Disposition for an image attachment', async () => {
+            const attachment = await createAttachment(
+                'png-test.png',
+                'image/png'
+            );
+
+            const response = await ownerAgent.get(
+                `/api/uploads/tasks/${attachment.stored_filename}`
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.headers['content-disposition']).toBeUndefined();
+        });
+
+        it('should force Content-Disposition: attachment for a legacy .svg file that predates the allow-list fix', async () => {
+            // SVG uploads are blocked at upload time (GHSA-x24w-9w59-wqhq),
+            // but a file uploaded before that fix could still be sitting on
+            // disk with its original .svg extension and DB record. This
+            // simulates that: the fix must hold regardless of what the DB
+            // mime_type says, since it's derived from the extension on disk.
+            const attachment = await createAttachment(
+                'legacy-test.svg',
+                'image/svg+xml',
+                '<svg xmlns="http://www.w3.org/2000/svg"><script>alert(document.domain)</script></svg>'
+            );
+
+            const response = await ownerAgent.get(
+                `/api/uploads/tasks/${attachment.stored_filename}`
+            );
+
+            expect(response.status).toBe(200);
+            expect(response.headers['content-disposition']).toBe('attachment');
+            expect(response.headers['x-content-type-options']).toBe('nosniff');
+        });
+    });
+
     describe('project images', () => {
         const projectUploadDir = path.join(uploadsDir, 'projects');
 

--- a/backend/utils/attachment-utils.js
+++ b/backend/utils/attachment-utils.js
@@ -34,6 +34,21 @@ const ALLOWED_TYPES = {
     'application/x-zip-compressed': ['.zip'],
 };
 
+// Extensions safe to render inline in the browser (used by <img>/<iframe>
+// previews in the app). Everything else served through /api/uploads gets
+// Content-Disposition: attachment so a browser can't execute it via direct
+// navigation. This is extension-based rather than DB-mimetype-based so it
+// also neutralizes any file whose extension predates the image/svg+xml
+// removal above (GHSA-43p8-ch4p-gqg4).
+const INLINE_SAFE_EXTENSIONS = new Set([
+    '.pdf',
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.gif',
+    '.webp',
+]);
+
 /**
  * Validate if file type is allowed
  */
@@ -112,6 +127,17 @@ async function deleteFileFromDisk(filepath) {
     }
 }
 
+// Delete the on-disk files for a set of TaskAttachment rows. Best-effort -
+// deleteFileFromDisk already logs and swallows per-file errors, so one bad
+// path doesn't abort the caller's larger deletion. Does not destroy the DB
+// rows; callers own that since transaction semantics differ per call site.
+async function deleteAttachmentFiles(attachments = []) {
+    for (const attachment of attachments) {
+        const filePath = path.join(config.uploadPath, attachment.file_path);
+        await deleteFileFromDisk(filePath);
+    }
+}
+
 /**
  * Ensure upload directory exists
  */
@@ -134,6 +160,7 @@ function getFileUrl(storedFilename) {
 
 module.exports = {
     ALLOWED_TYPES,
+    INLINE_SAFE_EXTENSIONS,
     validateFileType,
     getExtensionFromMimeType,
     formatFileSize,
@@ -141,6 +168,7 @@ module.exports = {
     isPdfFile,
     isTextFile,
     deleteFileFromDisk,
+    deleteAttachmentFiles,
     ensureUploadDir,
     getFileUrl,
 };


### PR DESCRIPTION
## Description

Closes two residual gaps flagged in GHSA-43p8-ch4p-gqg4 that survived the earlier SVG stored-XSS fix (GHSA-x24w-9w59-wqhq) and the uploads access-control fix (GHSA-49fc-pf7x-cj8x, #1406):

1. **No Content-Disposition on `/api/uploads`.** The static route served every file inline with no `Content-Disposition`, so a browser navigating directly to a file URL still executed it as a top-level document. This kept any attachment uploaded before the SVG allow-list fix (still sitting on disk with its original `.svg` extension and DB record) fully exploitable for anyone with read access to the owning task. The route now derives inline-vs-download from the file's actual extension on disk, not the DB-trusted `mime_type`, so the fix holds regardless of when a file was uploaded. Images and PDFs stay inline, matching the app's existing `<img>`/`<iframe>` preview behavior in `AttachmentPreview.tsx`; everything else is forced to download.

2. **Task deletion never cleaned up attachments.** Neither the on-disk files nor, in the primary REST delete route, the `TaskAttachment` DB rows were removed when a task was deleted (that route already disables FK enforcement around the same destroy call the way it does for `task_events`/`tasks_tags`, so the row-level cascade wasn't reliable either). Both single-task delete paths (`DELETE /task/:uid` and `TaskRepository.delete`, used by CalDAV) now load the task's attachments, unlink the files, and destroy the rows before destroying the task itself, mirroring the cleanup project deletion already did correctly. Bulk-destroy paths (admin user deletion, template deletion, CalDAV sync, subtask removal) are intentionally left for a follow-up since the Content-Disposition fix already makes anything they orphan non-executable when served.

Extracted the file-unlink loop from `projects/repository.js` into a shared `deleteAttachmentFiles()` helper in `attachment-utils.js` so all three call sites share one implementation.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes GHSA-43p8-ch4p-gqg4

## Testing

**How did you test this?**

- Added a `Content-Disposition` test suite to `uploads-static.test.js`: forced download for docx/txt/csv/zip/xlsx, no header for pdf/png, and a regression test that writes a raw `.svg` file with an embedded `<script>` directly to disk (simulating a pre-fix legacy attachment) and confirms it still gets `Content-Disposition: attachment`.
- Added a task-deletion test asserting the attachment file is removed from disk and the `TaskAttachment` row is gone after `DELETE /api/task/:id`.
- [x] `npm run pre-push` passes

## Screenshots

Not applicable (backend-only change).

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)

## Additional Notes

Out of scope for this PR, noted as deliberate follow-ups:
- Project-image/avatar uploads still derive their stored extension from the client-supplied filename rather than the validated MIME type (lower severity: svg is already blocked there by the existing regex filter).
- No bulk migration/rescan of existing on-disk attachments; the Content-Disposition fix neutralizes legacy files without needing to touch stored data.