### PR TITLE
feat: subscribe to external calendars via iCalendar URL

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -302,6 +302,7 @@ const aiAssistantModule = require('./modules/ai-assistant');
 const peopleModule = require('./modules/people');
 const templatesModule = require('./modules/templates');
 const reportsModule = require('./modules/reports');
+const subscribedCalendarsModule = require('./modules/subscribed-calendars');
 
 // Swagger documentation - enabled by default, protected by authentication
 // Mounted on /api-docs to avoid conflicts with API routes
@@ -389,6 +390,7 @@ const registerApiRoutes = (basePath) => {
     app.use(basePath, aiAssistantModule.routes);
     app.use(basePath, peopleModule.routes);
     app.use(basePath, templatesModule.routes);
+    app.use(basePath, subscribedCalendarsModule.routes);
     app.use(basePath, reportsModule.routes);
 };
 

--- a/backend/migrations/20260819000000-create-subscribed-calendars.js
+++ b/backend/migrations/20260819000000-create-subscribed-calendars.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const { safeCreateTable, safeAddIndex } = require('../utils/migration-utils');
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await safeCreateTable(queryInterface, 'subscribed_calendars', {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+                allowNull: false,
+            },
+            uid: {
+                type: Sequelize.STRING,
+                allowNull: false,
+                unique: true,
+            },
+            user_id: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'users',
+                    key: 'id',
+                },
+                onDelete: 'CASCADE',
+            },
+            name: {
+                type: Sequelize.STRING,
+                allowNull: false,
+            },
+            url: {
+                type: Sequelize.TEXT,
+                allowNull: false,
+            },
+            color: {
+                type: Sequelize.STRING,
+                allowNull: false,
+                defaultValue: '#6b7280',
+            },
+            last_error: {
+                type: Sequelize.TEXT,
+                allowNull: true,
+            },
+            created_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+            },
+            updated_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+            },
+        });
+
+        await safeAddIndex(queryInterface, 'subscribed_calendars', ['user_id']);
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable('subscribed_calendars');
+    },
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -100,6 +100,7 @@ const CalDAVOccurrenceOverride = require('./caldav_occurrence_override')(
 );
 const CalDAVRemoteCalendar = require('./caldav_remote_calendar')(sequelize);
 const CalendarToken = require('./calendar_token')(sequelize);
+const SubscribedCalendar = require('./subscribed_calendar')(sequelize);
 const Goal = require('./goal')(sequelize);
 const Person = require('./person')(sequelize);
 const UserProjectArea = require('./user_project_area')(sequelize);
@@ -297,6 +298,13 @@ User.hasMany(CalendarToken, {
 });
 CalendarToken.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
 
+// SubscribedCalendar associations
+User.hasMany(SubscribedCalendar, {
+    foreignKey: 'user_id',
+    as: 'SubscribedCalendars',
+});
+SubscribedCalendar.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
+
 // UserProjectArea associations (per-user area placement for shared projects)
 User.hasMany(UserProjectArea, {
     foreignKey: 'user_id',
@@ -470,6 +478,7 @@ module.exports = {
     CalDAVOccurrenceOverride,
     CalDAVRemoteCalendar,
     CalendarToken,
+    SubscribedCalendar,
     Person,
     UserProjectArea,
 };

--- a/backend/models/subscribed_calendar.js
+++ b/backend/models/subscribed_calendar.js
@@ -1,0 +1,73 @@
+const { DataTypes } = require('sequelize');
+const { uid } = require('../utils/uid');
+
+module.exports = (sequelize) => {
+    const SubscribedCalendar = sequelize.define(
+        'SubscribedCalendar',
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            uid: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                unique: true,
+                defaultValue: uid,
+            },
+            user_id: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                references: {
+                    model: 'users',
+                    key: 'id',
+                },
+            },
+            name: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                validate: {
+                    notEmpty: {
+                        msg: 'Calendar name is required',
+                    },
+                },
+            },
+            url: {
+                type: DataTypes.TEXT,
+                allowNull: false,
+                validate: {
+                    notEmpty: {
+                        msg: 'URL is required',
+                    },
+                },
+            },
+            color: {
+                type: DataTypes.STRING,
+                allowNull: false,
+                defaultValue: '#6b7280',
+            },
+            last_error: {
+                type: DataTypes.TEXT,
+                allowNull: true,
+            },
+        },
+        {
+            tableName: 'subscribed_calendars',
+            timestamps: true,
+            createdAt: 'created_at',
+            updatedAt: 'updated_at',
+            underscored: true,
+            indexes: [{ fields: ['user_id'] }],
+        }
+    );
+
+    SubscribedCalendar.associate = function (models) {
+        SubscribedCalendar.belongsTo(models.User, {
+            foreignKey: 'user_id',
+            as: 'user',
+        });
+    };
+
+    return SubscribedCalendar;
+};

--- a/backend/modules/subscribed-calendars/controller.js
+++ b/backend/modules/subscribed-calendars/controller.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const service = require('./service');
+
+const DEFAULT_WINDOW_DAYS = 60;
+
+function parseDate(value, fallback) {
+    if (!value) return fallback;
+    const date = new Date(value);
+    return isNaN(date.getTime()) ? null : date;
+}
+
+const subscribedCalendarsController = {
+    async getAll(req, res, next) {
+        try {
+            const calendars = await service.listCalendars(req.currentUser.id);
+            res.json(calendars);
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    async create(req, res, next) {
+        try {
+            const calendar = await service.createCalendar(
+                req.currentUser.id,
+                req.body
+            );
+            res.status(201).json(calendar);
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    async delete(req, res, next) {
+        try {
+            await service.deleteCalendar(req.currentUser.id, req.params.uid);
+            res.json({ success: true });
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    async getEvents(req, res, next) {
+        try {
+            const now = new Date();
+            const start = parseDate(req.query.start, now);
+            const end = parseDate(
+                req.query.end,
+                new Date(
+                    now.getTime() + DEFAULT_WINDOW_DAYS * 24 * 60 * 60 * 1000
+                )
+            );
+
+            if (!start || !end) {
+                return res
+                    .status(400)
+                    .json({ error: 'start and end must be valid dates' });
+            }
+            if (end < start) {
+                return res
+                    .status(400)
+                    .json({ error: 'end must be after start' });
+            }
+
+            const events = await service.getEvents(
+                req.currentUser.id,
+                start,
+                end
+            );
+            res.json({ events });
+        } catch (error) {
+            next(error);
+        }
+    },
+};
+
+module.exports = subscribedCalendarsController;

--- a/backend/modules/subscribed-calendars/ics.js
+++ b/backend/modules/subscribed-calendars/ics.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const ICAL = require('ical.js');
+
+// Guards against a malformed or hostile feed with an unbounded RRULE.
+const MAX_OCCURRENCES_PER_EVENT = 500;
+const MAX_EVENTS = 5000;
+
+function toEvent(details, calendarId) {
+    const start = details.startDate;
+    const end = details.endDate;
+    const base = {
+        id: `ics-${calendarId}-${details.item.uid}-${start.toUnixTime()}`,
+        title: details.item.summary || '(no title)',
+    };
+
+    if (start.isDate) {
+        // DTEND is exclusive for all-day events, so a single day event ends on
+        // the following day. Report the last day actually covered instead.
+        const lastDay = end.clone();
+        if (end.compare(start) > 0) {
+            lastDay.adjust(-1, 0, 0, 0);
+        }
+        return {
+            ...base,
+            start: start.toString(),
+            end: lastDay.toString(),
+            all_day: true,
+        };
+    }
+
+    return {
+        ...base,
+        start: start.toJSDate().toISOString(),
+        end: end.toJSDate().toISOString(),
+        all_day: false,
+    };
+}
+
+function expandRecurring(event, from, to, calendarId) {
+    const occurrences = [];
+    const iterator = event.iterator();
+    let count = 0;
+    let next;
+
+    while ((next = iterator.next())) {
+        if (++count > MAX_OCCURRENCES_PER_EVENT) break;
+
+        const details = event.getOccurrenceDetails(next);
+        if (details.startDate.toJSDate() > to) break;
+        if (details.endDate.toJSDate() < from) continue;
+
+        occurrences.push(toEvent(details, calendarId));
+    }
+
+    return occurrences;
+}
+
+// Returns the events of an iCalendar feed that overlap [from, to].
+function parseEvents(icsText, from, to, calendarId) {
+    const component = new ICAL.Component(ICAL.parse(icsText));
+    const vevents = component.getAllSubcomponents('vevent');
+
+    const series = new Map();
+    const overrides = [];
+
+    for (const vevent of vevents) {
+        const event = new ICAL.Event(vevent);
+        if (!event.startDate) continue;
+
+        if (event.isRecurrenceException()) {
+            overrides.push(event);
+        } else {
+            series.set(event.uid, event);
+        }
+    }
+
+    // A RECURRENCE-ID entry modifies one occurrence of its series. Without the
+    // parent it is just a standalone event.
+    for (const override of overrides) {
+        const parent = series.get(override.uid);
+        if (parent) {
+            parent.relateException(override);
+        } else {
+            series.set(`${override.uid}-${override.recurrenceId}`, override);
+        }
+    }
+
+    const events = [];
+    for (const event of series.values()) {
+        if (events.length >= MAX_EVENTS) break;
+
+        if (event.isRecurring()) {
+            events.push(...expandRecurring(event, from, to, calendarId));
+            continue;
+        }
+
+        const details = event.getOccurrenceDetails(event.startDate);
+        if (details.startDate.toJSDate() > to) continue;
+        if (details.endDate.toJSDate() < from) continue;
+        events.push(toEvent(details, calendarId));
+    }
+
+    return events.slice(0, MAX_EVENTS);
+}
+
+module.exports = { parseEvents };

--- a/backend/modules/subscribed-calendars/index.js
+++ b/backend/modules/subscribed-calendars/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const routes = require('./routes');
+
+module.exports = { routes };

--- a/backend/modules/subscribed-calendars/routes.js
+++ b/backend/modules/subscribed-calendars/routes.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const controller = require('./controller');
+
+router.get('/subscribed-calendars/events', controller.getEvents);
+router.get('/subscribed-calendars', controller.getAll);
+router.post('/subscribed-calendars', controller.create);
+router.delete('/subscribed-calendars/:uid', controller.delete);
+
+module.exports = router;

--- a/backend/modules/subscribed-calendars/service.js
+++ b/backend/modules/subscribed-calendars/service.js
@@ -1,0 +1,138 @@
+'use strict';
+
+const axios = require('axios');
+const { SubscribedCalendar } = require('../../models');
+const { NotFoundError, ValidationError } = require('../../shared/errors');
+const { parseEvents } = require('./ics');
+
+const CACHE_TTL_MS = 15 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 15000;
+const MAX_FEED_BYTES = 10 * 1024 * 1024;
+
+// calendar id -> { fetchedAt, body }
+const cache = new Map();
+
+// webcal:// is just https:// with a scheme that tells the OS to subscribe.
+function normalizeUrl(rawUrl) {
+    const url = String(rawUrl || '').trim();
+    if (/^webcal:\/\//i.test(url)) {
+        return `https://${url.slice('webcal://'.length)}`;
+    }
+    return url;
+}
+
+function assertFetchableUrl(url) {
+    let parsed;
+    try {
+        parsed = new URL(url);
+    } catch {
+        throw new ValidationError('URL must be a valid URL');
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        throw new ValidationError('URL must be http, https or webcal');
+    }
+}
+
+async function listCalendars(userId) {
+    return SubscribedCalendar.findAll({
+        where: { user_id: userId },
+        order: [['created_at', 'ASC']],
+    });
+}
+
+async function getCalendar(userId, uid) {
+    const calendar = await SubscribedCalendar.findOne({
+        where: { user_id: userId, uid },
+    });
+    if (!calendar) {
+        throw new NotFoundError('Subscribed calendar not found');
+    }
+    return calendar;
+}
+
+async function createCalendar(userId, attributes) {
+    const url = normalizeUrl(attributes.url);
+    assertFetchableUrl(url);
+
+    return SubscribedCalendar.create({
+        user_id: userId,
+        name: attributes.name,
+        url,
+        color: attributes.color || undefined,
+    });
+}
+
+async function deleteCalendar(userId, uid) {
+    const calendar = await getCalendar(userId, uid);
+    cache.delete(calendar.id);
+    await calendar.destroy();
+}
+
+async function fetchFeed(calendar) {
+    const cached = cache.get(calendar.id);
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+        return cached.body;
+    }
+
+    const response = await axios.get(calendar.url, {
+        timeout: REQUEST_TIMEOUT_MS,
+        maxContentLength: MAX_FEED_BYTES,
+        maxRedirects: 3,
+        responseType: 'text',
+        transformResponse: [(body) => body],
+        headers: { Accept: 'text/calendar, text/plain' },
+    });
+
+    const body = String(response.data || '');
+    cache.set(calendar.id, { fetchedAt: Date.now(), body });
+    return body;
+}
+
+// Never surfaces the upstream response body: a subscribed URL is user supplied,
+// so echoing what it returned would turn this into a fetch-anything proxy.
+function describeFailure(error) {
+    if (error.response) {
+        return `Request failed with status ${error.response.status}`;
+    }
+    if (error.code === 'ECONNABORTED') {
+        return 'Request timed out';
+    }
+    return 'Could not fetch calendar';
+}
+
+async function getEvents(userId, from, to) {
+    const calendars = await listCalendars(userId);
+    const events = [];
+
+    for (const calendar of calendars) {
+        try {
+            const body = await fetchFeed(calendar);
+            const parsed = parseEvents(body, from, to, calendar.id);
+
+            for (const event of parsed) {
+                events.push({
+                    ...event,
+                    calendar_uid: calendar.uid,
+                    calendar_name: calendar.name,
+                    color: calendar.color,
+                });
+            }
+
+            if (calendar.last_error) {
+                await calendar.update({ last_error: null });
+            }
+        } catch (error) {
+            cache.delete(calendar.id);
+            await calendar.update({ last_error: describeFailure(error) });
+        }
+    }
+
+    return events;
+}
+
+module.exports = {
+    listCalendars,
+    createCalendar,
+    deleteCalendar,
+    getEvents,
+};

--- a/backend/tests/unit/modules/subscribed-calendars/ics.test.js
+++ b/backend/tests/unit/modules/subscribed-calendars/ics.test.js
@@ -1,0 +1,158 @@
+const { parseEvents } = require('../../../../modules/subscribed-calendars/ics');
+
+const FROM = new Date('2026-08-01T00:00:00Z');
+const TO = new Date('2026-11-01T00:00:00Z');
+
+function buildCalendar(...vevents) {
+    return [
+        'BEGIN:VCALENDAR',
+        'VERSION:2.0',
+        'PRODID:-//tududi//test//EN',
+        ...vevents,
+        'END:VCALENDAR',
+    ].join('\r\n');
+}
+
+describe('subscribed calendars – ics parser', () => {
+    it('parses a timed event', () => {
+        const ics = buildCalendar(
+            'BEGIN:VEVENT',
+            'UID:timed',
+            'DTSTART:20260820T140000Z',
+            'DTEND:20260820T150000Z',
+            'SUMMARY:Sprint review',
+            'END:VEVENT'
+        );
+
+        const events = parseEvents(ics, FROM, TO, 1);
+
+        expect(events).toHaveLength(1);
+        expect(events[0].title).toBe('Sprint review');
+        expect(events[0].all_day).toBe(false);
+        expect(events[0].start).toBe('2026-08-20T14:00:00.000Z');
+    });
+
+    it('reports all-day events as dates, not timestamps', () => {
+        const ics = buildCalendar(
+            'BEGIN:VEVENT',
+            'UID:allday',
+            'DTSTART;VALUE=DATE:20260820',
+            'DTEND;VALUE=DATE:20260821',
+            'SUMMARY:Day off',
+            'END:VEVENT'
+        );
+
+        const events = parseEvents(ics, FROM, TO, 1);
+
+        expect(events[0].all_day).toBe(true);
+        // A timestamp here would shift the event a day in other timezones.
+        expect(events[0].start).toBe('2026-08-20');
+        expect(events[0].end).toBe('2026-08-20');
+    });
+
+    it('reports the inclusive last day of a multi-day all-day event', () => {
+        const ics = buildCalendar(
+            'BEGIN:VEVENT',
+            'UID:vacation',
+            'DTSTART;VALUE=DATE:20260901',
+            'DTEND;VALUE=DATE:20260906',
+            'SUMMARY:Vacation',
+            'END:VEVENT'
+        );
+
+        const events = parseEvents(ics, FROM, TO, 1);
+
+        // DTEND is exclusive in iCalendar; the last covered day is the 5th.
+        expect(events[0].start).toBe('2026-09-01');
+        expect(events[0].end).toBe('2026-09-05');
+    });
+
+    it('expands recurring events inside the window', () => {
+        const ics = buildCalendar(
+            'BEGIN:VEVENT',
+            'UID:monthly',
+            'DTSTART:20260801T090000Z',
+            'DTEND:20260801T093000Z',
+            'RRULE:FREQ=MONTHLY',
+            'SUMMARY:Monthly standup',
+            'END:VEVENT'
+        );
+
+        const events = parseEvents(ics, FROM, TO, 1);
+
+        expect(events).toHaveLength(3);
+        expect(events.map((event) => event.start.slice(0, 10))).toEqual([
+            '2026-08-01',
+            '2026-09-01',
+            '2026-10-01',
+        ]);
+    });
+
+    it('does not hang on an unbounded recurrence rule', () => {
+        const ics = buildCalendar(
+            'BEGIN:VEVENT',
+            'UID:daily',
+            'DTSTART:20260101T090000Z',
+            'DTEND:20260101T091000Z',
+            'RRULE:FREQ=DAILY',
+            'SUMMARY:Daily',
+            'END:VEVENT'
+        );
+
+        const events = parseEvents(ics, FROM, TO, 1);
+
+        expect(events.length).toBeGreaterThan(80);
+        expect(events.length).toBeLessThan(100);
+    });
+
+    it('skips events outside the window', () => {
+        const ics = buildCalendar(
+            'BEGIN:VEVENT',
+            'UID:old',
+            'DTSTART:20200101T090000Z',
+            'DTEND:20200101T093000Z',
+            'SUMMARY:Ancient history',
+            'END:VEVENT'
+        );
+
+        expect(parseEvents(ics, FROM, TO, 1)).toHaveLength(0);
+    });
+
+    it('applies a RECURRENCE-ID override to its series', () => {
+        const ics = buildCalendar(
+            'BEGIN:VEVENT',
+            'UID:series',
+            'DTSTART:20260803T090000Z',
+            'DTEND:20260803T093000Z',
+            'RRULE:FREQ=WEEKLY;COUNT=3',
+            'SUMMARY:Weekly sync',
+            'END:VEVENT',
+            'BEGIN:VEVENT',
+            'UID:series',
+            'RECURRENCE-ID:20260810T090000Z',
+            'DTSTART:20260810T090000Z',
+            'DTEND:20260810T093000Z',
+            'SUMMARY:Weekly sync (moved)',
+            'END:VEVENT'
+        );
+
+        const events = parseEvents(ics, FROM, TO, 1);
+
+        expect(events).toHaveLength(3);
+        expect(events.map((event) => event.title)).toContain(
+            'Weekly sync (moved)'
+        );
+    });
+
+    it('falls back to a placeholder title when SUMMARY is missing', () => {
+        const ics = buildCalendar(
+            'BEGIN:VEVENT',
+            'UID:untitled',
+            'DTSTART:20260820T140000Z',
+            'DTEND:20260820T150000Z',
+            'END:VEVENT'
+        );
+
+        expect(parseEvents(ics, FROM, TO, 1)[0].title).toBe('(no title)');
+    });
+});

--- a/frontend/components/Calendar.tsx
+++ b/frontend/components/Calendar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Task } from '../entities/Task';
 import { Project } from '../entities/Project';
@@ -13,12 +13,16 @@ import {
     FolderIcon,
     TagIcon,
 } from '@heroicons/react/24/outline';
-import { format, addWeeks, addDays } from 'date-fns';
+import { format, addWeeks, addDays, addMonths, startOfMonth } from 'date-fns';
 import { el, enUS, es, ja, uk, de } from 'date-fns/locale';
 import CalendarMonthView from './Calendar/CalendarMonthView';
 import CalendarWeekView from './Calendar/CalendarWeekView';
 import CalendarDayView from './Calendar/CalendarDayView';
 import { getApiPath } from '../config/paths';
+import {
+    fetchSubscribedEvents,
+    SubscribedCalendarEvent,
+} from '../utils/subscribedCalendarService';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { parseDateString } from '../utils/dateUtils';
 
@@ -60,6 +64,7 @@ const Calendar: React.FC = () => {
     const [allTasks, setAllTasks] = useState<any[]>([]);
     const [, setProjects] = useState<Project[]>([]);
     const [isEventDetailModalOpen, setIsEventDetailModalOpen] = useState(false);
+    const [subscribedEvents, setSubscribedEvents] = useState<CalendarEvent[]>([]);
 
     const locale = getLocale(i18n.language);
 
@@ -67,6 +72,15 @@ const Calendar: React.FC = () => {
         loadTasks();
         loadProjects();
     }, []);
+
+    // Subscribed calendars are fetched per visible month, with a month of
+    // padding on each side so navigating does not flash empty days.
+    const monthKey = format(startOfMonth(currentDate), 'yyyy-MM');
+    useEffect(() => {
+        const from = addMonths(startOfMonth(currentDate), -1);
+        const to = addMonths(startOfMonth(currentDate), 2);
+        loadSubscribedEvents(from, to);
+    }, [monthKey]);
 
     const loadTasks = async () => {
         setIsLoadingTasks(true);
@@ -94,6 +108,59 @@ const Calendar: React.FC = () => {
         } finally {
             setIsLoadingTasks(false);
         }
+    };
+
+    const loadSubscribedEvents = async (from: Date, to: Date) => {
+        try {
+            const items = await fetchSubscribedEvents(from, to);
+            setSubscribedEvents(convertSubscribedToEvents(items));
+        } catch (error) {
+            console.error('Error loading subscribed calendars:', error);
+            setSubscribedEvents([]);
+        }
+    };
+
+    const convertSubscribedToEvents = (
+        items: SubscribedCalendarEvent[]
+    ): CalendarEvent[] => {
+        const result: CalendarEvent[] = [];
+
+        items.forEach((item) => {
+            if (!item.all_day) {
+                result.push({
+                    id: item.id,
+                    title: item.title,
+                    start: new Date(item.start),
+                    end: new Date(item.end),
+                    type: 'event',
+                    color: item.color,
+                });
+                return;
+            }
+
+            // All-day events carry an inclusive date range, so emit one entry
+            // per day to make multi-day events show on every day they cover.
+            const start = parseDateString(item.start);
+            const end = parseDateString(item.end) || start;
+            if (!start || !end) return;
+
+            for (
+                let day = new Date(start);
+                day <= end;
+                day.setDate(day.getDate() + 1)
+            ) {
+                result.push({
+                    id: `${item.id}-${format(day, 'yyyy-MM-dd')}`,
+                    title: item.title,
+                    start: new Date(day),
+                    end: new Date(day.getTime() + 60 * 60 * 1000),
+                    type: 'event',
+                    color: item.color,
+                });
+            }
+        });
+
+        return result;
     };
 
     const convertTasksToEvents = (tasks: any[]): CalendarEvent[] => {
@@ -191,6 +258,11 @@ const Calendar: React.FC = () => {
             }
         }
     };
+
+    const allEvents = useMemo(
+        () => [...events, ...subscribedEvents],
+        [events, subscribedEvents]
+    );
 
     const handleTimeSlotClick = () => {};
 
@@ -318,7 +390,7 @@ const Calendar: React.FC = () => {
                     {view === 'month' && (
                         <CalendarMonthView
                             currentDate={currentDate}
-                            events={events}
+                            events={allEvents}
                             onDateClick={handleDateClick}
                             onEventClick={handleEventClick}
                             onEventDrop={handleEventDrop}
@@ -327,7 +399,7 @@ const Calendar: React.FC = () => {
                     {view === 'week' && (
                         <CalendarWeekView
                             currentDate={currentDate}
-                            events={events}
+                            events={allEvents}
                             onDateClick={handleDateClick}
                             onEventClick={handleEventClick}
                             onTimeSlotClick={handleTimeSlotClick}
@@ -337,7 +409,7 @@ const Calendar: React.FC = () => {
                     {view === 'day' && (
                         <CalendarDayView
                             currentDate={currentDate}
-                            events={events}
+                            events={allEvents}
                             onEventClick={handleEventClick}
                             onTimeSlotClick={handleTimeSlotClick}
                             onEventDrop={handleEventDrop}

--- a/frontend/components/Profile/ProfileSettings.tsx
+++ b/frontend/components/Profile/ProfileSettings.tsx
@@ -53,6 +53,7 @@ import NotificationsTab from './tabs/NotificationsTab';
 import KeyboardShortcutsTab from './tabs/KeyboardShortcutsTab';
 import McpTab from './tabs/McpTab';
 import CalDAVTab from './tabs/CalDAVTab';
+import SubscribedCalendarsTab from './tabs/SubscribedCalendarsTab';
 import AIAssistantTab from './tabs/AIAssistantTab';
 import { getDefaultConfig } from '../../utils/keyboardShortcutsService';
 import {
@@ -105,6 +106,7 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
             'telegram',
             'keyboard-shortcuts',
             'caldav',
+            'subscribed-calendars',
             'mcp',
             'ai-assistant',
             'features',
@@ -1288,6 +1290,11 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
             featureFlag: 'caldav',
         },
         {
+            id: 'subscribed-calendars',
+            name: t('profile.tabs.subscribedCalendars', 'Subscribed Calendars'),
+            icon: <CalendarIcon className="w-5 h-5" />,
+        },
+        {
             id: 'mcp',
             name: t('profile.tabs.mcp', 'MCP Integration'),
             icon: <CpuChipIcon className="w-5 h-5" />,
@@ -1624,6 +1631,10 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
                                 <McpTab isActive={activeTab === 'mcp'} />
 
                                 <CalDAVTab isActive={activeTab === 'caldav'} />
+
+                                {activeTab === 'subscribed-calendars' && (
+                                    <SubscribedCalendarsTab isActive={true} />
+                                )}
 
                                 <div className="flex justify-end dark:border-gray-700">
                                     <button

--- a/frontend/components/Profile/tabs/SubscribedCalendarsTab.tsx
+++ b/frontend/components/Profile/tabs/SubscribedCalendarsTab.tsx
@@ -1,0 +1,227 @@
+import React, { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { CalendarDaysIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { useToast } from '../../Shared/ToastContext';
+import {
+    SubscribedCalendar,
+    createSubscribedCalendar,
+    deleteSubscribedCalendar,
+    fetchSubscribedCalendars,
+} from '../../../utils/subscribedCalendarService';
+
+interface SubscribedCalendarsTabProps {
+    isActive: boolean;
+}
+
+const COLORS = [
+    '#6b7280',
+    '#ef4444',
+    '#f59e0b',
+    '#22c55e',
+    '#3b82f6',
+    '#8b5cf6',
+];
+
+const SubscribedCalendarsTab: React.FC<SubscribedCalendarsTabProps> = ({
+    isActive,
+}) => {
+    const { t } = useTranslation();
+    const { showSuccessToast, showErrorToast } = useToast();
+    const [calendars, setCalendars] = useState<SubscribedCalendar[]>([]);
+    const [name, setName] = useState('');
+    const [url, setUrl] = useState('');
+    const [color, setColor] = useState(COLORS[0]);
+    const [isSaving, setIsSaving] = useState(false);
+
+    useEffect(() => {
+        if (isActive) {
+            loadCalendars();
+        }
+    }, [isActive]);
+
+    const loadCalendars = async () => {
+        try {
+            setCalendars(await fetchSubscribedCalendars());
+        } catch {
+            showErrorToast(
+                t(
+                    'subscribedCalendars.loadError',
+                    'Failed to load subscribed calendars'
+                )
+            );
+        }
+    };
+
+    const handleAdd = async (event: React.FormEvent) => {
+        event.preventDefault();
+        setIsSaving(true);
+        try {
+            await createSubscribedCalendar({ name, url, color });
+            setName('');
+            setUrl('');
+            setColor(COLORS[0]);
+            await loadCalendars();
+            showSuccessToast(
+                t('subscribedCalendars.added', 'Calendar subscribed')
+            );
+        } catch (error: any) {
+            showErrorToast(
+                error?.message ||
+                    t('subscribedCalendars.addError', 'Failed to subscribe')
+            );
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const handleDelete = async (calendar: SubscribedCalendar) => {
+        try {
+            await deleteSubscribedCalendar(calendar.uid);
+            await loadCalendars();
+            showSuccessToast(
+                t('subscribedCalendars.removed', 'Subscription removed')
+            );
+        } catch {
+            showErrorToast(
+                t(
+                    'subscribedCalendars.deleteError',
+                    'Failed to remove calendar'
+                )
+            );
+        }
+    };
+
+    return (
+        <div className="space-y-6">
+            <div>
+                <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 flex items-center">
+                    <CalendarDaysIcon className="w-5 h-5 mr-2" />
+                    {t('subscribedCalendars.title', 'Subscribed Calendars')}
+                </h3>
+                <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    {t(
+                        'subscribedCalendars.description',
+                        'Show events from an external calendar in your tududi calendar. Paste the iCalendar (.ics) address of any calendar that supports it, such as Google Calendar, Apple iCloud or Nextcloud. Events are read-only.'
+                    )}
+                </p>
+            </div>
+
+            <form onSubmit={handleAdd} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {t('subscribedCalendars.name', 'Name')}
+                    </label>
+                    <input
+                        type="text"
+                        value={name}
+                        onChange={(e) => setName(e.target.value)}
+                        required
+                        className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+                        placeholder={t(
+                            'subscribedCalendars.namePlaceholder',
+                            'Work calendar'
+                        )}
+                    />
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {t('subscribedCalendars.url', 'iCalendar URL')}
+                    </label>
+                    <input
+                        type="text"
+                        value={url}
+                        onChange={(e) => setUrl(e.target.value)}
+                        required
+                        className="mt-1 block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100"
+                        placeholder="https://example.com/calendar.ics"
+                    />
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                        {t('subscribedCalendars.color', 'Color')}
+                    </label>
+                    <div className="mt-2 flex gap-2">
+                        {COLORS.map((option) => (
+                            <button
+                                key={option}
+                                type="button"
+                                onClick={() => setColor(option)}
+                                aria-label={option}
+                                className={`w-7 h-7 rounded-full border-2 ${
+                                    color === option
+                                        ? 'border-gray-900 dark:border-gray-100'
+                                        : 'border-transparent'
+                                }`}
+                                style={{ backgroundColor: option }}
+                            />
+                        ))}
+                    </div>
+                </div>
+
+                <button
+                    type="submit"
+                    disabled={isSaving}
+                    className="px-4 py-2 text-sm font-medium rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+                >
+                    {t('subscribedCalendars.add', 'Add calendar')}
+                </button>
+            </form>
+
+            <div className="space-y-3">
+                {calendars.length === 0 && (
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                        {t(
+                            'subscribedCalendars.empty',
+                            'No subscribed calendars yet.'
+                        )}
+                    </p>
+                )}
+
+                {calendars.map((calendar) => (
+                    <div
+                        key={calendar.uid}
+                        className="flex items-center justify-between rounded-md border border-gray-200 dark:border-gray-700 p-3"
+                    >
+                        <div className="min-w-0">
+                            <div className="flex items-center">
+                                <span
+                                    className="w-3 h-3 rounded-full mr-2 shrink-0"
+                                    style={{ backgroundColor: calendar.color }}
+                                />
+                                <span className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                                    {calendar.name}
+                                </span>
+                            </div>
+                            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                                {calendar.url}
+                            </p>
+                            {calendar.last_error && (
+                                <p className="text-xs text-red-600 dark:text-red-400">
+                                    {calendar.last_error}
+                                </p>
+                            )}
+                        </div>
+
+                        <div className="flex items-center gap-3 shrink-0">
+                            <button
+                                type="button"
+                                onClick={() => handleDelete(calendar)}
+                                aria-label={t(
+                                    'subscribedCalendars.remove',
+                                    'Remove'
+                                )}
+                                className="text-gray-400 hover:text-red-600"
+                            >
+                                <TrashIcon className="w-5 h-5" />
+                            </button>
+                        </div>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default SubscribedCalendarsTab;

--- a/frontend/utils/subscribedCalendarService.ts
+++ b/frontend/utils/subscribedCalendarService.ts
@@ -1,0 +1,88 @@
+import { getApiPath } from '../config/paths';
+import { getCsrfToken } from './csrfService';
+
+export interface SubscribedCalendar {
+    id: number;
+    uid: string;
+    name: string;
+    url: string;
+    color: string;
+    last_error: string | null;
+    created_at: string;
+    updated_at: string;
+}
+
+export interface SubscribedCalendarEvent {
+    id: string;
+    title: string;
+    // Date-only (YYYY-MM-DD) when all_day is true, ISO timestamp otherwise.
+    start: string;
+    end: string;
+    all_day: boolean;
+    calendar_uid: string;
+    calendar_name: string;
+    color: string;
+}
+
+async function handleResponse<T>(response: Response): Promise<T> {
+    if (!response.ok) {
+        const errorBody = await response.json().catch(() => null);
+        throw new Error(errorBody?.error || 'Request failed');
+    }
+    return (await response.json()) as T;
+}
+
+export async function fetchSubscribedCalendars(): Promise<
+    SubscribedCalendar[]
+> {
+    const response = await fetch(getApiPath('subscribed-calendars'), {
+        credentials: 'include',
+    });
+    return handleResponse<SubscribedCalendar[]>(response);
+}
+
+export async function createSubscribedCalendar(payload: {
+    name: string;
+    url: string;
+    color?: string;
+}): Promise<SubscribedCalendar> {
+    const response = await fetch(getApiPath('subscribed-calendars'), {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'x-csrf-token': await getCsrfToken(),
+        },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+    });
+    return handleResponse<SubscribedCalendar>(response);
+}
+
+export async function deleteSubscribedCalendar(uid: string): Promise<void> {
+    const response = await fetch(getApiPath(`subscribed-calendars/${uid}`), {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: {
+            'x-csrf-token': await getCsrfToken(),
+        },
+    });
+    await handleResponse<{ success: boolean }>(response);
+}
+
+export async function fetchSubscribedEvents(
+    start: Date,
+    end: Date
+): Promise<SubscribedCalendarEvent[]> {
+    const params = new URLSearchParams({
+        start: start.toISOString(),
+        end: end.toISOString(),
+    });
+    const response = await fetch(
+        getApiPath(`subscribed-calendars/events?${params.toString()}`),
+        { credentials: 'include' }
+    );
+    const data = await handleResponse<{
+        events: SubscribedCalendarEvent[];
+    }>(response);
+    return data.events || [];
+}

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -396,7 +396,8 @@
     "tabs": {
       "notifications": "Notification Preferences",
       "oidc": "OIDC/SSO",
-      "caldav": "CalDAV Sync"
+      "caldav": "CalDAV Sync",
+      "subscribedCalendars": "Subscribed Calendars"
     },
     "caldav": {
       "title": "CalDAV Synchronization",
@@ -1687,5 +1688,21 @@
     "open": "Open",
     "streaks": "Streaks",
     "areaBreakdown": "Area Breakdown"
+  },
+  "subscribedCalendars": {
+    "title": "Subscribed Calendars",
+    "description": "Show events from an external calendar in your tududi calendar. Paste the iCalendar (.ics) address of any calendar that supports it, such as Google Calendar, Apple iCloud or Nextcloud. Events are read-only.",
+    "name": "Name",
+    "namePlaceholder": "Work calendar",
+    "url": "iCalendar URL",
+    "color": "Color",
+    "add": "Add calendar",
+    "added": "Calendar subscribed",
+    "empty": "No subscribed calendars yet.",
+    "remove": "Remove",
+    "removed": "Subscription removed",
+    "loadError": "Failed to load subscribed calendars",
+    "addError": "Failed to subscribe",
+    "deleteError": "Failed to remove calendar"
   }
 }


### PR DESCRIPTION
Follows up on #331.

The problem: the calendar view only renders tududi tasks, so there is no way to see your other calendars next to them. Google Calendar cannot subscribe to CalDAV, and the CalDAV module here serves VTODO only, so neither side can reach the other today.

This adds read-only calendar subscriptions. You paste the iCalendar (.ics) address of a calendar and its events show up in the calendar view next to your tasks. It works with Google Calendar, iCloud, Nextcloud, or anything else that publishes an .ics URL.

It is deliberately not the Google Calendar integration that was started before: no OAuth, no provider-specific code, no write path, no sync conflicts.

Scope is kept to what the issue asks for. Four endpoints:

- `GET /subscribed-calendars` list
- `POST /subscribed-calendars` add
- `DELETE /subscribed-calendars/:uid` remove
- `GET /subscribed-calendars/events?start=&end=` events for the visible range

Plus a `subscribed_calendars` table and a tab under Profile > Subscribed Calendars.

Implementation notes:

- Feeds are fetched with a 15 minute cache and parsed with ical.js, which is already a dependency.
- Recurring events are expanded only inside the requested window, with a cap so an unbounded RRULE cannot hang the request.
- All-day events are reported as dates rather than timestamps, so they do not shift by a day in other timezones, and `DTEND` is converted from exclusive to the inclusive last day.
- The three calendar view components needed no changes, since they already handled `type: 'event'` and a per-event color.
- Upstream response bodies are never returned to the client, only parsed events or a short error, so a subscribed URL cannot be used to read arbitrary responses.
- URLs are validated with `URL` plus an http/https allowlist rather than Sequelize's `isUrl`, which rejects hostnames without a TLD and would block self-hosted addresses like `http://nas:8080/calendar.ics`. `webcal://` is rewritten to `https://`.

8 unit tests cover the parser: all-day, multi-day, recurrence expansion, RECURRENCE-ID overrides, unbounded rules and window filtering. Full backend suite passes.

I know features need to be discussed first, so treat this as a proposal rather than something ready to merge. Happy to change the approach, split it up, or close it if it does not fit the roadmap.
