### PR TITLE
fix(productivity): stop infinite mount/unmount loop with zero tasks

### DIFF
--- a/frontend/Layout.tsx
+++ b/frontend/Layout.tsx
@@ -101,6 +101,7 @@ const Layout: React.FC<LayoutProps> = ({
         tasksStore: {
             isLoading: isTasksLoading,
             isError: isTasksError,
+            hasLoaded: hasTasksLoaded,
             createTask: createTaskInStore,
         },
         projectsStore: {
@@ -426,7 +427,7 @@ const Layout: React.FC<LayoutProps> = ({
     const isLoading =
         (isNotesLoading && !hasNotesLoaded) ||
         (isAreasLoading && !hasAreasLoaded) ||
-        isTasksLoading ||
+        (isTasksLoading && !hasTasksLoaded) ||
         (isProjectsLoading && !hasProjectsLoaded) ||
         (isTagsLoading && !hasTagsLoaded);
     const isError =

--- a/frontend/__tests__/Layout.test.tsx
+++ b/frontend/__tests__/Layout.test.tsx
@@ -74,6 +74,7 @@ const baseStoreState: any = {
         tasks: [],
         isLoading: false,
         isError: false,
+        hasLoaded: true,
         createTask: jest.fn(),
     },
     projectsStore: {
@@ -165,5 +166,26 @@ describe('Layout loading gate', () => {
         renderLayout();
 
         expect(screen.queryByTestId('routed-page')).not.toBeInTheDocument();
+    });
+
+    it('does not swap the routed page out when tasksStore refetches after it has already loaded', () => {
+        // Mirrors ProductivityPage.tsx calling loadTasks() on mount: tasksStore
+        // goes back into isLoading even though hasLoaded is already true.
+        storeState = {
+            ...baseStoreState,
+            tasksStore: {
+                ...baseStoreState.tasksStore,
+                isLoading: true,
+                hasLoaded: true,
+            },
+        };
+
+        renderLayout();
+
+        // Regression guard for #1410: if Layout unmounted the routed page
+        // here, ProductivityPage's mount effect would refire loadTasks(),
+        // looping forever when the user has zero tasks.
+        expect(screen.getByTestId('routed-page')).toBeInTheDocument();
+        expect(screen.queryByText('common.loading')).not.toBeInTheDocument();
     });
 });

--- a/frontend/__tests__/ProductivityPage.test.tsx
+++ b/frontend/__tests__/ProductivityPage.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import ProductivityPage from '../components/Insights/ProductivityPage';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (key: string, fallback?: string) => fallback ?? key,
+    }),
+}));
+
+jest.mock('../components/Productivity/ProductivityAssistant', () => ({
+    __esModule: true,
+    default: () => <div data-testid="productivity-assistant" />,
+}));
+
+jest.mock('../utils/projectsService', () => ({
+    fetchProjects: jest.fn().mockResolvedValue([]),
+}));
+
+let storeState: any;
+
+jest.mock('../store/useStore', () => {
+    const mockUseStore: any = (selector: any) => selector(storeState);
+    return { useStore: mockUseStore };
+});
+
+describe('ProductivityPage', () => {
+    it('does not call loadTasks again once tasksStore has already loaded (even with zero tasks)', async () => {
+        const loadTasks = jest.fn();
+        storeState = {
+            tasksStore: {
+                tasks: [],
+                isLoading: false,
+                hasLoaded: true,
+                loadTasks,
+            },
+        };
+
+        await act(async () => {
+            render(<ProductivityPage />);
+        });
+
+        // Regression guard for #1410: once tasksStore has loaded, mounting
+        // ProductivityPage again (e.g. after Layout's loading gate remounts
+        // it) must not refire loadTasks(), which would loop forever when the
+        // user has zero tasks.
+        expect(loadTasks).not.toHaveBeenCalled();
+    });
+
+    it('calls loadTasks once when tasksStore has not loaded yet', async () => {
+        const loadTasks = jest.fn();
+        storeState = {
+            tasksStore: {
+                tasks: [],
+                isLoading: false,
+                hasLoaded: false,
+                loadTasks,
+            },
+        };
+
+        await act(async () => {
+            render(<ProductivityPage />);
+        });
+
+        expect(loadTasks).toHaveBeenCalledTimes(1);
+    });
+});

--- a/frontend/components/Insights/ProductivityPage.tsx
+++ b/frontend/components/Insights/ProductivityPage.tsx
@@ -5,11 +5,16 @@ import { fetchProjects } from '../../utils/projectsService';
 import ProductivityAssistant from '../Productivity/ProductivityAssistant';
 const ProductivityPage: React.FC = () => {
     const { t } = useTranslation();
-    const { tasks, isLoading: tasksLoading, loadTasks } = useStore((state) => state.tasksStore);
+    const {
+        tasks,
+        isLoading: tasksLoading,
+        hasLoaded: tasksHasLoaded,
+        loadTasks,
+    } = useStore((state) => state.tasksStore);
     const [projects, setProjects] = useState<any[]>([]);
 
     useEffect(() => {
-        if (tasks.length === 0) {
+        if (!tasksHasLoaded && !tasksLoading) {
             loadTasks();
         }
         fetchProjects()

--- a/frontend/store/useStore.ts
+++ b/frontend/store/useStore.ts
@@ -61,6 +61,7 @@ interface TasksStore {
     tasks: Task[];
     isLoading: boolean;
     isError: boolean;
+    hasLoaded: boolean;
     setTasks: (tasks: Task[]) => void;
     setLoading: (isLoading: boolean) => void;
     setError: (isError: boolean) => void;
@@ -534,6 +535,7 @@ export const useStore = create<StoreState>((set: any) => ({
         tasks: [],
         isLoading: false,
         isError: false,
+        hasLoaded: false,
         setTasks: (tasks) =>
             set((state) => ({ tasksStore: { ...state.tasksStore, tasks } })),
         setLoading: (isLoading) =>
@@ -558,6 +560,7 @@ export const useStore = create<StoreState>((set: any) => ({
                         ...state.tasksStore,
                         tasks,
                         isLoading: false,
+                        hasLoaded: true,
                     },
                 }));
             } catch (error) {
@@ -567,6 +570,7 @@ export const useStore = create<StoreState>((set: any) => ({
                         ...state.tasksStore,
                         isError: true,
                         isLoading: false,
+                        hasLoaded: true,
                     },
                 }));
             }


### PR DESCRIPTION
## Description

Opening Insights → Productivity Assistant with zero tasks caused an infinite mount/unmount loop (thousands of API requests, blank/unresponsive page).

`tasksStore` had no `hasLoaded` flag distinguishing "not loaded yet" from "loaded successfully with zero tasks." `ProductivityPage` decided whether to call `loadTasks()` by checking `tasks.length === 0`, which is true in both cases, and `Layout`'s full-screen loading gate was keyed off `isTasksLoading` alone (unlike the other stores, which gate on `hasLoaded` per #1435/#1427).

With zero tasks the cycle was:
1. `ProductivityPage` mounts, sees `tasks.length === 0`, calls `loadTasks()`.
2. `loadTasks()` sets `tasksStore.isLoading = true`.
3. `Layout` swaps `{children}` for the full-screen loader, unmounting `ProductivityPage`.
4. The fetch resolves to an empty array, `isLoading` goes back to `false`.
5. `Layout` restores `{children}`, remounting `ProductivityPage`.
6. `ProductivityPage` still sees `tasks.length === 0` and calls `loadTasks()` again, forever.

Fix: add `hasLoaded` to `tasksStore` (set on the `loadTasks` success/error path, matching the other stores), gate `ProductivityPage`'s mount effect on `hasLoaded` instead of `tasks.length`, and gate `Layout`'s loading condition on `hasLoaded` too, consistent with `notesStore`/`areasStore`/`projectsStore`/`tagsStore`.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1410

## Testing

**How did you test this?**

- Added a regression test in `Layout.test.tsx` mirroring the #1427 areas fix: `tasksStore` mid-refresh with `hasLoaded: true` no longer unmounts the routed page.
- Added `ProductivityPage.test.tsx` verifying `loadTasks()` fires once when `hasLoaded` is false and is skipped once `hasLoaded` is true (even with zero tasks).
- `npm run frontend:test` (full suite, 100 passed)
- `npx tsc --noEmit`
- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
