### PR TITLE
fix: multi-tag search/view filters now use AND instead of OR

### DIFF
--- a/backend/modules/search/repository.js
+++ b/backend/modules/search/repository.js
@@ -21,6 +21,57 @@ class SearchRepository {
     }
 
     /**
+     * Find task IDs that carry every one of the given tag IDs.
+     */
+    async findTaskIdsWithAllTags(tagIds) {
+        const rows = await sequelize.query(
+            `SELECT task_id FROM tasks_tags
+             WHERE tag_id IN (:tagIds)
+             GROUP BY task_id
+             HAVING COUNT(DISTINCT tag_id) = :tagCount`,
+            {
+                replacements: { tagIds, tagCount: tagIds.length },
+                type: sequelize.QueryTypes.SELECT,
+            }
+        );
+        return rows.map((row) => row.task_id);
+    }
+
+    /**
+     * Find project IDs that carry every one of the given tag IDs.
+     */
+    async findProjectIdsWithAllTags(tagIds) {
+        const rows = await sequelize.query(
+            `SELECT project_id FROM projects_tags
+             WHERE tag_id IN (:tagIds)
+             GROUP BY project_id
+             HAVING COUNT(DISTINCT tag_id) = :tagCount`,
+            {
+                replacements: { tagIds, tagCount: tagIds.length },
+                type: sequelize.QueryTypes.SELECT,
+            }
+        );
+        return rows.map((row) => row.project_id);
+    }
+
+    /**
+     * Find note IDs that carry every one of the given tag IDs.
+     */
+    async findNoteIdsWithAllTags(tagIds) {
+        const rows = await sequelize.query(
+            `SELECT note_id FROM notes_tags
+             WHERE tag_id IN (:tagIds)
+             GROUP BY note_id
+             HAVING COUNT(DISTINCT tag_id) = :tagCount`,
+            {
+                replacements: { tagIds, tagCount: tagIds.length },
+                type: sequelize.QueryTypes.SELECT,
+            }
+        );
+        return rows.map((row) => row.note_id);
+    }
+
+    /**
      * Count tasks matching conditions.
      */
     async countTasks(conditions, include) {

--- a/backend/modules/search/service.js
+++ b/backend/modules/search/service.js
@@ -213,6 +213,16 @@ class SearchService {
             deferDateCondition,
             nowDate
         );
+
+        if (tagIds.length > 1) {
+            const matchingIds =
+                await searchRepository.findTaskIdsWithAllTags(tagIds);
+            if (matchingIds.length === 0) {
+                return { count: 0, results: [] };
+            }
+            conditions.id = { [Op.in]: matchingIds };
+        }
+
         const { include, tagInclude } = this.buildTaskInclude(
             tagIds,
             params.extras
@@ -280,6 +290,15 @@ class SearchService {
 
         if (dueDateCondition) {
             conditions.due_date_at = dueDateCondition.due_date;
+        }
+
+        if (tagIds.length > 1) {
+            const matchingIds =
+                await searchRepository.findProjectIdsWithAllTags(tagIds);
+            if (matchingIds.length === 0) {
+                return { count: 0, results: [] };
+            }
+            conditions.id = { [Op.in]: matchingIds };
         }
 
         const requireTags = tagIds.length > 0 || extras.has('has_tags');
@@ -397,6 +416,15 @@ class SearchService {
                     }
                 ),
             ];
+        }
+
+        if (tagIds.length > 1) {
+            const matchingIds =
+                await searchRepository.findNoteIdsWithAllTags(tagIds);
+            if (matchingIds.length === 0) {
+                return { count: 0, results: [] };
+            }
+            conditions.id = { [Op.in]: matchingIds };
         }
 
         const include = [];

--- a/backend/tests/integration/search.test.js
+++ b/backend/tests/integration/search.test.js
@@ -512,7 +512,7 @@ describe('Universal Search Routes', () => {
                 expect(tasks.length).toBe(2); // Work task and Urgent work task
             });
 
-            it('should filter by multiple tags', async () => {
+            it('should filter tasks that have ALL requested tags (AND, not OR)', async () => {
                 const response = await agent.get('/api/search').query({
                     tags: 'work,urgent',
                     filters: 'Task',
@@ -522,8 +522,69 @@ describe('Universal Search Routes', () => {
                 const tasks = response.body.results.filter(
                     (r) => r.type === 'Task'
                 );
-                // Should return tasks that have either work OR urgent tag
-                expect(tasks.length).toBeGreaterThanOrEqual(1);
+                // Only "Urgent work task" has both the work and urgent tags.
+                // "Work task" (work only) must NOT be included.
+                expect(tasks.length).toBe(1);
+                expect(tasks[0].name).toBe('Urgent work task');
+            });
+
+            it('should return no tasks when no task has every requested tag', async () => {
+                const response = await agent.get('/api/search').query({
+                    tags: 'personal,urgent',
+                    filters: 'Task',
+                });
+
+                expect(response.status).toBe(200);
+                const tasks = response.body.results.filter(
+                    (r) => r.type === 'Task'
+                );
+                expect(tasks.length).toBe(0);
+            });
+
+            it('should filter projects that have ALL requested tags (AND, not OR)', async () => {
+                const project2 = await Project.create({
+                    user_id: user.id,
+                    name: 'Urgent work project',
+                    state: 'active',
+                });
+                await project2.addTag(workTag);
+                await project2.addTag(urgentTag);
+
+                const response = await agent.get('/api/search').query({
+                    tags: 'work,urgent',
+                    filters: 'Project',
+                });
+
+                expect(response.status).toBe(200);
+                const projects = response.body.results.filter(
+                    (r) => r.type === 'Project'
+                );
+                // "Work project" only has the work tag and must be excluded.
+                expect(projects.length).toBe(1);
+                expect(projects[0].name).toBe('Urgent work project');
+            });
+
+            it('should filter notes that have ALL requested tags (AND, not OR)', async () => {
+                const note2 = await Note.create({
+                    user_id: user.id,
+                    title: 'Urgent personal note',
+                    content: 'Some content',
+                });
+                await note2.addTag(personalTag);
+                await note2.addTag(urgentTag);
+
+                const response = await agent.get('/api/search').query({
+                    tags: 'personal,urgent',
+                    filters: 'Note',
+                });
+
+                expect(response.status).toBe(200);
+                const notes = response.body.results.filter(
+                    (r) => r.type === 'Note'
+                );
+                // "Personal note" only has the personal tag and must be excluded.
+                expect(notes.length).toBe(1);
+                expect(notes[0].title).toBe('Urgent personal note');
             });
 
             it('should filter projects by tag', async () => {


### PR DESCRIPTION
## Description

Views (and the `/search` endpoint) with two or more tags in the `tags` filter were matching items that have **any** of the listed tags instead of **all** of them, contradicting the documented behavior ("Items must have every tag in the list").

Root cause: `buildTaskInclude`/`searchProjects`/`searchNotes` in `backend/modules/search/service.js` filtered tags with a single join on `tag.id IN (tagIds)`, which is OR semantics regardless of how many tag ids are passed.

Fix: added `findTaskIdsWithAllTags`/`findProjectIdsWithAllTags`/`findNoteIdsWithAllTags` to `backend/modules/search/repository.js` (`GROUP BY ... HAVING COUNT(DISTINCT tag_id) = tagIds.length` over the join tables) and used them to restrict the main query to matching IDs whenever more than one tag is requested.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1422

## Testing

**How did you test this?**

- `npm run lint` passes (0 errors)
- `npm run backend:test -- backend/tests/integration/search.test.js` passes (56/56)
- Rewrote the existing "should filter by multiple tags" test, which had baked in the OR behavior as expected, and added coverage for projects, notes, and the empty-intersection case
- Manually verified against a live instance with real data (office=20 tasks, short=20 tasks, office∩short=12 tasks, matching the AND-filtered result)

- [x] `npm run pre-push` passes (via `npm run lint` + `npm run backend:test`, since `pre-push`/`lint-staged` only checks staged files)

## Checklist

- [ ] This is not an AI slop crap, I know what I am doing
- [ ] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
