### PR TITLE
fix(areas): stop mount/unmount loop when a loaded store refetches

### DIFF
--- a/frontend/Layout.tsx
+++ b/frontend/Layout.tsx
@@ -86,8 +86,18 @@ const Layout: React.FC<LayoutProps> = ({
     }, []);
 
     const {
-        notesStore: { notes, isLoading: isNotesLoading, isError: isNotesError },
-        areasStore: { areas, isLoading: isAreasLoading, isError: isAreasError },
+        notesStore: {
+            notes,
+            isLoading: isNotesLoading,
+            isError: isNotesError,
+            hasLoaded: hasNotesLoaded,
+        },
+        areasStore: {
+            areas,
+            isLoading: isAreasLoading,
+            isError: isAreasError,
+            hasLoaded: hasAreasLoaded,
+        },
         tasksStore: {
             isLoading: isTasksLoading,
             isError: isTasksError,
@@ -98,8 +108,14 @@ const Layout: React.FC<LayoutProps> = ({
             setProjects,
             isLoading: isProjectsLoading,
             isError: isProjectsError,
+            hasLoaded: hasProjectsLoaded,
         },
-        tagsStore: { tags, isLoading: isTagsLoading, isError: isTagsError },
+        tagsStore: {
+            tags,
+            isLoading: isTagsLoading,
+            isError: isTagsError,
+            hasLoaded: hasTagsLoaded,
+        },
     } = useStore();
 
     const createAndOpenTaskDetails = async () => {
@@ -402,12 +418,17 @@ const Layout: React.FC<LayoutProps> = ({
 
     const mainContentMarginLeft = isSidebarOpen ? 'ml-sidebar' : 'ml-0';
 
+    // Only show the full-screen loader for a store's *first* load. Once a
+    // store has loaded once, subsequent background refreshes (e.g. a page
+    // forcing a fresh fetch on remount) must not swap out `{children}` -
+    // doing so unmounts the routed page mid-fetch, which re-triggers its
+    // mount effect and refetches again, looping forever (issue #1427).
     const isLoading =
-        isNotesLoading ||
-        isAreasLoading ||
+        (isNotesLoading && !hasNotesLoaded) ||
+        (isAreasLoading && !hasAreasLoaded) ||
         isTasksLoading ||
-        isProjectsLoading ||
-        isTagsLoading;
+        (isProjectsLoading && !hasProjectsLoaded) ||
+        (isTagsLoading && !hasTagsLoaded);
     const isError =
         isNotesError ||
         isAreasError ||

--- a/frontend/__tests__/Layout.test.tsx
+++ b/frontend/__tests__/Layout.test.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Layout from '../Layout';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string, fallback?: string) => fallback ?? key,
+    }),
+}));
+
+jest.mock('../components/Shared/ToastContext', () => ({
+    useToast: () => ({
+        showSuccessToast: jest.fn(),
+        showErrorToast: jest.fn(),
+        showUndoToast: jest.fn(),
+    }),
+}));
+
+jest.mock('react-router-dom', () => ({
+    useLocation: () => ({ pathname: '/areas', search: '' }),
+    useNavigate: () => jest.fn(),
+}));
+
+jest.mock('../components/Navbar', () => ({
+    __esModule: true,
+    default: () => <div data-testid="navbar" />,
+}));
+
+jest.mock('../components/Sidebar', () => ({
+    __esModule: true,
+    default: () => <div data-testid="sidebar" />,
+}));
+
+jest.mock('../components/Project/ProjectModal', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+jest.mock('../components/Note/NoteModal', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+jest.mock('../components/Area/AreaModal', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+jest.mock('../components/Tag/TagModal', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+jest.mock('../components/People/PersonModal', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+const baseStoreState: any = {
+    notesStore: {
+        notes: [],
+        isLoading: false,
+        isError: false,
+        hasLoaded: true,
+        loadNotes: jest.fn(),
+        setNotes: jest.fn(),
+    },
+    areasStore: {
+        areas: [],
+        isLoading: false,
+        isError: false,
+        hasLoaded: true,
+        loadAreas: jest.fn(),
+        setAreas: jest.fn(),
+    },
+    tasksStore: {
+        tasks: [],
+        isLoading: false,
+        isError: false,
+        createTask: jest.fn(),
+    },
+    projectsStore: {
+        // Non-empty so Layout's own "load projects if empty" effect doesn't
+        // fire a real fetch during these tests.
+        projects: [{ id: 1, uid: 'p1', name: 'Project 1' }],
+        setProjects: jest.fn(),
+        isLoading: false,
+        isError: false,
+        hasLoaded: true,
+    },
+    tagsStore: {
+        tags: [],
+        isLoading: false,
+        isError: false,
+        hasLoaded: true,
+        setTags: jest.fn(),
+    },
+    peopleStore: {
+        people: [],
+    },
+};
+
+let storeState: any = baseStoreState;
+
+jest.mock('../store/useStore', () => {
+    const mockUseStore: any = () => storeState;
+    mockUseStore.getState = () => storeState;
+    return { useStore: mockUseStore };
+});
+
+const renderLayout = () =>
+    render(
+        <Layout
+            currentUser={{ email: 'user@example.com' } as any}
+            setCurrentUser={jest.fn()}
+            isDarkMode={false}
+            toggleDarkMode={jest.fn()}
+        >
+            <div data-testid="routed-page">Areas page content</div>
+        </Layout>
+    );
+
+describe('Layout loading gate', () => {
+    beforeEach(() => {
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: false,
+        }) as any;
+        storeState = baseStoreState;
+    });
+
+    it('renders the routed page once every store has loaded at least once', () => {
+        renderLayout();
+
+        expect(screen.getByTestId('routed-page')).toBeInTheDocument();
+    });
+
+    it('does not swap the routed page out for the full-screen loader when a store that has already loaded starts a background refresh', () => {
+        // Mirrors Areas.tsx calling loadAreas(true) on every mount: areasStore
+        // goes back into isLoading even though hasLoaded is already true.
+        storeState = {
+            ...baseStoreState,
+            areasStore: {
+                ...baseStoreState.areasStore,
+                isLoading: true,
+                hasLoaded: true,
+            },
+        };
+
+        renderLayout();
+
+        // Regression guard for #1427: if Layout unmounted the routed page
+        // here, the page's mount effect would refire its forced reload,
+        // looping forever.
+        expect(screen.getByTestId('routed-page')).toBeInTheDocument();
+        expect(screen.queryByText('common.loading')).not.toBeInTheDocument();
+    });
+
+    it('still shows the full-screen loader while a store has not loaded for the first time yet', () => {
+        storeState = {
+            ...baseStoreState,
+            areasStore: {
+                ...baseStoreState.areasStore,
+                isLoading: true,
+                hasLoaded: false,
+            },
+        };
+
+        renderLayout();
+
+        expect(screen.queryByTestId('routed-page')).not.toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Description

Navigating to `/areas` triggered a continuous, unthrottled loop of API requests (60-80 req/s, sustained indefinitely) that pegged the tab's CPU. Root cause was a mount/unmount loop between `Layout` and the `Areas` page:

1. `Areas.tsx` calls `loadAreas(true)` on every mount to force a fresh fetch, so the goal/task/project counts on the cards don't go stale after edits made elsewhere (#1393).
2. `loadAreas(true)` sets `areasStore.isLoading = true`, even though `areasStore.hasLoaded` is already `true`.
3. `Layout` aggregates `isLoading` across five stores (notes, areas, tasks, projects, tags) and, whenever any of them is loading, renders a full-screen loading state *instead of* `{children}`, which unmounts the routed page.
4. `Areas` unmounts mid-fetch. When the fetch resolves, `Layout` renders `{children}` again, remounting `Areas`, which calls `loadAreas(true)` again, restarting the loop.

Since only `Areas.tsx` force-reloads an already-loaded store on every mount, `/goals` and `/projects` don't hit this (they gate their own reloads on `!hasLoaded`).

Fix: `Layout`'s full-screen loading gate now only fires on a store's *first* load (`isLoading && !hasLoaded`), not on every `isLoading` transition. A background refresh of a store that has already loaded once now updates in place instead of tearing down the routed page, which also protects any future page that does the same kind of forced refresh.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1427

## Testing

**How did you test this?**

- Added `frontend/__tests__/Layout.test.tsx`, which reproduces the exact scenario from the issue (an already-loaded store going back into `isLoading`) and asserts the routed page stays mounted instead of being swapped for the loading screen. Verified the new test fails against the pre-fix `Layout.tsx` and passes after the fix.
- `npx tsc --noEmit`, `npm run frontend:test` (full suite, 83 tests), and `npm run lint` all pass clean.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
