### PR TITLE
fix: persist subtask status changes to the backend (#1420)

### DIFF
--- a/frontend/components/Task/TaskDetails.tsx
+++ b/frontend/components/Task/TaskDetails.tsx
@@ -720,15 +720,37 @@ const TaskDetails: React.FC = () => {
     }, [task?.parent_task?.uid]);
 
     const handleSubtaskUpdate = async (updatedSubtask: Task) => {
-        const taskIndex = tasksStore.tasks.findIndex((t: Task) => t.uid === uid);
-        if (taskIndex >= 0) {
-            const storeTask = tasksStore.tasks[taskIndex];
-            const updatedSubtasks = (storeTask.subtasks || []).map((s: Task) =>
-                s.id === updatedSubtask.id ? updatedSubtask : s
+        if (!updatedSubtask.uid) return;
+
+        try {
+            const savedSubtask = await updateTask(
+                updatedSubtask.uid,
+                updatedSubtask
             );
-            const updatedTasks = [...tasksStore.tasks];
-            updatedTasks[taskIndex] = { ...storeTask, subtasks: updatedSubtasks };
-            tasksStore.setTasks(updatedTasks);
+
+            const taskIndex = tasksStore.tasks.findIndex(
+                (t: Task) => t.uid === uid
+            );
+            if (taskIndex >= 0) {
+                const storeTask = tasksStore.tasks[taskIndex];
+                const updatedSubtasks = (storeTask.subtasks || []).map(
+                    (s: Task) =>
+                        s.id === savedSubtask.id
+                            ? { ...s, ...savedSubtask }
+                            : s
+                );
+                const updatedTasks = [...tasksStore.tasks];
+                updatedTasks[taskIndex] = {
+                    ...storeTask,
+                    subtasks: updatedSubtasks,
+                };
+                tasksStore.setTasks(updatedTasks);
+            }
+        } catch (error) {
+            console.error('Error updating subtask:', error);
+            showErrorToast(
+                t('task.statusUpdateError', 'Failed to update status')
+            );
         }
     };
 

--- a/frontend/components/Task/__tests__/TaskDetails.test.tsx
+++ b/frontend/components/Task/__tests__/TaskDetails.test.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TaskDetails from '../TaskDetails';
+
+jest.mock('react-router-dom', () => ({
+    useParams: () => ({ uid: 'task-1' }),
+    useNavigate: () => jest.fn(),
+    useLocation: () => ({ pathname: '/task/task-1', state: {} }),
+}));
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (_key: string, fallback?: string) => fallback ?? _key,
+    }),
+    initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+// dateUtils imports the real i18n singleton (i18next.use(Backend)...) purely
+// for its `language` field; stub it out so requiring TaskDetails doesn't
+// spin up the real i18next/http-backend/language-detector chain.
+jest.mock('../../../i18n', () => ({
+    __esModule: true,
+    default: { language: 'en' },
+}));
+
+jest.mock('../../Shared/ToastContext', () => ({
+    useToast: () => ({
+        showSuccessToast: jest.fn(),
+        showErrorToast: jest.fn(),
+        showUndoToast: jest.fn(),
+    }),
+}));
+
+jest.mock('../../Shared/LoadingScreen', () => ({
+    __esModule: true,
+    default: () => <div data-testid="loading-screen" />,
+}));
+
+jest.mock('../../Shared/ConfirmDialog', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('../../AI/TaskAIInsights', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('../TaskTimeline', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('../../../utils/projectsService', () => ({
+    createProject: jest.fn(),
+}));
+
+jest.mock('../../../utils/attachmentsService', () => ({
+    fetchAttachments: jest.fn().mockResolvedValue([]),
+}));
+
+const mockSubtaskInStore = {
+    id: 2,
+    uid: 'subtask-1',
+    name: 'Subtask A',
+    status: 'not_started',
+    parent_task_id: 1,
+};
+
+const mockParentTaskInStore = {
+    id: 1,
+    uid: 'task-1',
+    name: 'Parent Task',
+    status: 'not_started',
+    priority: 'medium',
+    project_id: null,
+    subtasks: [mockSubtaskInStore],
+};
+
+const mockUpdateTask = jest.fn();
+
+jest.mock('../../../utils/tasksService', () => ({
+    updateTask: (...args: any[]) => mockUpdateTask(...args),
+    deleteTask: jest.fn(),
+    // Deferred lookups (not `.mockResolvedValue(mockParentTaskInStore)`) so
+    // this factory doesn't dereference the outer consts before they're
+    // initialized - jest.mock factories run as soon as the mocked module is
+    // first required, which happens before this file's own top-level code.
+    fetchTaskByUid: jest.fn(() => Promise.resolve(mockParentTaskInStore)),
+    fetchTaskNextIterations: jest.fn().mockResolvedValue([]),
+    fetchSubtasks: jest.fn(() => Promise.resolve([mockSubtaskInStore])),
+    toggleTaskCompletion: jest.fn(),
+}));
+
+// Stub every TaskDetails/ card except TaskSubtasksCard, which we render
+// interactively so we can trigger the real handleSubtaskUpdate wiring from
+// TaskDetails.tsx - the same path a user hits from the subtask status
+// dropdown.
+jest.mock('../TaskDetails/', () => ({
+    TaskDetailsHeader: () => null,
+    TaskContentCard: () => null,
+    TaskProjectCard: () => null,
+    TaskTagsCard: () => null,
+    TaskSubtasksCard: ({ subtasks, onSubtaskUpdate }: any) => (
+        <div>
+            {subtasks.map((s: any) => (
+                <button
+                    key={s.uid}
+                    onClick={() =>
+                        onSubtaskUpdate({ ...s, status: 'in_progress' })
+                    }
+                >
+                    Change status of {s.name}
+                </button>
+            ))}
+        </div>
+    ),
+    TaskRecurrenceCard: () => null,
+    TaskDueDateCard: () => null,
+    TaskDeferUntilCard: () => null,
+    TaskAttachmentsCard: () => null,
+    TaskAreaCard: () => null,
+    TaskAssignedToCard: () => null,
+    TaskGoalCard: () => null,
+}));
+
+let mockTasksInStore: any[];
+const mockSetTasks = jest.fn((updated: any[]) => {
+    mockTasksInStore = updated;
+});
+
+jest.mock('../../../store/useStore', () => {
+    const mockUseStore: any = (selector: any) =>
+        selector({
+            projectsStore: { projects: [] },
+            tagsStore: {
+                tags: [],
+                hasLoaded: true,
+                isLoading: false,
+                loadTags: jest.fn(),
+            },
+            tasksStore: {
+                get tasks() {
+                    return mockTasksInStore;
+                },
+                setTasks: mockSetTasks,
+            },
+            areasStore: {
+                areas: [],
+                hasLoaded: true,
+                isLoading: false,
+                loadAreas: jest.fn(),
+            },
+            goalsStore: {
+                goals: [],
+                hasLoaded: true,
+                isLoading: false,
+                loadGoals: jest.fn(),
+            },
+            userSettingsStore: { aiAssistantEnabled: false },
+        });
+    mockUseStore.getState = () => ({
+        tasksStore: { tasks: mockTasksInStore, setTasks: mockSetTasks },
+    });
+    return { useStore: mockUseStore };
+});
+
+describe('TaskDetails subtask status updates', () => {
+    beforeEach(() => {
+        mockTasksInStore = [
+            {
+                ...mockParentTaskInStore,
+                subtasks: [{ ...mockSubtaskInStore }],
+            },
+        ];
+        mockUpdateTask.mockReset();
+        mockUpdateTask.mockResolvedValue({
+            ...mockSubtaskInStore,
+            status: 'in_progress',
+        });
+        mockSetTasks.mockClear();
+    });
+
+    it('persists a subtask status change via the API instead of only updating local state', async () => {
+        render(<TaskDetails />);
+
+        const button = await screen.findByText('Change status of Subtask A');
+        fireEvent.click(button);
+
+        // Regression guard for #1420: changing a subtask's status must PATCH
+        // the backend, not just mutate the in-memory tasksStore - otherwise
+        // the change is lost on refresh.
+        await waitFor(() => {
+            expect(mockUpdateTask).toHaveBeenCalledWith(
+                'subtask-1',
+                expect.objectContaining({ status: 'in_progress' })
+            );
+        });
+    });
+
+    it('reflects the server-saved subtask in the tasks store after the update', async () => {
+        render(<TaskDetails />);
+
+        const button = await screen.findByText('Change status of Subtask A');
+        fireEvent.click(button);
+
+        await waitFor(() => {
+            const lastCall =
+                mockSetTasks.mock.calls[mockSetTasks.mock.calls.length - 1];
+            const updatedTasks = lastCall?.[0];
+            const updatedParent = updatedTasks?.find(
+                (t: any) => t.uid === 'task-1'
+            );
+            expect(updatedParent?.subtasks?.[0]?.status).toBe('in_progress');
+        });
+    });
+});


### PR DESCRIPTION
## Description

Changing a subtask's status from the status dropdown on the Task Details page only updated the in-memory tasksStore (`handleSubtaskUpdate` in `TaskDetails.tsx`) - it never issued a PATCH request to the backend. The change appeared to apply immediately, since the subtask list rendered on that page is derived from the same store, but was lost on refresh because the backend never actually received it.

`handleSubtaskUpdate` now calls `updateTask()` to persist the change before merging the server response back into the store, matching the pattern already used for the parent task's own status updates (and every other field update) in this file.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1420

## Testing

**How did you test this?**

- Added `frontend/components/Task/__tests__/TaskDetails.test.tsx`, which mounts `TaskDetails` and simulates a subtask status change through the same `onSubtaskUpdate` wiring the UI uses. It asserts `updateTask` (the API PATCH) is called with the new status, and that the merged store reflects the server response. Verified the new test fails against the pre-fix code and passes with the fix.
- `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)