### PR TITLE
fix: subtasks inherit access from parent project

### DIFF
--- a/backend/modules/caldav/api/calendar-controller.js
+++ b/backend/modules/caldav/api/calendar-controller.js
@@ -1,4 +1,4 @@
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const CalendarRepository = require('../repositories/calendar-repository');
 const SyncStateRepository = require('../repositories/sync-state-repository');
 const { uid } = require('../../../utils/uid');

--- a/backend/modules/caldav/api/remote-calendar-controller.js
+++ b/backend/modules/caldav/api/remote-calendar-controller.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const { URL } = require('url');
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const RemoteCalendarRepository = require('../repositories/remote-calendar-repository');
 const CalendarRepository = require('../repositories/calendar-repository');
 const encryptionService = require('../services/encryption-service');

--- a/backend/modules/caldav/api/sync-controller.js
+++ b/backend/modules/caldav/api/sync-controller.js
@@ -1,4 +1,4 @@
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const syncScheduler = require('../services/sync-scheduler');
 const syncEngine = require('../sync/sync-engine');
 const MergePhase = require('../sync/merge-phase');

--- a/backend/modules/caldav/sync/merge-phase.js
+++ b/backend/modules/caldav/sync/merge-phase.js
@@ -1,4 +1,4 @@
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const logger = require('../../../services/logService');
 const { Task } = require('../../../models');
 const SyncStateRepository = require('../repositories/sync-state-repository');

--- a/backend/modules/caldav/sync/pull-phase.js
+++ b/backend/modules/caldav/sync/pull-phase.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 const { parseStringPromise } = require('xml2js');
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const logger = require('../../../services/logService');
 const RemoteCalendarRepository = require('../repositories/remote-calendar-repository');
 const { parseVTODOToTask } = require('../icalendar/vtodo-parser');

--- a/backend/modules/caldav/sync/push-phase.js
+++ b/backend/modules/caldav/sync/push-phase.js
@@ -1,5 +1,5 @@
 const axios = require('axios');
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const logger = require('../../../services/logService');
 const { Task } = require('../../../models');
 const SyncStateRepository = require('../repositories/sync-state-repository');

--- a/backend/modules/caldav/sync/sync-engine.js
+++ b/backend/modules/caldav/sync/sync-engine.js
@@ -1,4 +1,4 @@
-const { AppError } = require('../../../shared/errors/AppError');
+const { AppError } = require('../../../shared/errors');
 const logger = require('../../../services/logService');
 const PullPhase = require('./pull-phase');
 const MergePhase = require('./merge-phase');

--- a/backend/modules/tasks/operations/subtasks.js
+++ b/backend/modules/tasks/operations/subtasks.js
@@ -59,11 +59,19 @@ async function createSubtasks(parentTaskId, subtasks, userId) {
     );
     const maxOrder = existingSubtasks[0]?.order ?? 0;
 
+    // Inherit the parent's project so a subtask stays reachable through the
+    // same project-sharing checks as its parent task, instead of only being
+    // accessible to whoever happened to create it (#1425).
+    const parent = await taskRepository.findById(parentTaskId, {
+        attributes: ['id', 'project_id'],
+    });
+
     const subtasksData = subtasks
         .filter((subtask) => subtask.name && subtask.name.trim())
         .map((subtask, index) => ({
             name: subtask.name.trim(),
             parent_task_id: parentTaskId,
+            project_id: parent ? parent.project_id : null,
             user_id: userId,
             priority: parsePriority(subtask.priority) || Task.PRIORITY.LOW,
             status: parseStatus(subtask.status),

--- a/backend/services/permissionsService.js
+++ b/backend/services/permissionsService.js
@@ -45,16 +45,32 @@ async function getAccess(userId, resourceType, resourceUid) {
     } else if (resourceType === 'task') {
         const t = await Task.findOne({
             where: { uid: resourceUid },
-            attributes: ['user_id', 'project_id'],
+            attributes: ['user_id', 'project_id', 'parent_task_id'],
             raw: true,
         });
         if (!t) return ACCESS.NONE;
         if (t.user_id === userId) return ACCESS.RW;
 
+        // Subtasks don't always carry their own project_id, so walk up the
+        // parent chain to find the project (or an owning ancestor) they
+        // belong to (#1425).
+        let projectId = t.project_id;
+        let current = t;
+        while (!projectId && current.parent_task_id) {
+            current = await Task.findOne({
+                where: { id: current.parent_task_id },
+                attributes: ['user_id', 'project_id', 'parent_task_id'],
+                raw: true,
+            });
+            if (!current) break;
+            if (current.user_id === userId) return ACCESS.RW;
+            projectId = current.project_id;
+        }
+
         // Check if user has access through the parent project
-        if (t.project_id) {
+        if (projectId) {
             const project = await Project.findOne({
-                where: { id: t.project_id },
+                where: { id: projectId },
                 attributes: ['uid'],
                 raw: true,
             });

--- a/backend/tests/integration/permissions-tasks.test.js
+++ b/backend/tests/integration/permissions-tasks.test.js
@@ -1,6 +1,6 @@
 const request = require('supertest');
 const app = require('../../app');
-const { Task, Project } = require('../../models');
+const { Task, Project, Permission } = require('../../models');
 const { createTestUser } = require('../helpers/testUtils');
 
 describe('Tasks Permissions', () => {
@@ -148,5 +148,53 @@ describe('Tasks Permissions', () => {
             (task) => task.id
         );
         expect(suggestedTaskIds).not.toContain(otherTask.id);
+    });
+
+    describe('Subtask access via shared project (#1425)', () => {
+        it('should let a project collaborator open a subtask created by another collaborator', async () => {
+            const project = await Project.create({
+                name: 'Shared Project',
+                user_id: user.id,
+            });
+            await Permission.create({
+                user_id: otherUser.id,
+                resource_type: 'project',
+                resource_uid: project.uid,
+                access_level: 'rw',
+                propagation: 'direct',
+                granted_by_user_id: user.id,
+            });
+
+            const parentTask = await Task.create({
+                name: 'Parent Task',
+                user_id: user.id,
+                project_id: project.id,
+            });
+
+            const createRes = await agent
+                .patch(`/api/task/${parentTask.uid}`)
+                .send({
+                    subtasks: [
+                        { name: 'Subtask', isNew: true, status: 'not_started' },
+                    ],
+                });
+            expect(createRes.status).toBe(200);
+            expect(createRes.body.subtasks).toHaveLength(1);
+            const subtaskUid = createRes.body.subtasks[0].uid;
+
+            const otherAgent = request.agent(app);
+            await otherAgent
+                .post('/api/login')
+                .send({ email: otherUser.email, password: 'password123' });
+
+            const getRes = await otherAgent.get(`/api/task/${subtaskUid}`);
+            expect(getRes.status).toBe(200);
+            expect(getRes.body.uid).toBe(subtaskUid);
+
+            const deleteRes = await otherAgent.delete(
+                `/api/task/${subtaskUid}`
+            );
+            expect(deleteRes.status).toBe(200);
+        });
     });
 });

--- a/backend/tests/unit/services/permissionsService.test.js
+++ b/backend/tests/unit/services/permissionsService.test.js
@@ -159,6 +159,91 @@ describe('permissionsService', () => {
             expect(access).toBe('ro');
         });
 
+        it('should inherit subtask access from parent project permission even when the subtask has no project_id (#1425)', async () => {
+            const project = await Project.create({
+                name: 'P1',
+                user_id: owner.id,
+            });
+            const parentTask = await Task.create({
+                name: 'Parent',
+                user_id: owner.id,
+                project_id: project.id,
+            });
+            // Subtasks created before the #1425 fix (or through any path that
+            // doesn't propagate project_id) have a null project_id.
+            const subtask = await Task.create({
+                name: 'Sub',
+                user_id: owner.id,
+                parent_task_id: parentTask.id,
+                project_id: null,
+            });
+            await Permission.create({
+                user_id: otherUser.id,
+                resource_type: 'project',
+                resource_uid: project.uid,
+                access_level: 'rw',
+                propagation: 'direct',
+                granted_by_user_id: owner.id,
+            });
+
+            const access = await getAccess(otherUser.id, 'task', subtask.uid);
+            expect(access).toBe('rw');
+        });
+
+        it('should walk multiple levels of parent_task_id to find the project', async () => {
+            const project = await Project.create({
+                name: 'P1',
+                user_id: owner.id,
+            });
+            const parentTask = await Task.create({
+                name: 'Parent',
+                user_id: owner.id,
+                project_id: project.id,
+            });
+            const subtask = await Task.create({
+                name: 'Sub',
+                user_id: owner.id,
+                parent_task_id: parentTask.id,
+                project_id: null,
+            });
+            const subSubtask = await Task.create({
+                name: 'SubSub',
+                user_id: owner.id,
+                parent_task_id: subtask.id,
+                project_id: null,
+            });
+            await Permission.create({
+                user_id: otherUser.id,
+                resource_type: 'project',
+                resource_uid: project.uid,
+                access_level: 'ro',
+                propagation: 'direct',
+                granted_by_user_id: owner.id,
+            });
+
+            const access = await getAccess(
+                otherUser.id,
+                'task',
+                subSubtask.uid
+            );
+            expect(access).toBe('ro');
+        });
+
+        it('should return none for a subtask with no project anywhere in its chain', async () => {
+            const parentTask = await Task.create({
+                name: 'Parent',
+                user_id: owner.id,
+            });
+            const subtask = await Task.create({
+                name: 'Sub',
+                user_id: owner.id,
+                parent_task_id: parentTask.id,
+            });
+
+            const access = await getAccess(otherUser.id, 'task', subtask.uid);
+            expect(access).toBe('none');
+        });
+
         // --- Notes ---
 
         it('should return rw for note owner', async () => {


### PR DESCRIPTION
## Description

Subtasks are plain `Task` rows with `parent_task_id` set, but they were created without a `project_id`. Authorization for `GET /api/task/:uid` and `DELETE /api/task/:uid` inherits access from a task's parent project, but only when the row's own `project_id` is populated, so that inheritance path silently broke for every subtask and fell back to "you must be the creator." A collaborator with admin/rw access to the shared project could still be denied on a subtask created by someone else, matching the reported "Failed to delete task" error and the broken open view.

- `createSubtasks()` now copies the parent task's `project_id` onto every new subtask, so newly created subtasks stay in sync with their parent going forward.
- `permissionsService.getAccess()` now walks up the `parent_task_id` chain to resolve the owning project (or an owning ancestor) whenever a task's own `project_id` is missing. This fixes already-existing orphaned subtasks live, without needing a data migration.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1425

## Testing

**How did you test this?**

- Added unit tests in `permissionsService.test.js` covering subtask access inheritance through the parent chain (including multi-level nesting and the "no project anywhere in the chain" case).
- Added an integration test in `permissions-tasks.test.js` reproducing the exact issue scenario: a project owner shares a project with rw access, creates a subtask, and the collaborator can now open (`GET`) and delete (`DELETE`) that subtask.
- `npm run pre-push` passes.

## Checklist

- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests updated
