### PR TITLE
fix(offline): queue mutations instead of failing when CSRF token fetch is unreachable

### DIFF
--- a/docs/15-pwa.md
+++ b/docs/15-pwa.md
@@ -89,7 +89,8 @@ sync      → replay queued mutations (Background Sync API)
 |---|---|---|
 | Static assets (same-origin, non-API) | cache-first | Serve from `tududi-v1` cache; populate on first network hit |
 | API `GET` `/api/*` | `handleApiGet` | Network-first; on success write to `tududi-api-v1`; on network failure serve stale cache; if no cache return `503 { offline: true }` |
-| API mutations `/api/*` | `handleApiMutation` | Attempt network; if offline queue to IndexedDB, return `202 { queued: true }`; register Background Sync tag `tududi-sync` |
+| API mutations `/api/*` | `handleApiMutation` | Attempt network; if offline queue to IndexedDB, return `202 { queued: true }` with an `X-Tududi-Queued: 1` header; register Background Sync tag `tududi-sync` |
+| Stateless POST endpoints (e.g. `/api/inbox/analyze-text`) | `handleApiNoQueue` | Network-only; on failure return `503 { offline: true }` — never queued, since there's nothing meaningful to replay |
 | Navigation (`mode: navigate`) | inline | Network-first; fall back to cached `/` shell for SPA routing |
 
 ### Cache names
@@ -107,7 +108,9 @@ Mutations that fail due to network error are stored in an IndexedDB database nam
 { id, url, method, headers (auth headers stripped), body, sessionId, timestamp }
 ```
 
-The Background Sync API fires the `tududi-sync` event when connectivity returns. The SW replays each entry in order, deleting successfully-replayed entries from the store. After all replays it sends `{ type: 'SYNC_COMPLETE' }` to all open windows; `frontend/index.tsx` handles this by calling SWR's global `mutate(() => true)` to revalidate all cached data.
+The Background Sync API fires the `tududi-sync` event when connectivity returns. Before replaying each entry the SW re-fetches a fresh CSRF token (`GET /api/csrf-token`) and overwrites whatever `x-csrf-token`/`X-CSRF-Token` header was captured at queue time — a token fetched while offline (see below) may be missing or stale by replay time, and the session-scoped CSRF secret backing it doesn't rotate, so a freshly-issued token is always valid. If the refresh itself fails, the entry replays with its original header and is left queued for the next sync attempt. The SW replays entries in order, deleting successfully-replayed entries from the store. After all replays it sends `{ type: 'SYNC_COMPLETE' }` to all open windows; `frontend/index.tsx` handles this by calling SWR's global `mutate(() => true)` to revalidate all cached data.
+
+**CSRF tokens while offline:** every mutating request needs a CSRF token, normally fetched via `getCsrfToken()` (`frontend/utils/csrfService.ts`) — itself a `GET`, so it's never queued by the SW. If that fetch fails (e.g. offline), `getCsrfToken()` resolves `''` instead of throwing, so the caller's actual mutating `fetch()` still fires and reaches `handleApiMutation` to be queued, rather than aborting before the request is ever made. Frontend code that receives the synthetic `202` response must check for it (`isQueuedOfflineResponse()` / `handleAuthResponse()` throwing `OfflineQueuedError`, both in `frontend/utils/authUtils.ts`) rather than treating the `{ queued: true }` placeholder body as the real resource.
 
 **Limitation:** Creating tasks offline generates a server-assigned numeric ID on replay. If the queue contains multiple dependent mutations (e.g. create task then update it) the second mutation may reference an ID that didn't exist at queue time. This edge case is tracked alongside the broader id/uid consistency work.
 

--- a/frontend/components/Inbox/InboxItems.tsx
+++ b/frontend/components/Inbox/InboxItems.tsx
@@ -23,6 +23,7 @@ import QuickCaptureInput from './QuickCaptureInput';
 import { createTask } from '../../utils/tasksService';
 import { createProject } from '../../utils/projectsService';
 import { createNote } from '../../utils/notesService';
+import { OfflineQueuedError } from '../../utils/authUtils';
 import { isUrl } from '../../utils/urlService';
 import { fetchAreas } from '../../utils/areasService';
 import { fetchProjects } from '../../utils/projectsService';
@@ -432,8 +433,10 @@ const InboxItems: React.FC = () => {
 
             return createdTask;
         } catch (error) {
-            console.error('Failed to create task:', error);
-            showErrorToast(t('task.createError'));
+            if (!(error instanceof OfflineQueuedError)) {
+                console.error('Failed to create task:', error);
+                showErrorToast(t('task.createError'));
+            }
             throw error;
         } finally {
             if (options.inboxItemUid) {
@@ -455,8 +458,16 @@ const InboxItems: React.FC = () => {
                 inboxItemUid,
                 navigateAfterCreate: false,
             });
-        } catch {
-            // Errors are already reported via toast notifications
+        } catch (error) {
+            if (error instanceof OfflineQueuedError) {
+                showSuccessToast(
+                    t(
+                        'inbox.itemQueuedOffline',
+                        "Saved offline. It'll sync automatically once you're back online."
+                    )
+                );
+            }
+            // Other errors are already reported via toast notifications
         }
     };
 
@@ -529,6 +540,15 @@ const InboxItems: React.FC = () => {
                 }
             }
         } catch (error) {
+            if (error instanceof OfflineQueuedError) {
+                showSuccessToast(
+                    t(
+                        'inbox.itemQueuedOffline',
+                        "Saved offline. It'll sync automatically once you're back online."
+                    )
+                );
+                return;
+            }
             console.error('Failed to create project:', error);
             showErrorToast(t('project.createError'));
         }
@@ -565,6 +585,9 @@ const InboxItems: React.FC = () => {
 
             setIsNoteModalOpen(false);
         } catch (error) {
+            if (error instanceof OfflineQueuedError) {
+                throw error;
+            }
             console.error('Failed to create note:', error);
             showErrorToast(t('note.createError', 'Failed to create note'));
         }

--- a/frontend/components/Inbox/QuickCaptureInput.tsx
+++ b/frontend/components/Inbox/QuickCaptureInput.tsx
@@ -13,7 +13,7 @@ import { Note } from '../../entities/Note';
 import { useToast } from '../Shared/ToastContext';
 import { useTranslation } from 'react-i18next';
 import { createInboxItemWithStore } from '../../utils/inboxService';
-import { isAuthError } from '../../utils/authUtils';
+import { isAuthError, OfflineQueuedError } from '../../utils/authUtils';
 import { createTag } from '../../utils/tagsService';
 import { createProject } from '../../utils/projectsService';
 import {
@@ -1091,6 +1091,20 @@ const QuickCaptureInput = React.forwardRef<
                             }
                             return;
                         } catch (error: any) {
+                            if (error instanceof OfflineQueuedError) {
+                                showSuccessToast(
+                                    t(
+                                        'inbox.itemQueuedOffline',
+                                        "Saved offline. It'll sync automatically once you're back online."
+                                    )
+                                );
+                                setInputText('');
+                                setAnalysisResult(null);
+                                if (inputRef.current) {
+                                    inputRef.current.focus();
+                                }
+                                return;
+                            }
                             if (isAuthError(error)) {
                                 return;
                             }
@@ -1171,6 +1185,20 @@ const QuickCaptureInput = React.forwardRef<
                             }
                             return;
                         } catch (error: any) {
+                            if (error instanceof OfflineQueuedError) {
+                                showSuccessToast(
+                                    t(
+                                        'inbox.itemQueuedOffline',
+                                        "Saved offline. It'll sync automatically once you're back online."
+                                    )
+                                );
+                                setInputText('');
+                                setAnalysisResult(null);
+                                if (inputRef.current) {
+                                    inputRef.current.focus();
+                                }
+                                return;
+                            }
                             console.error(
                                 'Error in note creation flow:',
                                 error
@@ -1193,10 +1221,38 @@ const QuickCaptureInput = React.forwardRef<
                             inputRef.current.focus();
                         }
                     } catch (error) {
+                        if (error instanceof OfflineQueuedError) {
+                            showSuccessToast(
+                                t(
+                                    'inbox.itemQueuedOffline',
+                                    "Saved offline. It'll sync automatically once you're back online."
+                                )
+                            );
+                            setInputText('');
+                            setAnalysisResult(null);
+                            if (inputRef.current) {
+                                inputRef.current.focus();
+                            }
+                            return;
+                        }
                         console.error('Failed to create inbox item:', error);
                         showErrorToast(t('inbox.addError'));
                     }
                 } catch (error) {
+                    if (error instanceof OfflineQueuedError) {
+                        showSuccessToast(
+                            t(
+                                'inbox.itemQueuedOffline',
+                                "Saved offline. It'll sync automatically once you're back online."
+                            )
+                        );
+                        setInputText('');
+                        setAnalysisResult(null);
+                        if (inputRef.current) {
+                            inputRef.current.focus();
+                        }
+                        return;
+                    }
                     console.error('Failed to save:', error);
                     showErrorToast(t('inbox.addError'));
                 } finally {

--- a/frontend/components/Kanban/KanbanBoard.tsx
+++ b/frontend/components/Kanban/KanbanBoard.tsx
@@ -8,6 +8,7 @@ import { Project } from '../../entities/Project';
 import { Tag } from '../../entities/Tag';
 import TaskItem from '../Task/TaskItem';
 import { getCsrfToken } from '../../utils/csrfService';
+import { isQueuedOfflineResponse } from '../../utils/authUtils';
 
 const COLUMN_STATUS: Record<string, number> = {
     not_started: 0,
@@ -208,6 +209,12 @@ const KanbanBoard: React.FC = () => {
                 },
                 body: JSON.stringify(updatedTask),
             });
+            if (isQueuedOfflineResponse(res)) {
+                // Queued for background sync (see public/sw.js) - the body
+                // is a placeholder, not the updated task, so leave local
+                // state as-is rather than merging it in.
+                return;
+            }
             if (res.ok) {
                 const saved = await res.json();
                 setTasks((prev) =>

--- a/frontend/components/Tasks.tsx
+++ b/frontend/components/Tasks.tsx
@@ -21,6 +21,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { getApiPath } from '../config/paths';
 import { getCsrfToken } from '../utils/csrfService';
+import { isQueuedOfflineResponse } from '../utils/authUtils';
 import { isTaskActive } from '../constants/taskStatus';
 
 const capitalize = (str: string) => str.charAt(0).toUpperCase() + str.slice(1);
@@ -395,6 +396,13 @@ const Tasks: React.FC = () => {
                     body: JSON.stringify(updatedTask),
                 }
             );
+
+            if (isQueuedOfflineResponse(response)) {
+                // Queued for background sync (see public/sw.js) - the body
+                // is a placeholder, not the updated task, so leave local
+                // state as-is rather than merging it in.
+                return;
+            }
 
             if (response.ok) {
                 const updatedTaskFromServer = await response.json();

--- a/frontend/utils/__tests__/authUtils.test.ts
+++ b/frontend/utils/__tests__/authUtils.test.ts
@@ -1,0 +1,79 @@
+import {
+    handleAuthResponse,
+    isQueuedOfflineResponse,
+    OfflineQueuedError,
+} from '../authUtils';
+
+// jsdom has no Response constructor, so stub the parts callers use
+const makeResponse = (
+    status: number,
+    body: unknown,
+    headers: Record<string, string> = {}
+) =>
+    ({
+        ok: status >= 200 && status < 300,
+        status,
+        headers: { get: (key: string) => headers[key] ?? null },
+        json: async () => body,
+    }) as unknown as Response;
+
+describe('isQueuedOfflineResponse', () => {
+    it('is true only when the service worker set the queued marker header', () => {
+        expect(
+            isQueuedOfflineResponse(
+                makeResponse(202, { queued: true }, {
+                    'X-Tududi-Queued': '1',
+                })
+            )
+        ).toBe(true);
+        expect(isQueuedOfflineResponse(makeResponse(200, { id: 1 }))).toBe(
+            false
+        );
+    });
+});
+
+describe('handleAuthResponse', () => {
+    // #1417: a mutation queued for background sync (see handleApiMutation
+    // in public/sw.js) must not be treated as if the placeholder { queued:
+    // true } body were the real created/updated resource.
+    it('throws OfflineQueuedError for a service-worker-queued response', async () => {
+        const response = makeResponse(
+            202,
+            { queued: true, offline: true },
+            { 'X-Tududi-Queued': '1' }
+        );
+
+        await expect(
+            handleAuthResponse(response, 'Failed to create task.')
+        ).rejects.toBeInstanceOf(OfflineQueuedError);
+    });
+
+    it('passes a normal successful response through unchanged', async () => {
+        const response = makeResponse(200, { id: 1 });
+
+        await expect(
+            handleAuthResponse(response, 'Failed to create task.')
+        ).resolves.toBe(response);
+    });
+
+    it('still throws the auth error for a 401', async () => {
+        jest.useFakeTimers();
+        try {
+            const response = makeResponse(401, { error: 'Unauthorized' });
+
+            await expect(
+                handleAuthResponse(response, 'Failed to fetch tasks.')
+            ).rejects.toThrow('Authentication required');
+        } finally {
+            jest.useRealTimers();
+        }
+    });
+
+    it('surfaces the backend error message for other failures', async () => {
+        const response = makeResponse(404, { error: 'Task not found.' });
+
+        await expect(
+            handleAuthResponse(response, 'Failed to fetch task.')
+        ).rejects.toThrow('Task not found.');
+    });
+});

--- a/frontend/utils/__tests__/csrfService.test.ts
+++ b/frontend/utils/__tests__/csrfService.test.ts
@@ -1,0 +1,82 @@
+import { getCsrfToken, clearCsrfToken } from '../csrfService';
+
+// jsdom has no Response constructor, so stub the parts fetch callers use
+const jsonResponse = (status: number, body: unknown) =>
+    ({
+        ok: status >= 200 && status < 300,
+        status,
+        json: async () => body,
+    }) as Response;
+
+describe('getCsrfToken', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        clearCsrfToken();
+        jest.restoreAllMocks();
+    });
+
+    it('fetches and caches the token', async () => {
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(
+                jsonResponse(200, { csrfToken: 'abc123' })
+            ) as jest.Mock;
+
+        await expect(getCsrfToken()).resolves.toBe('abc123');
+        await expect(getCsrfToken()).resolves.toBe('abc123');
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    // #1417: a failed CSRF fetch (e.g. offline) must not block the caller's
+    // own mutating fetch() from ever being dispatched - resolving '' lets
+    // the request still reach the service worker's offline queue instead.
+    it('resolves an empty string instead of rejecting when the network is unreachable', async () => {
+        global.fetch = jest
+            .fn()
+            .mockRejectedValue(new TypeError('Failed to fetch')) as jest.Mock;
+
+        await expect(getCsrfToken()).resolves.toBe('');
+    });
+
+    it('resolves an empty string when the server responds with an error status', async () => {
+        global.fetch = jest
+            .fn()
+            .mockResolvedValue(
+                jsonResponse(503, { error: 'Offline', offline: true })
+            ) as jest.Mock;
+
+        await expect(getCsrfToken()).resolves.toBe('');
+    });
+
+    it('does not retry the network again within the backoff window after a failure', async () => {
+        global.fetch = jest
+            .fn()
+            .mockRejectedValue(new TypeError('Failed to fetch')) as jest.Mock;
+
+        await getCsrfToken();
+        await getCsrfToken();
+
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries immediately once the browser reports connectivity again', async () => {
+        global.fetch = jest
+            .fn()
+            .mockRejectedValue(new TypeError('Failed to fetch')) as jest.Mock;
+
+        await getCsrfToken();
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        window.dispatchEvent(new Event('online'));
+
+        (global.fetch as jest.Mock).mockResolvedValue(
+            jsonResponse(200, { csrfToken: 'xyz789' })
+        );
+
+        await expect(getCsrfToken()).resolves.toBe('xyz789');
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+});

--- a/frontend/utils/__tests__/tasksService.createTask.test.ts
+++ b/frontend/utils/__tests__/tasksService.createTask.test.ts
@@ -1,0 +1,61 @@
+import { createTask } from '../tasksService';
+import { OfflineQueuedError } from '../authUtils';
+import { clearCsrfToken } from '../csrfService';
+
+// jsdom has no Response constructor, so stub the parts fetch callers use
+const jsonResponse = (
+    status: number,
+    body: unknown,
+    headers: Record<string, string> = {}
+) =>
+    ({
+        ok: status >= 200 && status < 300,
+        status,
+        headers: { get: (key: string) => headers[key] ?? null },
+        json: async () => body,
+    }) as Response;
+
+describe('createTask', () => {
+    beforeEach(() => {
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        clearCsrfToken();
+        jest.restoreAllMocks();
+    });
+
+    it('resolves the created task on success', async () => {
+        global.fetch = jest
+            .fn()
+            .mockResolvedValueOnce(jsonResponse(200, { csrfToken: 'tok' })) // GET /csrf-token
+            .mockResolvedValueOnce(
+                jsonResponse(201, { id: 1, uid: 'abc', name: 'Buy milk' })
+            ) as jest.Mock; // POST /task
+
+        await expect(createTask({ name: 'Buy milk' } as any)).resolves.toEqual(
+            { id: 1, uid: 'abc', name: 'Buy milk' }
+        );
+    });
+
+    // #1417: when the network is unavailable, the CSRF fetch degrades
+    // gracefully (see csrfService.test.ts) so the actual POST still fires
+    // and reaches the service worker's offline queue instead of failing
+    // before ever being dispatched.
+    it('throws OfflineQueuedError when the request was queued for offline sync', async () => {
+        global.fetch = jest
+            .fn()
+            .mockRejectedValueOnce(new TypeError('Failed to fetch')) // GET /csrf-token fails offline
+            .mockResolvedValueOnce(
+                jsonResponse(
+                    202,
+                    { queued: true, offline: true },
+                    { 'X-Tududi-Queued': '1' }
+                )
+            ) as jest.Mock; // POST /task queued by the service worker
+
+        await expect(createTask({ name: 'Buy milk' } as any)).rejects.toBeInstanceOf(
+            OfflineQueuedError
+        );
+    });
+});

--- a/frontend/utils/authUtils.ts
+++ b/frontend/utils/authUtils.ts
@@ -25,12 +25,32 @@ export const getPostHeadersWithCsrf = async (): Promise<
     };
 };
 
+// Thrown when a mutation was queued for background sync instead of
+// reaching the server - see handleApiMutation in public/sw.js. Callers
+// that care about the real created/updated resource should catch this
+// separately rather than treating the queued placeholder body as the
+// resource itself.
+export class OfflineQueuedError extends Error {
+    constructor(
+        message = 'This action was saved offline and will sync automatically.'
+    ) {
+        super(message);
+        this.name = 'OfflineQueuedError';
+    }
+}
+
+export const isQueuedOfflineResponse = (response: Response): boolean =>
+    response.headers.get('X-Tududi-Queued') === '1';
+
 let isRedirecting = false;
 
 export const handleAuthResponse = async (
     response: Response,
     errorMessage: string
 ): Promise<Response> => {
+    if (isQueuedOfflineResponse(response)) {
+        throw new OfflineQueuedError();
+    }
     if (!response.ok) {
         if (response.status === 401) {
             if (window.location.pathname !== '/login' && !isRedirecting) {

--- a/frontend/utils/csrfService.ts
+++ b/frontend/utils/csrfService.ts
@@ -3,9 +3,35 @@ import { getApiPath } from '../config/paths';
 let csrfToken: string | null = null;
 let tokenPromise: Promise<string> | null = null;
 
+// If the last fetch attempt failed (typically because the device is
+// offline), don't hammer the network again on every subsequent call -
+// e.g. keystroke-triggered requests can retry this dozens of times a
+// minute. Back off briefly and retry immediately once the browser
+// reports connectivity again.
+let lastFailureAt: number | null = null;
+const FAILURE_BACKOFF_MS = 4000;
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('online', () => {
+        lastFailureAt = null;
+    });
+}
+
+// Mutations must still be attempted even when a CSRF token can't be
+// fetched (e.g. offline): the caller's own fetch() needs to fire so the
+// service worker's offline queue (see public/sw.js) can catch and queue
+// it. Resolving '' instead of rejecting lets every caller of this
+// function proceed rather than aborting before the mutation is issued.
 export const getCsrfToken = async (): Promise<string> => {
     if (csrfToken) {
         return csrfToken;
+    }
+
+    if (
+        lastFailureAt !== null &&
+        Date.now() - lastFailureAt < FAILURE_BACKOFF_MS
+    ) {
+        return '';
     }
 
     if (tokenPromise) {
@@ -28,7 +54,9 @@ export const getCsrfToken = async (): Promise<string> => {
         })
         .catch((error) => {
             tokenPromise = null;
-            throw error;
+            lastFailureAt = Date.now();
+            console.warn('Unable to fetch CSRF token, proceeding without one:', error);
+            return '';
         });
 
     return tokenPromise;
@@ -37,6 +65,7 @@ export const getCsrfToken = async (): Promise<string> => {
 export const clearCsrfToken = (): void => {
     csrfToken = null;
     tokenPromise = null;
+    lastFailureAt = null;
 };
 
 export const fetchWithCsrf = async (

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -808,6 +808,7 @@
     "captureThought": "Capture a thought…",
     "saveToInbox": "Save to Inbox",
     "itemAdded": "Item added to inbox",
+    "itemQueuedOffline": "Saved offline. It'll sync automatically once you're back online.",
     "itemProcessed": "Item processed",
     "itemDeleted": "Item deleted",
     "itemUpdated": "Item updated",

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,6 +2,11 @@ const CACHE_VERSION = 'tududi-v1';
 const API_CACHE = 'tududi-api-v1';
 const SYNC_QUEUE = 'tududi-sync-queue';
 
+// Non-GET endpoints with nothing worth replaying later (stateless reads
+// that happen to use a POST body). Queuing these would waste storage and
+// hand callers a stale/synthetic result instead of a real one.
+const NO_QUEUE_PATHS = ['/api/inbox/analyze-text'];
+
 // Set via SESSION_UPDATE message from the client after login.
 // Used to tag queued mutations and detect cross-principal replays.
 let sessionUserId = null;
@@ -84,6 +89,8 @@ self.addEventListener('fetch', (event) => {
     if (url.pathname.startsWith('/api/')) {
         if (request.method === 'GET') {
             event.respondWith(handleApiGet(request));
+        } else if (NO_QUEUE_PATHS.some((p) => url.pathname.startsWith(p))) {
+            event.respondWith(handleApiNoQueue(request));
         } else {
             event.respondWith(handleApiMutation(request));
         }
@@ -153,6 +160,22 @@ async function handleApiGet(request) {
     }
 }
 
+// ─── API calls that are never queued (stateless, nothing to replay) ──────────
+
+async function handleApiNoQueue(request) {
+    try {
+        return await fetch(request);
+    } catch {
+        return new Response(
+            JSON.stringify({ error: 'Offline', offline: true }),
+            {
+                status: 503,
+                headers: { 'Content-Type': 'application/json' },
+            }
+        );
+    }
+}
+
 // ─── API Mutations: queue when offline, replay on sync ───────────────────────
 
 async function handleApiMutation(request) {
@@ -164,7 +187,10 @@ async function handleApiMutation(request) {
             JSON.stringify({ queued: true, offline: true }),
             {
                 status: 202,
-                headers: { 'Content-Type': 'application/json' },
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Tududi-Queued': '1',
+                },
             }
         );
     }
@@ -215,6 +241,32 @@ self.addEventListener('sync', (event) => {
     }
 });
 
+// Entries may have been queued with no CSRF token (getCsrfToken()
+// degrades to '' offline - see frontend/utils/csrfService.ts) or with one
+// that's gone stale by the time we're back online. The Background Sync
+// event firing implies connectivity, so fetch a fresh one and overwrite
+// whatever the entry captured before replaying. Falls back to the
+// entry's original headers if the refresh itself fails, so a flaky
+// reconnect doesn't drop the whole batch - the per-entry try/catch below
+// leaves it queued for the next sync either way.
+async function refreshCsrfHeader(headers) {
+    const csrfKey = Object.keys(headers).find(
+        (key) => key.toLowerCase() === 'x-csrf-token'
+    );
+    if (!csrfKey) return headers;
+
+    try {
+        const response = await fetch('/api/csrf-token', {
+            credentials: 'include',
+        });
+        if (!response.ok) return headers;
+        const { csrfToken } = await response.json();
+        return { ...headers, [csrfKey]: csrfToken };
+    } catch {
+        return headers;
+    }
+}
+
 async function replayQueuedRequests() {
     const db = await openQueueDb();
     const tx = db.transaction(SYNC_QUEUE, 'readonly');
@@ -234,9 +286,10 @@ async function replayQueuedRequests() {
         }
 
         try {
+            const headers = await refreshCsrfHeader(entry.headers);
             const response = await fetch(entry.url, {
                 method: entry.method,
-                headers: entry.headers,
+                headers,
                 body: entry.body || undefined,
             });
             if (response.ok) {


### PR DESCRIPTION
## Description

When offline, every mutating request (create task, create inbox item, create project, etc.) needs a CSRF token first. That token fetch is a plain `GET /api/csrf-token`, which the service worker's offline queue never intercepts for queuing (only non-GET requests get queued). When it fails offline, `getCsrfToken()` threw *before* the actual mutating `fetch()` was ever constructed, so the mutation never reached the service worker's `handleApiMutation` handler at all - the offline queue was bypassed entirely and the user just got a hard error, instead of the "queued and synced later" experience `docs/15-pwa.md` promises.

This PR makes the CSRF fetch degrade gracefully instead of blocking dispatch, makes the service worker's synthetic "queued" response self-identifying so callers don't corrupt state by treating its placeholder body as the real resource, and refreshes the CSRF token when the service worker replays queued mutations later (a token captured while offline may be empty or stale by replay time).

**Changes:**
- `csrfService.ts`: `getCsrfToken()` resolves `''` instead of rejecting on fetch failure, with a short backoff so repeated calls (e.g. keystrokes triggering inbox text analysis) don't hammer the network while offline. Resets instantly on the browser's `online` event.
- `authUtils.ts`: `handleAuthResponse()` throws a new `OfflineQueuedError` for the service worker's synthetic `202 {queued:true}` response instead of letting it pass through as if it were the real created/updated resource.
- `sw.js`: tags the queued response with an `X-Tududi-Queued` header, refreshes the CSRF token before replaying each queued mutation, and stops queuing `/api/inbox/analyze-text` (a stateless read-only call that has nothing useful to replay).
- `Tasks.tsx` / `KanbanBoard.tsx`: stop merging the queued placeholder body into task state on task update (this was corrupting task fields once mutations started reaching the service worker - plausibly the "blank page" symptom also mentioned in the issue).
- `InboxItems.tsx` / `QuickCaptureInput.tsx`: show a "saved offline, will sync automatically" toast instead of an error toast when task/note/project/inbox-item creation via Quick Capture gets queued.

**Known scope boundary:** roughly three dozen other mutation call sites across the app check `response.ok` manually instead of going through `handleAuthResponse` (CalDAV, backups, API keys, habits, goals, templates, views, shares, profile, etc.). These aren't given bespoke "queued" UX in this PR - they fall through to their existing generic error handling on a queued response. This isn't a regression (they already errored on any offline mutation before this fix), and the mutation now actually reaches the service worker and gets synced regardless of what toast is shown. Extending friendly "queued" messaging everywhere is left as a follow-up.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1417

## Testing

**How did you test this?**

- Added unit tests for `getCsrfToken`'s graceful-degrade/backoff behavior, `handleAuthResponse`'s new `OfflineQueuedError`, and an integration test for `createTask` asserting the error bubbles up for the synthetic queued response.
- `npm run frontend:test` - all 97 tests pass.
- `npx tsc --noEmit` - clean.
- Manual verification: production build, DevTools → Network → Offline, Quick Capture a task/note/inbox item - each now shows a "saved offline" toast and the entry appears in IndexedDB's `tududi-offline/tududi-sync-queue`; going back online and triggering Background Sync replays and clears the queue.
- [x] `npm run pre-push` passes (lint + frontend tests scoped to changed files; no backend files touched by this PR)

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)