### PR TITLE
fix(search): use AND semantics for multi-tag filtering

### DIFF
--- a/backend/modules/search/repository.js
+++ b/backend/modules/search/repository.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Task, Tag, Project, Area, Note, sequelize } = require('../../models');
-const { Op } = require('sequelize');
+const { Op, QueryTypes } = require('sequelize');
 
 class SearchRepository {
     /**
@@ -18,6 +18,34 @@ class SearchRepository {
             attributes: ['id'],
         });
         return tags.map((tag) => tag.id);
+    }
+
+    // Find ids of owner rows in a tag join table that carry every tag in
+    // tagIds (AND semantics), not just any one of them.
+    async findIdsWithAllTags(joinTable, ownerColumn, tagIds) {
+        const rows = await sequelize.query(
+            `SELECT ${ownerColumn} AS owner_id FROM ${joinTable}
+             WHERE tag_id IN (:tagIds)
+             GROUP BY ${ownerColumn}
+             HAVING COUNT(DISTINCT tag_id) = :tagCount`,
+            {
+                replacements: { tagIds, tagCount: tagIds.length },
+                type: QueryTypes.SELECT,
+            }
+        );
+        return rows.map((row) => row.owner_id);
+    }
+
+    async findTaskIdsWithAllTags(tagIds) {
+        return this.findIdsWithAllTags('tasks_tags', 'task_id', tagIds);
+    }
+
+    async findProjectIdsWithAllTags(tagIds) {
+        return this.findIdsWithAllTags('projects_tags', 'project_id', tagIds);
+    }
+
+    async findNoteIdsWithAllTags(tagIds) {
+        return this.findIdsWithAllTags('notes_tags', 'note_id', tagIds);
     }
 
     /**

--- a/backend/modules/search/service.js
+++ b/backend/modules/search/service.js
@@ -206,6 +206,14 @@ class SearchService {
         nowDate,
         timezone
     ) {
+        let matchingIds = null;
+        if (tagIds.length > 0) {
+            matchingIds = await searchRepository.findTaskIdsWithAllTags(tagIds);
+            if (matchingIds.length === 0) {
+                return { count: 0, results: [] };
+            }
+        }
+
         const conditions = this.buildTaskConditions(
             userId,
             params,
@@ -213,6 +221,9 @@ class SearchService {
             deferDateCondition,
             nowDate
         );
+        if (matchingIds) {
+            conditions.id = { [Op.in]: matchingIds };
+        }
         const { include, tagInclude } = this.buildTaskInclude(
             tagIds,
             params.extras
@@ -254,7 +265,19 @@ class SearchService {
         const { searchQuery, priority, extras, hasPagination, limit, offset } =
             params;
 
+        let matchingIds = null;
+        if (tagIds.length > 0) {
+            matchingIds =
+                await searchRepository.findProjectIdsWithAllTags(tagIds);
+            if (matchingIds.length === 0) {
+                return { count: 0, results: [] };
+            }
+        }
+
         const conditions = { user_id: userId };
+        if (matchingIds) {
+            conditions.id = { [Op.in]: matchingIds };
+        }
 
         if (searchQuery) {
             const lowerQuery = searchQuery.toLowerCase();
@@ -379,7 +402,18 @@ class SearchService {
     async searchNotes(userId, params, tagIds) {
         const { searchQuery, hasPagination, limit, offset } = params;
 
+        let matchingIds = null;
+        if (tagIds.length > 0) {
+            matchingIds = await searchRepository.findNoteIdsWithAllTags(tagIds);
+            if (matchingIds.length === 0) {
+                return { count: 0, results: [] };
+            }
+        }
+
         const conditions = { user_id: userId };
+        if (matchingIds) {
+            conditions.id = { [Op.in]: matchingIds };
+        }
 
         if (searchQuery) {
             const lowerQuery = searchQuery.toLowerCase();

--- a/backend/tests/integration/search.test.js
+++ b/backend/tests/integration/search.test.js
@@ -512,7 +512,7 @@ describe('Universal Search Routes', () => {
                 expect(tasks.length).toBe(2); // Work task and Urgent work task
             });
 
-            it('should filter by multiple tags', async () => {
+            it('should filter by multiple tags using AND semantics', async () => {
                 const response = await agent.get('/api/search').query({
                     tags: 'work,urgent',
                     filters: 'Task',
@@ -522,8 +522,23 @@ describe('Universal Search Routes', () => {
                 const tasks = response.body.results.filter(
                     (r) => r.type === 'Task'
                 );
-                // Should return tasks that have either work OR urgent tag
-                expect(tasks.length).toBeGreaterThanOrEqual(1);
+                // Only tasks that have BOTH work AND urgent should be returned
+                expect(tasks.length).toBe(1);
+                expect(tasks[0].name).toBe('Urgent work task');
+            });
+
+            it('should exclude tasks that only have some of the requested tags', async () => {
+                const response = await agent.get('/api/search').query({
+                    tags: 'work,personal',
+                    filters: 'Task',
+                });
+
+                expect(response.status).toBe(200);
+                const tasks = response.body.results.filter(
+                    (r) => r.type === 'Task'
+                );
+                // No task in the fixture has both work AND personal
+                expect(tasks.length).toBe(0);
             });
 
             it('should filter projects by tag', async () => {
@@ -552,6 +567,64 @@ describe('Universal Search Routes', () => {
                 );
                 expect(notes.length).toBe(1);
                 expect(notes[0].title).toBe('Personal note');
+            });
+
+            it('should filter projects by multiple tags using AND semantics', async () => {
+                const soloProject = await Project.create({
+                    user_id: user.id,
+                    name: 'Personal only project',
+                    state: 'active',
+                });
+                await soloProject.addTag(personalTag);
+
+                const bothProject = await Project.create({
+                    user_id: user.id,
+                    name: 'Work and personal project',
+                    state: 'active',
+                });
+                await bothProject.addTag(workTag);
+                await bothProject.addTag(personalTag);
+
+                const response = await agent.get('/api/search').query({
+                    tags: 'work,personal',
+                    filters: 'Project',
+                });
+
+                expect(response.status).toBe(200);
+                const projects = response.body.results.filter(
+                    (r) => r.type === 'Project'
+                );
+                expect(projects.length).toBe(1);
+                expect(projects[0].name).toBe('Work and personal project');
+            });
+
+            it('should filter notes by multiple tags using AND semantics', async () => {
+                const soloNote = await Note.create({
+                    user_id: user.id,
+                    title: 'Urgent only note',
+                    content: 'Content',
+                });
+                await soloNote.addTag(urgentTag);
+
+                const bothNote = await Note.create({
+                    user_id: user.id,
+                    title: 'Personal and urgent note',
+                    content: 'Content',
+                });
+                await bothNote.addTag(personalTag);
+                await bothNote.addTag(urgentTag);
+
+                const response = await agent.get('/api/search').query({
+                    tags: 'personal,urgent',
+                    filters: 'Note',
+                });
+
+                expect(response.status).toBe(200);
+                const notes = response.body.results.filter(
+                    (r) => r.type === 'Note'
+                );
+                expect(notes.length).toBe(1);
+                expect(notes[0].title).toBe('Personal and urgent note');
             });
 
             it('should return empty results for non-existent tag', async () => {

--- a/backend/tests/integration/views.test.js
+++ b/backend/tests/integration/views.test.js
@@ -422,8 +422,9 @@ describe('Views Routes', () => {
             const tasks = searchResponse.body.results.filter(
                 (r) => r.type === 'Task'
             );
-            // Should find tasks with either work OR urgent tag
-            expect(tasks.length).toBeGreaterThanOrEqual(1);
+            // Should only find tasks that have BOTH work AND urgent
+            expect(tasks.length).toBe(1);
+            expect(tasks[0].name).toBe('Urgent work task');
         });
 
         it('should persist tags correctly after update', async () => {


### PR DESCRIPTION
## Description

Filtering tasks, projects, or notes by multiple tags (via a saved View or the `/api/search` endpoint) returned items matching **any** of the requested tags instead of **all** of them, contradicting the documented behavior ("Has ALL specified tags").

The bug was in how the Tag `include` was joined: `{ model: Tag, where: { id: { [Op.in]: tagIds } } }` filters the join rows, not the owner rows, so a single matching tag was enough to keep the task/project/note in the result set (OR semantics), regardless of how many tags were requested.

The fix resolves which task/project/note ids carry *every* requested tag first (`GROUP BY owner_id HAVING COUNT(DISTINCT tag_id) = tagIds.length`) and restricts the main query to that id set, before applying the rest of the existing filters/includes. Same fix applied to tasks, projects, and notes since all three share this pattern in `backend/modules/search/service.js`.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1422

## Testing

**How did you test this?**

- Added integration tests reproducing the issue's repro steps (task with only tag A, task with only tag B, task with both A and B, filtering by `[A, B]` returns only the task with both).
- Added equivalent multi-tag AND coverage for projects and notes.
- Updated two existing tests that had asserted the old OR behavior as expected/documented.
- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
