### PR TITLE
fix: weekly recurring tasks use user-local weekday instead of UTC day

### DIFF
--- a/backend/modules/mcp/tools/taskTools.js
+++ b/backend/modules/mcp/tools/taskTools.js
@@ -326,12 +326,15 @@ function registerTaskTools(server, context, tools) {
             if (recurrenceType !== 'none' && !dueDateInput) {
                 // Calculate the first occurrence based on the recurrence pattern,
                 // matching the behavior of POST /api/task
-                dueDateInput = calculateInitialDueDate({
-                    recurrence_type: recurrenceType,
-                    recurrence_month_day: params.recurrence_month_day,
-                    recurrence_weekday: params.recurrence_weekday,
-                    recurrence_weekdays: params.recurrence_weekdays,
-                });
+                dueDateInput = calculateInitialDueDate(
+                    {
+                        recurrence_type: recurrenceType,
+                        recurrence_month_day: params.recurrence_month_day,
+                        recurrence_weekday: params.recurrence_weekday,
+                        recurrence_weekdays: params.recurrence_weekdays,
+                    },
+                    context.user.timezone
+                );
             }
             // Normalize to end-of-day in the user's timezone, matching
             // POST /api/task, so a date-only due_date doesn't shift to the
@@ -593,21 +596,24 @@ function registerTaskTools(server, context, tools) {
             ) {
                 // Calculate the first occurrence based on the recurrence pattern,
                 // matching the behavior of PATCH /api/task/:uid
-                const dueDateString = calculateInitialDueDate({
-                    recurrence_type: updates.recurrence_type,
-                    recurrence_month_day:
-                        updates.recurrence_month_day !== undefined
-                            ? updates.recurrence_month_day
-                            : task.recurrence_month_day,
-                    recurrence_weekday:
-                        updates.recurrence_weekday !== undefined
-                            ? updates.recurrence_weekday
-                            : task.recurrence_weekday,
-                    recurrence_weekdays:
-                        updates.recurrence_weekdays !== undefined
-                            ? updates.recurrence_weekdays
-                            : task.recurrence_weekdays,
-                });
+                const dueDateString = calculateInitialDueDate(
+                    {
+                        recurrence_type: updates.recurrence_type,
+                        recurrence_month_day:
+                            updates.recurrence_month_day !== undefined
+                                ? updates.recurrence_month_day
+                                : task.recurrence_month_day,
+                        recurrence_weekday:
+                            updates.recurrence_weekday !== undefined
+                                ? updates.recurrence_weekday
+                                : task.recurrence_weekday,
+                        recurrence_weekdays:
+                            updates.recurrence_weekdays !== undefined
+                                ? updates.recurrence_weekdays
+                                : task.recurrence_weekdays,
+                    },
+                    context.user.timezone
+                );
                 updates.due_date = processDueDateForStorage(
                     dueDateString,
                     context.user.timezone

--- a/backend/modules/tasks/core/builders.js
+++ b/backend/modules/tasks/core/builders.js
@@ -1,3 +1,4 @@
+const moment = require('moment-timezone');
 const { Task } = require('../../../models');
 const { parsePriority, parseStatus } = require('./parsers');
 const {
@@ -5,10 +6,16 @@ const {
     processDeferUntilForStorage,
 } = require('../../../utils/timezone-utils');
 
-function calculateInitialDueDate(body) {
+function calculateInitialDueDate(body, timezone = 'UTC') {
     const recurrenceType = body.recurrence_type;
-    const now = new Date();
-    now.setUTCHours(0, 0, 0, 0);
+    // Build "today" as a calendar-only UTC Date from the user's LOCAL date
+    // components, so the getUTC*() reads below reflect the user's calendar
+    // day rather than the server's UTC day.
+    const todayLocalStr = moment.tz(timezone).format('YYYY-MM-DD');
+    const [todayYear, todayMonth, todayDay] = todayLocalStr
+        .split('-')
+        .map(Number);
+    const now = new Date(Date.UTC(todayYear, todayMonth - 1, todayDay));
 
     // For monthly recurrence with specific day of month
     if (
@@ -134,7 +141,7 @@ function buildTaskAttributes(body, userId, timezone, isUpdate = false) {
         (dueDate === undefined || dueDate === null || dueDate === '')
     ) {
         // Calculate proper first occurrence based on recurrence pattern
-        dueDate = calculateInitialDueDate(body);
+        dueDate = calculateInitialDueDate(body, timezone);
     }
 
     const attrs = {
@@ -236,24 +243,30 @@ function buildUpdateAttributes(body, task, timezone) {
     if (body.due_date !== undefined) {
         if (isRecurring && (body.due_date === null || body.due_date === '')) {
             // Calculate proper first occurrence based on recurrence pattern
-            const dueDateString = calculateInitialDueDate({
-                recurrence_type: recurrenceType,
-                recurrence_month_day: attrs.recurrence_month_day,
-                recurrence_weekday: attrs.recurrence_weekday,
-                recurrence_weekdays: attrs.recurrence_weekdays,
-            });
+            const dueDateString = calculateInitialDueDate(
+                {
+                    recurrence_type: recurrenceType,
+                    recurrence_month_day: attrs.recurrence_month_day,
+                    recurrence_weekday: attrs.recurrence_weekday,
+                    recurrence_weekdays: attrs.recurrence_weekdays,
+                },
+                timezone
+            );
             attrs.due_date = processDueDateForStorage(dueDateString, timezone);
         } else {
             attrs.due_date = processDueDateForStorage(body.due_date, timezone);
         }
     } else if (isAddingRecurrence && (!task.due_date || task.due_date === '')) {
         // Calculate proper first occurrence based on recurrence pattern
-        const dueDateString = calculateInitialDueDate({
-            recurrence_type: recurrenceType,
-            recurrence_month_day: attrs.recurrence_month_day,
-            recurrence_weekday: attrs.recurrence_weekday,
-            recurrence_weekdays: attrs.recurrence_weekdays,
-        });
+        const dueDateString = calculateInitialDueDate(
+            {
+                recurrence_type: recurrenceType,
+                recurrence_month_day: attrs.recurrence_month_day,
+                recurrence_weekday: attrs.recurrence_weekday,
+                recurrence_weekdays: attrs.recurrence_weekdays,
+            },
+            timezone
+        );
         attrs.due_date = processDueDateForStorage(dueDateString, timezone);
     }
 

--- a/backend/modules/tasks/operations/recurring.js
+++ b/backend/modules/tasks/operations/recurring.js
@@ -6,6 +6,7 @@ const {
     getSafeTimezone,
     dateStringToUTC,
     getCurrentDateInTimezone,
+    getWeekdayInTimezone,
 } = require('../../../utils/timezone-utils');
 
 async function handleRecurrenceUpdate(task, recurrenceFields, reqBody) {
@@ -107,7 +108,7 @@ async function calculateNextIterations(task, startFromDate, userTimezone) {
             const weekdays = Array.isArray(task.recurrence_weekdays)
                 ? task.recurrence_weekdays
                 : JSON.parse(task.recurrence_weekdays);
-            const todayWeekday = nextDate.getUTCDay();
+            const todayWeekday = getWeekdayInTimezone(nextDate, safeTimezone);
             console.log('Weekly recurrence check:', {
                 weekdays,
                 todayWeekday,
@@ -118,7 +119,7 @@ async function calculateNextIterations(task, startFromDate, userTimezone) {
             task.recurrence_weekday !== null &&
             task.recurrence_weekday !== undefined
         ) {
-            const todayWeekday = nextDate.getUTCDay();
+            const todayWeekday = getWeekdayInTimezone(nextDate, safeTimezone);
             includesToday = task.recurrence_weekday === todayWeekday;
         }
     } else if (task.recurrence_type === 'daily') {
@@ -177,7 +178,10 @@ async function calculateNextIterations(task, startFromDate, userTimezone) {
                     ? task.recurrence_weekdays
                     : JSON.parse(task.recurrence_weekdays);
                 const sorted = [...weekdays].sort((a, b) => a - b);
-                const currentDay = nextDate.getUTCDay();
+                const currentDay = getWeekdayInTimezone(
+                    nextDate,
+                    safeTimezone
+                );
                 const laterInWeek = sorted.filter((d) => d > currentDay);
                 if (laterInWeek.length > 0) {
                     nextDate.setUTCDate(
@@ -196,7 +200,10 @@ async function calculateNextIterations(task, startFromDate, userTimezone) {
                 task.recurrence_weekday !== null &&
                 task.recurrence_weekday !== undefined
             ) {
-                const currentWeekday = nextDate.getUTCDay();
+                const currentWeekday = getWeekdayInTimezone(
+                    nextDate,
+                    safeTimezone
+                );
                 const daysUntilTarget =
                     (task.recurrence_weekday - currentWeekday + 7) % 7;
                 if (daysUntilTarget === 0) {
@@ -232,7 +239,7 @@ async function calculateNextIterations(task, startFromDate, userTimezone) {
             const nextLocalDateStr = `${nextYear}-${String(nextMonthZeroIdx + 1).padStart(2, '0')}-${String(finalDay).padStart(2, '0')}`;
             nextDate = dateStringToUTC(nextLocalDateStr, safeTimezone, 'start');
         } else {
-            nextDate = calculateNextDueDate(task, startDate);
+            nextDate = calculateNextDueDate(task, startDate, safeTimezone);
         }
     }
 
@@ -267,7 +274,10 @@ async function calculateNextIterations(task, startFromDate, userTimezone) {
                     : JSON.parse(task.recurrence_weekdays);
                 const interval = task.recurrence_interval || 1;
                 const sorted = [...weekdays].sort((a, b) => a - b);
-                const currentDay = nextDate.getUTCDay();
+                const currentDay = getWeekdayInTimezone(
+                    nextDate,
+                    safeTimezone
+                );
                 const laterInWeek = sorted.filter((d) => d > currentDay);
 
                 if (laterInWeek.length > 0) {
@@ -314,7 +324,7 @@ async function calculateNextIterations(task, startFromDate, userTimezone) {
             const nextLocalDateStr = `${nextYear}-${String(nextMonthZeroIdx + 1).padStart(2, '0')}-${String(finalDay).padStart(2, '0')}`;
             nextDate = dateStringToUTC(nextLocalDateStr, safeTimezone, 'start');
         } else {
-            nextDate = calculateNextDueDate(task, nextDate);
+            nextDate = calculateNextDueDate(task, nextDate, safeTimezone);
         }
     }
 

--- a/backend/modules/tasks/operations/recurring.js
+++ b/backend/modules/tasks/operations/recurring.js
@@ -178,10 +178,7 @@ async function calculateNextIterations(task, startFromDate, userTimezone) {
                     ? task.recurrence_weekdays
                     : JSON.parse(task.recurrence_weekdays);
                 const sorted = [...weekdays].sort((a, b) => a - b);
-                const currentDay = getWeekdayInTimezone(
-                    nextDate,
-                    safeTimezone
-                );
+                const currentDay = getWeekdayInTimezone(nextDate, safeTimezone);
                 const laterInWeek = sorted.filter((d) => d > currentDay);
                 if (laterInWeek.length > 0) {
                     nextDate.setUTCDate(
@@ -274,10 +271,7 @@ async function calculateNextIterations(task, startFromDate, userTimezone) {
                     : JSON.parse(task.recurrence_weekdays);
                 const interval = task.recurrence_interval || 1;
                 const sorted = [...weekdays].sort((a, b) => a - b);
-                const currentDay = getWeekdayInTimezone(
-                    nextDate,
-                    safeTimezone
-                );
+                const currentDay = getWeekdayInTimezone(nextDate, safeTimezone);
                 const laterInWeek = sorted.filter((d) => d > currentDay);
 
                 if (laterInWeek.length > 0) {

--- a/backend/modules/tasks/recurringTaskService.js
+++ b/backend/modules/tasks/recurringTaskService.js
@@ -1,4 +1,6 @@
-const calculateNextDueDate = (task, fromDate) => {
+const { getWeekdayInTimezone } = require('../../utils/timezone-utils');
+
+const calculateNextDueDate = (task, fromDate, timezone = 'UTC') => {
     if (
         !task ||
         !task.recurrence_type ||
@@ -22,7 +24,8 @@ const calculateNextDueDate = (task, fromDate) => {
                 startDate,
                 task.recurrence_interval || 1,
                 task.recurrence_weekday,
-                task.recurrence_weekdays
+                task.recurrence_weekdays,
+                timezone
             );
 
         case 'monthly':
@@ -57,7 +60,13 @@ const calculateDailyRecurrence = (fromDate, interval) => {
     return nextDate;
 };
 
-const calculateWeeklyRecurrence = (fromDate, interval, weekday, weekdays) => {
+const calculateWeeklyRecurrence = (
+    fromDate,
+    interval,
+    weekday,
+    weekdays,
+    timezone = 'UTC'
+) => {
     const nextDate = new Date(fromDate);
 
     // Handle multiple weekdays (e.g. Tuesday AND Thursday)
@@ -69,7 +78,10 @@ const calculateWeeklyRecurrence = (fromDate, interval, weekday, weekdays) => {
 
     if (parsedWeekdays && parsedWeekdays.length > 0) {
         const sorted = [...parsedWeekdays].sort((a, b) => a - b);
-        const currentDay = nextDate.getUTCDay();
+        // Read the weekday in the user's timezone, not getUTCDay(): fromDate
+        // may represent "local midnight" as a UTC instant, whose UTC calendar
+        // day is the previous day for positive-UTC-offset timezones.
+        const currentDay = getWeekdayInTimezone(nextDate, timezone);
 
         // Find next weekday in calendar order (accounting for week wrap)
         let nextWeekday = null;
@@ -119,7 +131,7 @@ const calculateWeeklyRecurrence = (fromDate, interval, weekday, weekdays) => {
 
         nextDate.setUTCDate(nextDate.getUTCDate() + daysToNext);
     } else if (weekday !== null && weekday !== undefined) {
-        const currentWeekday = nextDate.getUTCDay();
+        const currentWeekday = getWeekdayInTimezone(nextDate, timezone);
         let daysUntilTarget = (weekday - currentWeekday + 7) % 7;
 
         if (daysUntilTarget === 0) {
@@ -306,7 +318,7 @@ const calculateVirtualOccurrences = (
             is_virtual: true,
         });
 
-        currentDate = calculateNextDueDate(task, currentDate);
+        currentDate = calculateNextDueDate(task, currentDate, userTimezone);
         if (!currentDate) break;
 
         iterationCount++;

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -136,7 +136,7 @@ function expandRecurringTasks(
                 task.completion_based && task.completed_at
                     ? new Date(task.completed_at)
                     : new Date(task.due_date || now);
-            const nextDate = calculateNextDueDate(task, baseDate);
+            const nextDate = calculateNextDueDate(task, baseDate, userTimezone);
             startFrom = nextDate || now;
             console.log(
                 '[DEBUG] Task is completed, starting from next occurrence:',
@@ -148,7 +148,7 @@ function expandRecurringTasks(
             const MAX_ITERATIONS = 100;
 
             while (nextDate && nextDate < now && iterations < MAX_ITERATIONS) {
-                nextDate = calculateNextDueDate(task, nextDate);
+                nextDate = calculateNextDueDate(task, nextDate, userTimezone);
                 iterations++;
             }
 
@@ -788,7 +788,8 @@ router.patch('/task/:uid', requireTaskWriteAccess, async (req, res) => {
                 : new Date(originalDueDate);
             const nextDueDate = calculateNextDueDate(
                 recurrenceContext,
-                baseDate
+                baseDate,
+                timezone
             );
 
             recurringCompletionPayload = {

--- a/backend/tests/integration/recurring-tasks-timezone-weekday.test.js
+++ b/backend/tests/integration/recurring-tasks-timezone-weekday.test.js
@@ -1,0 +1,70 @@
+const request = require('supertest');
+const moment = require('moment-timezone');
+const app = require('../../app');
+const { createTestUser } = require('../helpers/testUtils');
+
+describe('Recurring Tasks - Weekday Recurrence Across Timezones (issue #1415)', () => {
+    let user, agent;
+
+    beforeEach(async () => {
+        user = await createTestUser({
+            email: 'tokyo-user@example.com',
+            timezone: 'Asia/Tokyo',
+        });
+
+        agent = request.agent(app);
+        await agent.post('/api/login').send({
+            email: user.email,
+            password: 'password123',
+        });
+    });
+
+    it('never expands a Mon-Fri recurring task onto a Saturday/Sunday for a UTC+9 user', async () => {
+        const taskData = {
+            name: 'Weekday Standup',
+            recurrence_type: 'weekly',
+            recurrence_weekdays: [1, 2, 3, 4, 5],
+        };
+
+        const createResponse = await agent.post('/api/task').send(taskData);
+        expect(createResponse.status).toBe(201);
+
+        const listResponse = await agent.get(
+            '/api/tasks?type=upcoming&groupBy=day&maxDays=21'
+        );
+        expect(listResponse.status).toBe(200);
+
+        const occurrences = listResponse.body.tasks.filter(
+            (t) => t.original_name === 'Weekday Standup'
+        );
+        expect(occurrences.length).toBeGreaterThan(0);
+
+        occurrences.forEach((occurrence) => {
+            const localWeekday = moment
+                .tz(occurrence.due_date, 'Asia/Tokyo')
+                .day();
+            expect(localWeekday).toBeGreaterThanOrEqual(1);
+            expect(localWeekday).toBeLessThanOrEqual(5);
+        });
+    });
+
+    it('advances a "Repeat on Monday" task to the correct weekday, not one day late', async () => {
+        const taskData = {
+            name: 'Every Monday Review',
+            recurrence_type: 'weekly',
+            recurrence_weekday: 1,
+        };
+
+        const createResponse = await agent.post('/api/task').send(taskData);
+        expect(createResponse.status).toBe(201);
+
+        const iterationsResponse = await agent.get(
+            `/api/task/${createResponse.body.uid}/next-iterations`
+        );
+        expect(iterationsResponse.status).toBe(200);
+
+        iterationsResponse.body.iterations.forEach((iteration) => {
+            expect(moment.tz(iteration.date, 'Asia/Tokyo').day()).toBe(1);
+        });
+    });
+});

--- a/backend/tests/unit/modules/tasks/builders.test.js
+++ b/backend/tests/unit/modules/tasks/builders.test.js
@@ -216,6 +216,48 @@ describe('calculateInitialDueDate', () => {
         });
     });
 
+    describe('Weekly recurrence with non-UTC timezone (issue #1415)', () => {
+        it('uses the user local weekday, not the server UTC weekday, to find the next occurrence', () => {
+            // This instant is Thursday in UTC but already Friday in Asia/Tokyo
+            // (UTC+9) - the exact divergence that used to corrupt the "next
+            // weekday in pattern" calculation for positive-UTC-offset users.
+            const instant = new Date(Date.UTC(2026, 7, 27, 16, 0, 0, 0));
+            expect(instant.getUTCDay()).toBe(4); // Thursday in UTC
+
+            const RealDate = Date;
+            global.Date = class extends RealDate {
+                constructor(...args) {
+                    if (args.length === 0) {
+                        super(instant);
+                    } else {
+                        super(...args);
+                    }
+                }
+                static [Symbol.hasInstance](i) {
+                    return i instanceof RealDate;
+                }
+            };
+            global.Date.UTC = RealDate.UTC;
+            global.Date.parse = RealDate.parse;
+            global.Date.now = () => instant.getTime();
+
+            const result = calculateInitialDueDate(
+                {
+                    recurrence_type: 'weekly',
+                    recurrence_weekdays: [1, 2, 3, 4, 5],
+                },
+                'Asia/Tokyo'
+            );
+
+            // Local "today" is Friday (already in the pattern); the next
+            // occurrence strictly after today is Monday 2026-08-31, not
+            // 2026-08-28 (which is what the server-UTC-only calculation
+            // would incorrectly produce).
+            expect(result).toBe('2026-08-31');
+            global.Date = RealDate;
+        });
+    });
+
     describe('Weekly recurrence with single weekday (backward compatibility)', () => {
         it('should calculate correct due date for single weekday', () => {
             const monday = new Date(Date.UTC(2026, 2, 23, 0, 0, 0, 0));

--- a/backend/tests/unit/modules/tasks/recurringTaskService.weekly-timezone.test.js
+++ b/backend/tests/unit/modules/tasks/recurringTaskService.weekly-timezone.test.js
@@ -29,9 +29,7 @@ describe('RecurringTaskService - Weekly Recurrence Timezone Awareness (issue #14
 
             expect(occurrences).toHaveLength(10);
             occurrences.forEach((occurrence) => {
-                const localWeekday = moment
-                    .tz(occurrence.due_date, tz)
-                    .day();
+                const localWeekday = moment.tz(occurrence.due_date, tz).day();
                 expect(localWeekday).toBeGreaterThanOrEqual(1);
                 expect(localWeekday).toBeLessThanOrEqual(5);
             });

--- a/backend/tests/unit/modules/tasks/recurringTaskService.weekly-timezone.test.js
+++ b/backend/tests/unit/modules/tasks/recurringTaskService.weekly-timezone.test.js
@@ -1,0 +1,109 @@
+const moment = require('moment-timezone');
+const {
+    calculateWeeklyRecurrence,
+    calculateVirtualOccurrences,
+} = require('../../../../modules/tasks/recurringTaskService');
+
+describe('RecurringTaskService - Weekly Recurrence Timezone Awareness (issue #1415)', () => {
+    describe('calculateVirtualOccurrences - Mon-Fri weekdays', () => {
+        it('never generates a weekend occurrence for a positive-UTC-offset timezone (Asia/Tokyo)', () => {
+            const tz = 'Asia/Tokyo';
+            // Friday local midnight in Tokyo -> UTC instant is still Thursday,
+            // the exact condition that used to corrupt the "last weekday" check.
+            const fridayLocal = moment
+                .tz('2026-08-28', tz)
+                .startOf('day')
+                .toDate();
+            const task = {
+                recurrence_type: 'weekly',
+                recurrence_interval: 1,
+                recurrence_weekdays: [1, 2, 3, 4, 5],
+            };
+
+            const occurrences = calculateVirtualOccurrences(
+                task,
+                10,
+                fridayLocal,
+                tz
+            );
+
+            expect(occurrences).toHaveLength(10);
+            occurrences.forEach((occurrence) => {
+                const localWeekday = moment
+                    .tz(occurrence.due_date, tz)
+                    .day();
+                expect(localWeekday).toBeGreaterThanOrEqual(1);
+                expect(localWeekday).toBeLessThanOrEqual(5);
+            });
+        });
+
+        it('does not skip Monday after a Friday occurrence (Asia/Tokyo)', () => {
+            const tz = 'Asia/Tokyo';
+            const fridayLocal = moment
+                .tz('2026-08-28', tz)
+                .startOf('day')
+                .toDate();
+            const task = {
+                recurrence_type: 'weekly',
+                recurrence_interval: 1,
+                recurrence_weekdays: [1, 2, 3, 4, 5],
+            };
+
+            const occurrences = calculateVirtualOccurrences(
+                task,
+                2,
+                fridayLocal,
+                tz
+            );
+
+            expect(occurrences[0].due_date).toBe('2026-08-28'); // Friday
+            expect(occurrences[1].due_date).toBe('2026-08-31'); // Monday
+        });
+    });
+
+    describe('calculateVirtualOccurrences - single weekday ("Repeat on")', () => {
+        it('lands on the configured weekday, not the day after, for Europe/Berlin', () => {
+            const tz = 'Europe/Berlin';
+            const mondayLocal = moment
+                .tz('2026-08-31', tz)
+                .startOf('day')
+                .toDate();
+            const task = {
+                recurrence_type: 'weekly',
+                recurrence_interval: 1,
+                recurrence_weekday: 1, // Monday
+            };
+
+            const occurrences = calculateVirtualOccurrences(
+                task,
+                5,
+                mondayLocal,
+                tz
+            );
+
+            occurrences.forEach((occurrence) => {
+                expect(moment.tz(occurrence.due_date, tz).day()).toBe(1);
+            });
+        });
+    });
+
+    describe('calculateWeeklyRecurrence - UTC default remains unchanged (regression guard)', () => {
+        // These mirror existing assertions in recurringTaskService.test.js to lock
+        // in that passing no timezone (or 'UTC') is a byte-for-byte no-op.
+        it('matches prior UTC-only behavior for multi-weekday pattern', () => {
+            const friday = new Date(Date.UTC(2026, 0, 16, 0, 0, 0, 0)); // Friday
+            const weekdays = [1, 3, 5];
+            const result = calculateWeeklyRecurrence(friday, 1, null, weekdays);
+
+            expect(result.getUTCDay()).toBe(1);
+        });
+
+        it('matches prior UTC-only behavior for single weekday', () => {
+            const monday = new Date(Date.UTC(2026, 0, 12, 0, 0, 0, 0)); // Monday
+            const result = calculateWeeklyRecurrence(monday, 2, 1, null);
+
+            expect(result.getUTCDay()).toBe(1);
+            expect(result.getUTCDate()).toBe(26);
+        });
+    });
+});

--- a/backend/utils/timezone-utils.js
+++ b/backend/utils/timezone-utils.js
@@ -175,6 +175,21 @@ function processDeferUntilForResponse(utcDeferUntil, userTimezone) {
 }
 
 /**
+ * Get the day of week (0=Sunday..6=Saturday) for a UTC instant, as observed
+ * in the user's timezone. Use this instead of `date.getUTCDay()` whenever
+ * `date` may represent "local midnight" converted to a UTC instant, since
+ * for positive-UTC-offset timezones that instant's UTC calendar day is the
+ * previous local day, and `getUTCDay()` would return the wrong weekday.
+ * @param {Date} date - UTC Date instant
+ * @param {string} userTimezone - User's timezone
+ * @returns {number|null} Day of week local to userTimezone, or null
+ */
+function getWeekdayInTimezone(date, userTimezone) {
+    if (!date) return null;
+    return moment.tz(date, userTimezone || 'UTC').day();
+}
+
+/**
  * Validate timezone string
  * @param {string} timezone - Timezone to validate
  * @returns {boolean} True if timezone is valid
@@ -216,4 +231,5 @@ module.exports = {
     processDeferUntilForResponse,
     isValidTimezone,
     getSafeTimezone,
+    getWeekdayInTimezone,
 };

--- a/frontend/components/Task/TaskDetails.tsx
+++ b/frontend/components/Task/TaskDetails.tsx
@@ -720,15 +720,37 @@ const TaskDetails: React.FC = () => {
     }, [task?.parent_task?.uid]);
 
     const handleSubtaskUpdate = async (updatedSubtask: Task) => {
-        const taskIndex = tasksStore.tasks.findIndex((t: Task) => t.uid === uid);
-        if (taskIndex >= 0) {
-            const storeTask = tasksStore.tasks[taskIndex];
-            const updatedSubtasks = (storeTask.subtasks || []).map((s: Task) =>
-                s.id === updatedSubtask.id ? updatedSubtask : s
+        if (!updatedSubtask.uid) return;
+
+        try {
+            const savedSubtask = await updateTask(
+                updatedSubtask.uid,
+                updatedSubtask
             );
-            const updatedTasks = [...tasksStore.tasks];
-            updatedTasks[taskIndex] = { ...storeTask, subtasks: updatedSubtasks };
-            tasksStore.setTasks(updatedTasks);
+
+            const taskIndex = tasksStore.tasks.findIndex(
+                (t: Task) => t.uid === uid
+            );
+            if (taskIndex >= 0) {
+                const storeTask = tasksStore.tasks[taskIndex];
+                const updatedSubtasks = (storeTask.subtasks || []).map(
+                    (s: Task) =>
+                        s.id === savedSubtask.id
+                            ? { ...s, ...savedSubtask }
+                            : s
+                );
+                const updatedTasks = [...tasksStore.tasks];
+                updatedTasks[taskIndex] = {
+                    ...storeTask,
+                    subtasks: updatedSubtasks,
+                };
+                tasksStore.setTasks(updatedTasks);
+            }
+        } catch (error) {
+            console.error('Error updating subtask:', error);
+            showErrorToast(
+                t('task.statusUpdateError', 'Failed to update status')
+            );
         }
     };
 

--- a/frontend/components/Task/__tests__/TaskDetails.test.tsx
+++ b/frontend/components/Task/__tests__/TaskDetails.test.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TaskDetails from '../TaskDetails';
+
+jest.mock('react-router-dom', () => ({
+    useParams: () => ({ uid: 'task-1' }),
+    useNavigate: () => jest.fn(),
+    useLocation: () => ({ pathname: '/task/task-1', state: {} }),
+}));
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (_key: string, fallback?: string) => fallback ?? _key,
+    }),
+    initReactI18next: { type: '3rdParty', init: () => {} },
+}));
+
+// dateUtils imports the real i18n singleton (i18next.use(Backend)...) purely
+// for its `language` field; stub it out so requiring TaskDetails doesn't
+// spin up the real i18next/http-backend/language-detector chain.
+jest.mock('../../../i18n', () => ({
+    __esModule: true,
+    default: { language: 'en' },
+}));
+
+jest.mock('../../Shared/ToastContext', () => ({
+    useToast: () => ({
+        showSuccessToast: jest.fn(),
+        showErrorToast: jest.fn(),
+        showUndoToast: jest.fn(),
+    }),
+}));
+
+jest.mock('../../Shared/LoadingScreen', () => ({
+    __esModule: true,
+    default: () => <div data-testid="loading-screen" />,
+}));
+
+jest.mock('../../Shared/ConfirmDialog', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('../../AI/TaskAIInsights', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('../TaskTimeline', () => ({
+    __esModule: true,
+    default: () => null,
+}));
+
+jest.mock('../../../utils/projectsService', () => ({
+    createProject: jest.fn(),
+}));
+
+jest.mock('../../../utils/attachmentsService', () => ({
+    fetchAttachments: jest.fn().mockResolvedValue([]),
+}));
+
+const mockSubtaskInStore = {
+    id: 2,
+    uid: 'subtask-1',
+    name: 'Subtask A',
+    status: 'not_started',
+    parent_task_id: 1,
+};
+
+const mockParentTaskInStore = {
+    id: 1,
+    uid: 'task-1',
+    name: 'Parent Task',
+    status: 'not_started',
+    priority: 'medium',
+    project_id: null,
+    subtasks: [mockSubtaskInStore],
+};
+
+const mockUpdateTask = jest.fn();
+
+jest.mock('../../../utils/tasksService', () => ({
+    updateTask: (...args: any[]) => mockUpdateTask(...args),
+    deleteTask: jest.fn(),
+    // Deferred lookups (not `.mockResolvedValue(mockParentTaskInStore)`) so
+    // this factory doesn't dereference the outer consts before they're
+    // initialized - jest.mock factories run as soon as the mocked module is
+    // first required, which happens before this file's own top-level code.
+    fetchTaskByUid: jest.fn(() => Promise.resolve(mockParentTaskInStore)),
+    fetchTaskNextIterations: jest.fn().mockResolvedValue([]),
+    fetchSubtasks: jest.fn(() => Promise.resolve([mockSubtaskInStore])),
+    toggleTaskCompletion: jest.fn(),
+}));
+
+// Stub every TaskDetails/ card except TaskSubtasksCard, which we render
+// interactively so we can trigger the real handleSubtaskUpdate wiring from
+// TaskDetails.tsx - the same path a user hits from the subtask status
+// dropdown.
+jest.mock('../TaskDetails/', () => ({
+    TaskDetailsHeader: () => null,
+    TaskContentCard: () => null,
+    TaskProjectCard: () => null,
+    TaskTagsCard: () => null,
+    TaskSubtasksCard: ({ subtasks, onSubtaskUpdate }: any) => (
+        <div>
+            {subtasks.map((s: any) => (
+                <button
+                    key={s.uid}
+                    onClick={() =>
+                        onSubtaskUpdate({ ...s, status: 'in_progress' })
+                    }
+                >
+                    Change status of {s.name}
+                </button>
+            ))}
+        </div>
+    ),
+    TaskRecurrenceCard: () => null,
+    TaskDueDateCard: () => null,
+    TaskDeferUntilCard: () => null,
+    TaskAttachmentsCard: () => null,
+    TaskAreaCard: () => null,
+    TaskAssignedToCard: () => null,
+    TaskGoalCard: () => null,
+}));
+
+let mockTasksInStore: any[];
+const mockSetTasks = jest.fn((updated: any[]) => {
+    mockTasksInStore = updated;
+});
+
+jest.mock('../../../store/useStore', () => {
+    const mockUseStore: any = (selector: any) =>
+        selector({
+            projectsStore: { projects: [] },
+            tagsStore: {
+                tags: [],
+                hasLoaded: true,
+                isLoading: false,
+                loadTags: jest.fn(),
+            },
+            tasksStore: {
+                get tasks() {
+                    return mockTasksInStore;
+                },
+                setTasks: mockSetTasks,
+            },
+            areasStore: {
+                areas: [],
+                hasLoaded: true,
+                isLoading: false,
+                loadAreas: jest.fn(),
+            },
+            goalsStore: {
+                goals: [],
+                hasLoaded: true,
+                isLoading: false,
+                loadGoals: jest.fn(),
+            },
+            userSettingsStore: { aiAssistantEnabled: false },
+        });
+    mockUseStore.getState = () => ({
+        tasksStore: { tasks: mockTasksInStore, setTasks: mockSetTasks },
+    });
+    return { useStore: mockUseStore };
+});
+
+describe('TaskDetails subtask status updates', () => {
+    beforeEach(() => {
+        mockTasksInStore = [
+            {
+                ...mockParentTaskInStore,
+                subtasks: [{ ...mockSubtaskInStore }],
+            },
+        ];
+        mockUpdateTask.mockReset();
+        mockUpdateTask.mockResolvedValue({
+            ...mockSubtaskInStore,
+            status: 'in_progress',
+        });
+        mockSetTasks.mockClear();
+    });
+
+    it('persists a subtask status change via the API instead of only updating local state', async () => {
+        render(<TaskDetails />);
+
+        const button = await screen.findByText('Change status of Subtask A');
+        fireEvent.click(button);
+
+        // Regression guard for #1420: changing a subtask's status must PATCH
+        // the backend, not just mutate the in-memory tasksStore - otherwise
+        // the change is lost on refresh.
+        await waitFor(() => {
+            expect(mockUpdateTask).toHaveBeenCalledWith(
+                'subtask-1',
+                expect.objectContaining({ status: 'in_progress' })
+            );
+        });
+    });
+
+    it('reflects the server-saved subtask in the tasks store after the update', async () => {
+        render(<TaskDetails />);
+
+        const button = await screen.findByText('Change status of Subtask A');
+        fireEvent.click(button);
+
+        await waitFor(() => {
+            const lastCall =
+                mockSetTasks.mock.calls[mockSetTasks.mock.calls.length - 1];
+            const updatedTasks = lastCall?.[0];
+            const updatedParent = updatedTasks?.find(
+                (t: any) => t.uid === 'task-1'
+            );
+            expect(updatedParent?.subtasks?.[0]?.status).toBe('in_progress');
+        });
+    });
+});


### PR DESCRIPTION
## Description

Recurring tasks configured to repeat on weekdays (or a single specific weekday) could show occurrences on the wrong day, including weekends, for users in positive-UTC-offset timezones (e.g. Asia/Tokyo, most of Europe, Australia).

Several code paths build a `Date` representing local midnight in the user's timezone, a valid UTC instant, then read the weekday back out with `getUTCDay()` instead of a timezone-aware accessor. For positive-offset zones, local midnight's UTC calendar date is the previous day, so the weekly recurrence engine's weekday matching misfired and corrupted the anchor for every subsequent occurrence.

Fix: added `getWeekdayInTimezone()` to `timezone-utils.js` and threaded the user's timezone through `calculateNextDueDate`/`calculateWeeklyRecurrence`, the "Repeat on" next-iterations preview, and the initial due date calculation for new recurring tasks, so weekday matching is always evaluated in the user's local timezone. All new/changed function parameters default to `'UTC'`, so existing UTC-based behavior is unchanged (verified: `moment.tz(date, 'UTC').day() === date.getUTCDay()` always).

Scoped out: the monthly-recurrence bugs reported in the issue's comments (4-week interval drift, "after completion" date math) have a related but distinct root cause (month-boundary crossing rather than every-occurrence) and are better tracked as a separate follow-up issue.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1415

## Testing

**How did you test this?**

- Added unit coverage (`recurringTaskService.weekly-timezone.test.js`, plus a new case in `builders.test.js`) reproducing the exact bug for Asia/Tokyo and Europe/Berlin timezones, confirming Mon-Fri patterns never land on a weekend and single-weekday patterns land exactly on the configured day.
- Added an integration test (`recurring-tasks-timezone-weekday.test.js`) exercising the real API routes (task creation, `GET /api/tasks?type=upcoming&groupBy=day`, `GET /api/task/:uid/next-iterations`) for a `Asia/Tokyo` user.
- Ran the full existing recurrence/DST/builders test suites (161 tests) to confirm no regressions for UTC and other timezones.
- `npm run pre-push` passes.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)