### PR TITLE
fix(habits): allow one completion per calendar day instead of per period

### DIFF
--- a/backend/modules/habits/habitService.js
+++ b/backend/modules/habits/habitService.js
@@ -9,22 +9,21 @@ class HabitService {
             throw new Error('Task is not a habit');
         }
 
-        const period = task.habit_frequency_period || 'daily';
-        const { start: periodStart, end: periodEnd } = this.getPeriodWindow(
-            period,
-            completedAt
-        );
+        const dayStart = new Date(completedAt);
+        dayStart.setHours(0, 0, 0, 0);
+        const dayEnd = new Date(completedAt);
+        dayEnd.setHours(23, 59, 59, 999);
 
-        const existingInPeriod = await RecurringCompletion.findOne({
+        const existingOnDay = await RecurringCompletion.findOne({
             where: {
                 task_id: task.id,
                 skipped: false,
-                completed_at: { [Op.between]: [periodStart, periodEnd] },
+                completed_at: { [Op.between]: [dayStart, dayEnd] },
             },
         });
 
-        if (existingInPeriod) {
-            return { completion: existingInPeriod, task };
+        if (existingOnDay) {
+            return { completion: existingOnDay, task };
         }
 
         const completion = await RecurringCompletion.create({
@@ -147,14 +146,8 @@ class HabitService {
 
         const period = task.habit_frequency_period || 'daily';
 
-        const distinctPeriods = new Set(
-            completions.map((c) =>
-                this.getPeriodStart(period, new Date(c.completed_at)).getTime()
-            )
-        ).size;
-
         const updates = {
-            habit_total_completions: distinctPeriods,
+            habit_total_completions: completions.length,
             habit_last_completion_at:
                 completions.length > 0 ? completions[0].completed_at : null,
         };

--- a/backend/tests/unit/modules/habits/habitService.test.js
+++ b/backend/tests/unit/modules/habits/habitService.test.js
@@ -8,10 +8,27 @@ jest.mock('../../../../models', () => ({
     },
 }));
 
+const { Op } = require('sequelize');
+const { RecurringCompletion } = require('../../../../models');
 const habitService = require('../../../../modules/habits/habitService');
 
 function makeCompletion(isoDate) {
     return { completed_at: isoDate, skipped: false };
+}
+
+function makeHabit(overrides = {}) {
+    return {
+        id: 1,
+        habit_mode: true,
+        habit_frequency_period: 'weekly',
+        habit_streak_mode: 'calendar',
+        habit_total_completions: 0,
+        habit_best_streak: 0,
+        habit_current_streak: 0,
+        habit_last_completion_at: null,
+        update: jest.fn(),
+        ...overrides,
+    };
 }
 
 describe('HabitService - getPeriodStart', () => {
@@ -200,5 +217,108 @@ describe('HabitService - calculateBestStreak', () => {
             makeCompletion('2026-08-02T09:00:00'),
         ];
         expect(habitService.calculateBestStreak(completions)).toBe(2);
+    });
+});
+
+describe('HabitService - logCompletion', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        RecurringCompletion.findAll.mockResolvedValue([]);
+    });
+
+    it('rejects a non-habit task', async () => {
+        const task = makeHabit({ habit_mode: false });
+        await expect(habitService.logCompletion(task)).rejects.toThrow(
+            'Task is not a habit'
+        );
+    });
+
+    it('creates a completion when none exists yet that day', async () => {
+        const task = makeHabit();
+        RecurringCompletion.findOne.mockResolvedValue(null);
+        RecurringCompletion.create.mockResolvedValue({ id: 1 });
+
+        const completedAt = new Date('2026-08-04T09:00:00'); // Tue this week
+        const result = await habitService.logCompletion(task, completedAt);
+
+        expect(RecurringCompletion.create).toHaveBeenCalledWith({
+            task_id: task.id,
+            completed_at: completedAt,
+            original_due_date: completedAt,
+            skipped: false,
+        });
+        expect(task.update).toHaveBeenCalled();
+        expect(result.completion).toEqual({ id: 1 });
+    });
+
+    it('reuses the existing completion when the same day is logged twice', async () => {
+        const task = makeHabit();
+        const existing = { id: 1 };
+        RecurringCompletion.findOne.mockResolvedValue(existing);
+
+        const result = await habitService.logCompletion(
+            task,
+            new Date('2026-08-04T09:00:00')
+        );
+
+        expect(RecurringCompletion.create).not.toHaveBeenCalled();
+        expect(task.update).not.toHaveBeenCalled();
+        expect(result.completion).toBe(existing);
+    });
+
+    it('allows a second completion in the same week on a different day (regression for #1421)', async () => {
+        const task = makeHabit();
+
+        // Tuesday is already completed, but Wednesday (same week) is not.
+        const tuesday = new Date('2026-08-04T09:00:00');
+        const wednesday = new Date('2026-08-05T09:00:00');
+
+        RecurringCompletion.findOne.mockImplementation(({ where }) => {
+            const [start, end] = where.completed_at[Op.between];
+            const isTuesday = tuesday >= start && tuesday <= end;
+            return Promise.resolve(isTuesday ? { id: 1 } : null);
+        });
+        RecurringCompletion.create.mockResolvedValue({ id: 2 });
+
+        const result = await habitService.logCompletion(task, wednesday);
+
+        expect(RecurringCompletion.create).toHaveBeenCalledWith({
+            task_id: task.id,
+            completed_at: wednesday,
+            original_due_date: wednesday,
+            skipped: false,
+        });
+        expect(result.completion).toEqual({ id: 2 });
+    });
+
+    it('queries only the clicked calendar day, not the whole frequency period', async () => {
+        const task = makeHabit({ habit_frequency_period: 'weekly' });
+        RecurringCompletion.findOne.mockResolvedValue(null);
+        RecurringCompletion.create.mockResolvedValue({ id: 1 });
+
+        const completedAt = new Date('2026-08-05T15:00:00'); // Wednesday
+        await habitService.logCompletion(task, completedAt);
+
+        const { where } = RecurringCompletion.findOne.mock.calls[0][0];
+        const [start, end] = where.completed_at[Op.between];
+
+        expect(start.getDate()).toBe(5);
+        expect(start.getHours()).toBe(0);
+        expect(end.getDate()).toBe(5);
+        expect(end.getHours()).toBe(23);
+    });
+});
+
+describe('HabitService - recalculateStreaks', () => {
+    it('counts habit_total_completions as every logged day, not distinct periods', async () => {
+        const task = makeHabit({ habit_frequency_period: 'weekly' });
+        RecurringCompletion.findAll.mockResolvedValue([
+            makeCompletion('2026-08-05T09:00:00'), // Wed this week
+            makeCompletion('2026-08-04T09:00:00'), // Tue this week
+        ]);
+
+        const updates = await habitService.recalculateStreaks(task);
+
+        expect(updates.habit_total_completions).toBe(2);
     });
 });


### PR DESCRIPTION
## Description

For a habit whose Target Frequency is weekly or monthly, `logCompletion()` only checked whether *any* completion already existed somewhere in the current period (week/month). Once one day in that period was marked done, clicking any other day in the habit's history calendar silently reused the existing completion instead of creating a new one, the click briefly registered in the UI and then reverted.

This makes the day-by-day history calendar effectively non-functional for any non-daily habit: only one day per week/month could ever be marked complete, and it couldn't be changed without first deleting the existing completion.

Fix: check for an existing completion on the exact clicked day instead of anywhere in the period. Frequency period now only affects streak/rate math, as expected, not how many completions can exist.

Also fixed `recalculateStreaks()` (used after deleting a completion) to count `habit_total_completions` as the number of logged days rather than distinct periods, since multiple completions per period are now possible; leaving it as-is would have undercounted the total after any deletion on a weekly/monthly habit.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1421

## Testing

**How did you test this?**

- Added unit tests in `backend/tests/unit/modules/habits/habitService.test.js` covering: creating a completion on a day with none yet, reusing an existing completion when the same day is logged twice, allowing a second completion in the same week on a different day (the reported bug), confirming the day-level (not period-level) query window, and `recalculateStreaks()` counting total completions per day.
- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
