### PR TITLE
fix(config): fall back to BASE_URL for sign-up verification email links

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -7,6 +7,8 @@ PORT=3002
 # DB_FILE=db/development.sqlite3
 
 FRONTEND_URL=http://localhost:8080
+# Public URL of the backend, used to build links in emails (e.g. sign-up
+# verification). Falls back to BASE_URL below if not set.
 BACKEND_URL=http://localhost:3002
 
 TUDUDI_USER_EMAIL=admin@example.com
@@ -79,7 +81,7 @@ TUDUDI_TRUST_PROXY=true
 # OIDC/SSO Configuration
 # See docs/10-oidc-sso.md for detailed setup instructions
 OIDC_ENABLED=false
-# BASE_URL=https://your-domain.com  # Required for OIDC callbacks
+# BASE_URL=https://your-domain.com  # Required for OIDC callbacks; also used as a fallback for BACKEND_URL
 
 # Password Authentication
 # Set to false to disable password login/registration (SSO-only mode)

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -78,7 +78,13 @@ const config = {
 
     frontendUrl: process.env.FRONTEND_URL || 'http://localhost:8080',
 
-    backendUrl: process.env.BACKEND_URL || 'http://localhost:3002',
+    // BACKEND_URL is the primary variable; BASE_URL (documented for OIDC
+    // callbacks) is accepted as a fallback since it's the publicly-facing
+    // URL of the deployment and users commonly set only that one.
+    backendUrl:
+        process.env.BACKEND_URL ||
+        process.env.BASE_URL ||
+        'http://localhost:3002',
 
     // Some CI/sandbox environments disallow binding to 0.0.0.0, so force
     // loopback for tests unless HOST is explicitly provided.

--- a/backend/tests/unit/config/config.test.js
+++ b/backend/tests/unit/config/config.test.js
@@ -1,0 +1,39 @@
+describe('config backendUrl', () => {
+    const ORIGINAL_ENV = process.env;
+
+    beforeEach(() => {
+        jest.resetModules();
+        process.env = { ...ORIGINAL_ENV };
+    });
+
+    afterAll(() => {
+        process.env = ORIGINAL_ENV;
+    });
+
+    it('uses BACKEND_URL when set', () => {
+        process.env.BACKEND_URL = 'http://backend.example.com';
+        process.env.BASE_URL = 'http://base.example.com';
+
+        const { getConfig } = require('../../../config/config');
+
+        expect(getConfig().backendUrl).toBe('http://backend.example.com');
+    });
+
+    it('falls back to BASE_URL when BACKEND_URL is not set', () => {
+        delete process.env.BACKEND_URL;
+        process.env.BASE_URL = 'http://10.10.10.10:3002';
+
+        const { getConfig } = require('../../../config/config');
+
+        expect(getConfig().backendUrl).toBe('http://10.10.10.10:3002');
+    });
+
+    it('falls back to the default when neither is set', () => {
+        delete process.env.BACKEND_URL;
+        delete process.env.BASE_URL;
+
+        const { getConfig } = require('../../../config/config');
+
+        expect(getConfig().backendUrl).toBe('http://localhost:3002');
+    });
+});


### PR DESCRIPTION
## Description

Sign-up verification emails always linked to `http://localhost:3002`, even when `BASE_URL` was set (e.g. `BASE_URL=http://10.10.10.10:3002`).

The verification link is built from `config.backendUrl`, which reads `process.env.BACKEND_URL`. `BASE_URL` is a separate variable, currently only consumed for OIDC callbacks and the `WWW-Authenticate` header. README and `.env.example` mainly document `BASE_URL` as the deployment's public URL, so users setting it alone (not `BACKEND_URL`) saw no effect on the email link.

`config.backendUrl` now falls back to `BASE_URL` when `BACKEND_URL` isn't set, so either variable produces the expected verification link.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1432

## Testing

**How did you test this?**

- Added `backend/tests/unit/config/config.test.js` covering: `BACKEND_URL` set, `BASE_URL`-only fallback, and the default with neither set.
- `npm run pre-push` passes.

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
