### PR TITLE
fix(caldav): import AppError as named export from shared/errors index

### DIFF
--- a/backend/modules/caldav/api/calendar-controller.js
+++ b/backend/modules/caldav/api/calendar-controller.js
@@ -1,4 +1,4 @@
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const CalendarRepository = require('../repositories/calendar-repository');
 const SyncStateRepository = require('../repositories/sync-state-repository');
 const { uid } = require('../../../utils/uid');

--- a/backend/modules/caldav/api/remote-calendar-controller.js
+++ b/backend/modules/caldav/api/remote-calendar-controller.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const { URL } = require('url');
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const RemoteCalendarRepository = require('../repositories/remote-calendar-repository');
 const CalendarRepository = require('../repositories/calendar-repository');
 const encryptionService = require('../services/encryption-service');

--- a/backend/modules/caldav/api/sync-controller.js
+++ b/backend/modules/caldav/api/sync-controller.js
@@ -1,4 +1,4 @@
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const syncScheduler = require('../services/sync-scheduler');
 const syncEngine = require('../sync/sync-engine');
 const MergePhase = require('../sync/merge-phase');

--- a/backend/modules/caldav/sync/merge-phase.js
+++ b/backend/modules/caldav/sync/merge-phase.js
@@ -1,4 +1,4 @@
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const logger = require('../../../services/logService');
 const { Task } = require('../../../models');
 const SyncStateRepository = require('../repositories/sync-state-repository');

--- a/backend/modules/caldav/sync/pull-phase.js
+++ b/backend/modules/caldav/sync/pull-phase.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const { parseStringPromise } = require('xml2js');
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const logger = require('../../../services/logService');
 const RemoteCalendarRepository = require('../repositories/remote-calendar-repository');
 const { parseVTODOToTask } = require('../icalendar/vtodo-parser');

--- a/backend/modules/caldav/sync/push-phase.js
+++ b/backend/modules/caldav/sync/push-phase.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const logger = require('../../../services/logService');
 const { Task } = require('../../../models');
 const SyncStateRepository = require('../repositories/sync-state-repository');

--- a/backend/modules/caldav/sync/sync-engine.js
+++ b/backend/modules/caldav/sync/sync-engine.js
@@ -1,4 +1,4 @@
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const logger = require('../../../services/logService');
 const PullPhase = require('./pull-phase');
 const MergePhase = require('./merge-phase');


### PR DESCRIPTION
## Description

`backend/shared/errors/AppError.js` does a plain default export (`module.exports = AppError`), but 7 files under `backend/modules/caldav/**` imported it with a named destructure (`const { AppError } = require('../../../shared/errors/AppError')`). That made the destructured `AppError` `undefined`, so any `new AppError(...)` in those files threw `TypeError: AppError is not a constructor` as an uncaught exception, crashing the whole Node process instead of returning an error response.

`backend/shared/errors/index.js` already re-exports `AppError` correctly as a named export alongside `NotFoundError`, `ValidationError`, etc. This PR switches all 7 files to import from the index instead of the class file directly, matching the pattern already used elsewhere (e.g. `shared/middleware/errorHandler.js`, `modules/ai-assistant/service.js`).

Affected files:
- `backend/modules/caldav/sync/push-phase.js`
- `backend/modules/caldav/sync/pull-phase.js`
- `backend/modules/caldav/sync/merge-phase.js`
- `backend/modules/caldav/sync/sync-engine.js`
- `backend/modules/caldav/api/sync-controller.js`
- `backend/modules/caldav/api/calendar-controller.js`
- `backend/modules/caldav/api/remote-calendar-controller.js`

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1424

## Testing

**How did you test this?**

- Ran the full caldav test suite (integration + unit): 13 suites, 206 tests, all passing.
- Ran eslint against the 7 changed files: no errors.
- [x] `npm run pre-push` passes (lint-staged on the commit diff)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable): no new tests needed, this is a one-line import fix per file already covered by existing caldav test suites
