### PR TITLE
fix(areas): make projects stat on area details page clickable

### DIFF
--- a/frontend/components/Area/AreaDetails.tsx
+++ b/frontend/components/Area/AreaDetails.tsx
@@ -187,7 +187,12 @@ const AreaDetails: React.FC = () => {
                                 </p>
                             )}
                             <div className={`mt-3 flex gap-4 text-xs ${area.color ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'}`}>
-                                <span>{areaProjects.length} {t('areas.projects', 'projects')}</span>
+                                <Link
+                                    to={`/projects?area=${area.uid}`}
+                                    className={`hover:underline ${area.color ? 'hover:text-white' : 'hover:text-gray-700 dark:hover:text-gray-200'}`}
+                                >
+                                    {areaProjects.length} {t('areas.projects', 'projects')}
+                                </Link>
                                 <span>{areaGoals.length} {t('areas.goals', 'goals')}</span>
                                 <span>{areaTasks.length} {t('areas.tasks', 'tasks')}</span>
                             </div>

--- a/frontend/components/Area/__tests__/AreaDetails.test.tsx
+++ b/frontend/components/Area/__tests__/AreaDetails.test.tsx
@@ -29,6 +29,10 @@ const tasks = [
     { uid: 'task-3', name: 'Archived task', status: 'archived' },
 ];
 
+const projects = [
+    { uid: 'project-1', name: 'Project one', area: { uid: 'areauid1' } },
+];
+
 jest.mock('../../../utils/tasksService', () => ({
     fetchTasks: jest.fn(() => Promise.resolve({ tasks })),
 }));
@@ -52,7 +56,7 @@ jest.mock('../../../store/useStore', () => ({
                 loadAreas: jest.fn(),
             },
             projectsStore: {
-                projects: [],
+                projects,
                 hasLoaded: true,
                 isLoading: false,
                 loadProjects: jest.fn(),
@@ -89,5 +93,15 @@ describe('AreaDetails header stats', () => {
         });
 
         expect(screen.getByText('2 goals')).toBeInTheDocument();
+    });
+
+    it('links the projects stat to the projects list filtered by this area', async () => {
+        renderPage();
+
+        const projectsLink = await screen.findByText('1 projects');
+        expect(projectsLink.closest('a')).toHaveAttribute(
+            'href',
+            '/projects?area=areauid1'
+        );
     });
 });


### PR DESCRIPTION
## Description

The area detail page (`/area/:uidSlug`) shows a header stat like "1 projects", but it was plain text with no click handler, so nothing happened when clicking it. This restores the pre-1.4 behavior of navigating to the projects list filtered by that area.

The fix wraps the projects stat in a `Link` to `/projects?area=<area.uid>`, which the Projects page already supports via its existing area query-param filtering logic (used elsewhere by the area filter dropdown).

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1412

## Testing

**How did you test this?**

- Added a regression test asserting the projects stat renders as a link with `href="/projects?area=<uid>"`
- Manually verified in dev that clicking "N projects" on an area detail page navigates to the projects list pre-filtered to that area
- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)