### PR TITLE
fix(tasks): allow assigning tasks to other users in shared projects

### DIFF
--- a/backend/modules/people/controller.js
+++ b/backend/modules/people/controller.js
@@ -2,6 +2,7 @@
 
 const peopleService = require('./service');
 const { getAuthenticatedUserId } = require('../../utils/request-utils');
+const { extractUidFromSlug } = require('../../utils/slug-utils');
 const { UnauthorizedError } = require('../../shared/errors');
 
 function requireUserId(req) {
@@ -21,6 +22,22 @@ const peopleController = {
                 relationship_type,
                 unlinked,
             });
+            res.json({ people });
+        } catch (err) {
+            next(err);
+        }
+    },
+
+    async listAssignable(req, res, next) {
+        try {
+            const userId = requireUserId(req);
+            const projectUid = extractUidFromSlug(req.params.uidSlug);
+            const { archived, sort, relationship_type, unlinked } = req.query;
+            const people = await peopleService.getAssignableForProject(
+                userId,
+                projectUid,
+                { archived, sort, relationship_type, unlinked }
+            );
             res.json({ people });
         } catch (err) {
             next(err);

--- a/backend/modules/people/repository.js
+++ b/backend/modules/people/repository.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Person, Task } = require('../../models');
+const { Person, Task, Project, Permission } = require('../../models');
 const { Op } = require('sequelize');
 
 class PeopleRepository {
@@ -59,6 +59,36 @@ class PeopleRepository {
     async findByLinkedUserId(ownerUserId, linkedUserId) {
         return Person.findOne({
             where: { user_id: ownerUserId, linked_user_id: linkedUserId },
+        });
+    }
+
+    async findProjectOwnerUserId(projectUid) {
+        const project = await Project.findOne({
+            where: { uid: projectUid },
+            attributes: ['user_id'],
+            raw: true,
+        });
+        return project ? project.user_id : null;
+    }
+
+    async findProjectCollaboratorUserIds(projectUid) {
+        const rows = await Permission.findAll({
+            where: {
+                resource_type: 'project',
+                resource_uid: projectUid,
+                propagation: 'direct',
+            },
+            attributes: ['user_id'],
+            raw: true,
+        });
+        return Array.from(new Set(rows.map((r) => r.user_id)));
+    }
+
+    async findSelfPeopleByUserIds(userIds) {
+        if (!userIds.length) return [];
+        return Person.findAll({
+            where: { linked_user_id: userIds },
+            order: [['name', 'ASC']],
         });
     }
 }

--- a/backend/modules/people/routes.js
+++ b/backend/modules/people/routes.js
@@ -3,6 +3,22 @@
 const express = require('express');
 const router = express.Router();
 const peopleController = require('./controller');
+const { hasAccess } = require('../../middleware/authorize');
+const projectsService = require('../projects/service');
+
+// People assignable to tasks in a project: the caller's own people plus the
+// self-person of the project owner and any collaborators it's shared with.
+// Requires at least read access to the project.
+router.get(
+    '/projects/:uidSlug/assignable-people',
+    hasAccess(
+        'ro',
+        'project',
+        (req) => projectsService.getProjectUidIfExists(req.params.uidSlug),
+        { notFoundMessage: 'Project not found' }
+    ),
+    peopleController.listAssignable
+);
 
 router.get('/people', peopleController.list);
 router.get('/people/:uid', peopleController.getOne);

--- a/backend/modules/people/service.js
+++ b/backend/modules/people/service.js
@@ -14,6 +14,37 @@ class PeopleService {
         return peopleRepository.findAllByUser(userId, filters);
     }
 
+    // Own people plus the self-person of the project owner and any
+    // collaborators the project is shared with, so a task in a shared
+    // project can be assigned to anyone who actually has access to it.
+    async getAssignableForProject(userId, projectUid, filters = {}) {
+        const people = await peopleRepository.findAllByUser(userId, filters);
+
+        const ownerUserId =
+            await peopleRepository.findProjectOwnerUserId(projectUid);
+        if (!ownerUserId) return people;
+
+        const collaboratorUserIds =
+            await peopleRepository.findProjectCollaboratorUserIds(projectUid);
+        const otherUserIds = Array.from(
+            new Set([ownerUserId, ...collaboratorUserIds])
+        ).filter((id) => id !== userId);
+
+        if (!otherUserIds.length) return people;
+
+        const selfPeople =
+            await peopleRepository.findSelfPeopleByUserIds(otherUserIds);
+        const existingUids = new Set(people.map((p) => p.uid));
+        const merged = [...people];
+        for (const person of selfPeople) {
+            if (!existingUids.has(person.uid)) {
+                merged.push(person);
+                existingUids.add(person.uid);
+            }
+        }
+        return merged;
+    }
+
     async getUnlinked(userId) {
         return peopleRepository.findAllByUser(userId, {
             archived: false,

--- a/backend/tests/integration/people-assignable.test.js
+++ b/backend/tests/integration/people-assignable.test.js
@@ -1,0 +1,96 @@
+const request = require('supertest');
+const app = require('../../app');
+const { sequelize } = require('../../models');
+const { createTestUser } = require('../helpers/testUtils');
+const peopleService = require('../../modules/people/service');
+
+describe('Assignable people for shared projects', () => {
+    let ownerUser, sharedUser, outsiderUser;
+    let ownerAgent, sharedUserAgent, outsiderAgent;
+    let project;
+
+    beforeEach(async () => {
+        ownerUser = await createTestUser({
+            email: `owner_${Date.now()}@test.com`,
+            name: 'Owner',
+            timezone: 'UTC',
+        });
+
+        sharedUser = await createTestUser({
+            email: `shared_${Date.now()}@test.com`,
+            name: 'Shared',
+            timezone: 'UTC',
+        });
+
+        outsiderUser = await createTestUser({
+            email: `outsider_${Date.now()}@test.com`,
+            name: 'Outsider',
+            timezone: 'UTC',
+        });
+
+        // In the real app a self-person is created on registration; the
+        // test helper creates users directly, so do it explicitly here.
+        await peopleService.createSelfPerson(ownerUser);
+        await peopleService.createSelfPerson(sharedUser);
+        await peopleService.createSelfPerson(outsiderUser);
+
+        ownerAgent = request.agent(app);
+        sharedUserAgent = request.agent(app);
+        outsiderAgent = request.agent(app);
+
+        await ownerAgent
+            .post('/api/login')
+            .send({ email: ownerUser.email, password: 'password123' });
+        await sharedUserAgent
+            .post('/api/login')
+            .send({ email: sharedUser.email, password: 'password123' });
+        await outsiderAgent
+            .post('/api/login')
+            .send({ email: outsiderUser.email, password: 'password123' });
+
+        const projectResponse = await ownerAgent.post('/api/project').send({
+            name: 'Shared Assignable Project',
+            description: 'Project for assignable-people tests',
+        });
+        project = projectResponse.body;
+
+        await ownerAgent.post('/api/shares').send({
+            resource_type: 'project',
+            resource_uid: project.uid,
+            target_user_email: sharedUser.email,
+            access_level: 'rw',
+        });
+    });
+
+    afterAll(async () => {
+        await sequelize.close();
+    });
+
+    test('owner sees the shared user as an assignable person', async () => {
+        const response = await ownerAgent.get(
+            `/api/projects/${project.uid}/assignable-people`
+        );
+
+        expect(response.status).toBe(200);
+        const names = response.body.people.map((p) => p.name);
+        expect(names).toContain('Shared');
+    });
+
+    test('shared user sees the owner as an assignable person', async () => {
+        const response = await sharedUserAgent.get(
+            `/api/projects/${project.uid}/assignable-people`
+        );
+
+        expect(response.status).toBe(200);
+        const names = response.body.people.map((p) => p.name);
+        expect(names).toContain('Owner');
+    });
+
+    test('user without access to the project is forbidden', async () => {
+        const response = await outsiderAgent.get(
+            `/api/projects/${project.uid}/assignable-people`
+        );
+
+        expect(response.status).toBe(403);
+    });
+});

--- a/frontend/components/Task/TaskDetails/TaskAssignedToCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskAssignedToCard.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { UserIcon } from '@heroicons/react/24/outline';
 import { Task } from '../../../entities/Task';
 import { Person } from '../../../entities/Person';
-import { fetchPeople } from '../../../utils/peopleService';
+import { fetchPeople, fetchAssignablePeopleForProject } from '../../../utils/peopleService';
 import PersonDropdown from '../../Shared/PersonDropdown';
 
 interface TaskAssignedToCardProps {
@@ -14,10 +14,13 @@ const TaskAssignedToCard: React.FC<TaskAssignedToCardProps> = ({ task, onAssign 
     const [people, setPeople] = useState<Person[]>([]);
 
     useEffect(() => {
-        fetchPeople().catch(console.error).then((p) => {
+        const load = task.project_uid
+            ? fetchAssignablePeopleForProject(task.project_uid)
+            : fetchPeople();
+        load.catch(console.error).then((p) => {
             if (p) setPeople(p);
         });
-    }, []);
+    }, [task.project_uid]);
 
     // Merge the embedded AssignedTo person (from shared tasks) with the user's own people
     // so assignees from other users' person records are visible

--- a/frontend/utils/peopleService.ts
+++ b/frontend/utils/peopleService.ts
@@ -25,6 +25,32 @@ export const fetchPeople = async (params: {
     return data.people;
 };
 
+export const fetchAssignablePeopleForProject = async (
+    projectUid: string,
+    params: {
+        archived?: boolean;
+        sort?: string;
+        relationship_type?: string;
+        unlinked?: boolean;
+    } = {}
+): Promise<Person[]> => {
+    const query = new URLSearchParams();
+    if (params.archived !== undefined) query.set('archived', String(params.archived));
+    if (params.sort) query.set('sort', params.sort);
+    if (params.relationship_type) query.set('relationship_type', params.relationship_type);
+    if (params.unlinked) query.set('unlinked', 'true');
+
+    const path = `projects/${projectUid}/assignable-people`;
+    const url = query.toString() ? `${path}?${query.toString()}` : path;
+    const response = await fetch(getApiPath(url), {
+        credentials: 'include',
+        headers: { Accept: 'application/json' },
+    });
+    await handleAuthResponse(response, 'Failed to fetch assignable people.');
+    const data = await response.json();
+    return data.people;
+};
+
 export const fetchPersonByUid = async (uid: string): Promise<Person> => {
     const response = await fetch(getApiPath(`people/${uid}`), {
         credentials: 'include',


### PR DESCRIPTION
## Description

In a shared project, the "Assigned To" dropdown only ever showed "Unassigned" and the current user, never the other collaborators the project was shared with.

Root cause: task assignment targets `Person` records (each user has an auto-created "self person"), and the frontend fetched candidates via `GET /api/people`, which is hard-scoped to `where: { user_id: <caller> }`. There was no endpoint that returned "people belonging to everyone with access to this project," so a collaborator's self-person never surfaced as an option.

Fix: add `GET /api/projects/:uid/assignable-people`, which (given at least read access to the project) returns the caller's own people plus the self-person of the project owner and any user the project is shared with. `TaskAssignedToCard` now calls this project-scoped endpoint whenever the task belongs to a project, falling back to the personal `/people` list otherwise.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1419

## Testing

**How did you test this?**

- Added `backend/tests/integration/people-assignable.test.js`: owner sees the shared user as assignable, shared user sees the owner as assignable, and a user with no access to the project gets 403.
- Ran the existing sharing/permission integration suites (`task-edit-shared-project`, `shares`, `permissions-projects`) to confirm no regressions.
- `npx tsc --noEmit` passes.
- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
