### PR TITLE
feat(pwa): share links and text from the OS share sheet into the Inbox

### DIFF
--- a/docs/04-inbox-page.md
+++ b/docs/04-inbox-page.md
@@ -58,6 +58,16 @@ Located at the top of the Inbox page:
    - Keyboard shortcut: `g` then `i` (Go to Inbox)
    - Sidebar navigation clicks auto-focus input
 
+### Share Sheet (installed PWA)
+
+Share a link or selected text from another app (Android, or desktop Chrome/Edge) and pick tududi:
+- The app opens on `/inbox` with the shared title, text and URL prefilled in Quick Capture
+- Nothing is saved yet — edit it, then press Enter or pick Task / Note / Project
+- Smart parsing, URL preview and suggestions behave exactly as if you had typed it
+- If your session expired, you land on login first and the shared content is restored afterwards
+
+See [PWA & Offline Support](15-pwa.md) for the manifest configuration and limitations (text/links only, not available on iOS).
+
 ### Telegram Integration
 
 Send messages to your tududi bot:

--- a/docs/15-pwa.md
+++ b/docs/15-pwa.md
@@ -50,6 +50,11 @@ Tududi is an installable Progressive Web App (PWA). Users can add it to their ho
   "background_color": "#ffffff",
   "lang": "en",
   "orientation": "portrait-primary",
+  "share_target": {
+    "action": "/inbox",
+    "method": "GET",
+    "params": { "title": "title", "text": "text", "url": "url" }
+  },
   "icons": [
     { "src": "/icon-logo.png", "sizes": "512x512", "type": "image/png", "purpose": "any" },
     { "src": "/icon-logo.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" },
@@ -66,6 +71,38 @@ Tududi is an installable Progressive Web App (PWA). Users can add it to their ho
 - Two separate entries are required; `"purpose": "any maskable"` in a single entry is a spec violation
 
 **Sub-path deployments (e.g. Home Assistant ingress):** The static `start_url: "/"` and `scope: "/"` will not match the ingress path, so the install prompt will not appear. A dynamic manifest served from the backend is needed for those deployments — this is a known limitation and a future enhancement.
+
+---
+
+## Share Target (Android / desktop share sheet)
+
+Once installed, tududi appears in the OS share sheet. Sharing a link or text from another app (Chrome, YouTube, a mail client, …) hands the content to the Inbox composer.
+
+### How it works
+
+1. `share_target` in the manifest registers tududi as a share handler. `method: "GET"` means the OS performs a plain navigation — no service worker interception needed:
+   ```
+   GET /inbox?title=<page title>&text=<selected text>&url=<link>
+   ```
+2. `captureSharedPayload()` (`frontend/utils/shareTargetService.ts`) runs in `frontend/index.tsx` **before React renders**. It:
+   - composes one string from `title`/`text`/`url`, dropping empty and duplicate values (Chrome on Android sends the same URL as both `text` and `url`)
+   - stores it in `sessionStorage` under `tududi_pending_share` with a timestamp
+   - rewrites the URL with `history.replaceState()` to strip the share params, so a reload doesn't replay the same share (other params such as `?loaded=` are preserved)
+3. `InboxItems` calls `takeSharedText()` on mount and passes the result as `initialValue` to `QuickCaptureInput`. The first call moves the payload out of `sessionStorage` and holds it in module scope for the rest of the page load, so every call returns the same text; `App.tsx` releases it with `clearSharedText()` on the first navigation away from `/inbox`.
+
+   The claim has to survive remounts: `Layout` swaps the routed page out for a full-screen spinner while its stores run their **first** fetch, so `InboxItems` mounts, unmounts and mounts again on every cold start — which is exactly what a launch from the share sheet is. A read that emptied `sessionStorage` on the first, discarded mount left the surviving composer blank every time.
+
+The shared content is **prefilled, not auto-saved** — the user can edit it and still choose Task / Note / Project, and the existing smart parsing (URL preview, `#tag`, `+Project`, task/note suggestion) applies as if they had typed it.
+
+### Why sessionStorage instead of reading the URL directly
+
+If the session has expired, `/inbox` is redirected to `/login` by `App.tsx` and the query params are lost. Stashing the payload first means the share survives the login round-trip: after authentication `App.tsx` sees `hasPendingSharedText()` and navigates to `/inbox`. Pending shares older than 10 minutes are discarded so a stale payload can't hijack a later navigation.
+
+### Limitations
+
+- **Text and links only.** Sharing *files* (images, PDFs) requires `method: "POST"` with a `multipart/form-data` enctype and a service worker `fetch` handler that intercepts the POST to `/inbox` — not implemented.
+- **iOS does not support Web Share Target**, so tududi will not appear in the iOS share sheet. iOS users can still use Shortcuts against the REST API.
+- Sub-path deployments have the same `action: "/inbox"` problem as `start_url` (see above).
 
 ---
 
@@ -87,7 +124,7 @@ sync      → replay queued mutations (Background Sync API)
 
 | Request type | Handler | Behaviour |
 |---|---|---|
-| Static assets (same-origin, non-API) | cache-first | Serve from `tududi-v1` cache; populate on first network hit |
+| Static assets (same-origin, non-API) | cache-first | Serve from `tududi-v2` cache; populate on first network hit |
 | API `GET` `/api/*` | `handleApiGet` | Network-first; on success write to `tududi-api-v1`; on network failure serve stale cache; if no cache return `503 { offline: true }` |
 | API mutations `/api/*` | `handleApiMutation` | Attempt network; if offline queue to IndexedDB, return `202 { queued: true }` with an `X-Tududi-Queued: 1` header; register Background Sync tag `tududi-sync` |
 | Stateless POST endpoints (e.g. `/api/inbox/analyze-text`) | `handleApiNoQueue` | Network-only; on failure return `503 { offline: true }` — never queued, since there's nothing meaningful to replay |
@@ -97,7 +134,7 @@ sync      → replay queued mutations (Background Sync API)
 
 | Name | Contents | Cleared when |
 |------|----------|-------------|
-| `tududi-v1` | Static assets (JS, CSS, fonts, icons, manifest) | SW activate removes old versions |
+| `tududi-v2` | Static assets (JS, CSS, fonts, icons, manifest) | SW activate removes old versions |
 | `tududi-api-v1` | API GET responses | 401/403 from any live fetch; CLEAR_CACHE message; manual SW update |
 
 ### Offline mutation queue
@@ -201,10 +238,10 @@ async function handleApiGet(request) {
 
 ## Updating the Cache Version
 
-When making a breaking change to the static asset structure (e.g. removing or renaming a cached file), bump `CACHE_VERSION` at the top of `public/sw.js`:
+When making a breaking change to the static asset structure — removing or renaming a cached file, or editing a pre-cached one such as `manifest.json`, since cache-first would otherwise serve the stale copy forever — bump `CACHE_VERSION` at the top of `public/sw.js`:
 
 ```javascript
-const CACHE_VERSION = 'tududi-v2'; // was tududi-v1
+const CACHE_VERSION = 'tududi-v3'; // was tududi-v2
 ```
 
 The `activate` event deletes all caches that don't match the current `CACHE_VERSION` or `API_CACHE`. If the API response format changes significantly, also bump `API_CACHE`:
@@ -223,6 +260,7 @@ const API_CACHE = 'tududi-api-v2'; // was tududi-api-v1
 | Offline task creation | Creating a task offline queues a POST; the server-assigned `id` is unknown at queue time, so dependent mutations in the same offline session may fail on replay |
 | No conflict resolution | If the server state changed while offline, replayed mutations apply on top of the new state without merging — last writer wins |
 | iOS Safari background sync | iOS does not support the Background Sync API; queued mutations are replayed the next time the app is opened while online |
+| Share target scope | Text and links only (`method: "GET"`); sharing files would need a POST share target intercepted by the service worker. Not available on iOS, which has no Web Share Target support |
 
 ---
 

--- a/e2e/tests/share-target.spec.ts
+++ b/e2e/tests/share-target.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+// The OS share sheet hands content to the installed PWA as a plain GET
+// navigation to the share_target action declared in public/manifest.json:
+//   /inbox?title=...&text=...&url=...
+// This reproduces that navigation in a real browser.
+test.describe('Web Share Target', () => {
+    async function login(page, baseURL) {
+        const appUrl =
+            baseURL ?? process.env.APP_URL ?? 'http://localhost:8080';
+        await page.goto(`${appUrl}/login`);
+        await page
+            .getByTestId('login-email')
+            .fill(process.env.E2E_EMAIL || 'test@tududi.com');
+        await page
+            .getByTestId('login-password')
+            .fill(process.env.E2E_PASSWORD || 'password123');
+        await page.getByTestId('login-submit').click();
+        await page.waitForURL(/\/(dashboard|today)/, { timeout: 10000 });
+        return appUrl;
+    }
+
+    test('prefills quick capture from a shared link', async ({
+        page,
+        baseURL,
+    }) => {
+        const appUrl = await login(page, baseURL);
+
+        await page.goto(
+            `${appUrl}/inbox?title=Great+article&url=https%3A%2F%2Fexample.com%2Fa`
+        );
+
+        const composer = page.locator('textarea').first();
+        await expect(composer).toHaveValue(
+            'Great article https://example.com/a'
+        );
+    });
+
+    test('prefills quick capture from shared plain text', async ({
+        page,
+        baseURL,
+    }) => {
+        const appUrl = await login(page, baseURL);
+
+        await page.goto(`${appUrl}/inbox?text=Buy+milk`);
+
+        const composer = page.locator('textarea').first();
+        await expect(composer).toHaveValue('Buy milk');
+    });
+});

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -1,5 +1,13 @@
 import React, { useEffect, useState, Suspense, lazy } from 'react';
-import { Routes, Route, Navigate, Outlet, useParams } from 'react-router-dom';
+import {
+    Routes,
+    Route,
+    Navigate,
+    Outlet,
+    useParams,
+    useNavigate,
+    useLocation,
+} from 'react-router-dom';
 
 const NoteRedirect: React.FC = () => {
     const { uidSlug } = useParams<{ uidSlug: string }>();
@@ -47,11 +55,17 @@ import { getApiPath, getLocalesPath } from './config/paths';
 import { useStore } from './store/useStore';
 import { invalidateProfileCache } from './utils/profileService';
 import { notifySwSession, notifySwClearCache } from './utils/swUtils';
+import {
+    clearSharedText,
+    hasPendingSharedText,
+} from './utils/shareTargetService';
 // Lazy load Tasks component to prevent issues with tags loading
 const Tasks = lazy(() => import('./components/Tasks'));
 
 const App: React.FC = () => {
     const { i18n } = useTranslation();
+    const navigate = useNavigate();
+    const location = useLocation();
     const [currentUser, setCurrentUser] = useState<User | null>(null);
     const [loading, setLoading] = useState(true);
 
@@ -136,6 +150,25 @@ const App: React.FC = () => {
                 handleUserLoggedIn as EventListener
             );
     }, []);
+
+    // A share handed over while the session was expired lands on /login, so
+    // send the user to the Inbox composer once they're authenticated again
+    useEffect(() => {
+        if (!currentUser) return;
+        if (location.pathname === '/inbox') return;
+        if (!hasPendingSharedText()) return;
+
+        navigate('/inbox', { replace: true });
+    }, [currentUser, location.pathname, navigate]);
+
+    // The Inbox keeps offering a claimed share while the user stays on it (the
+    // page remounts whenever Layout shows its first-load spinner), so the claim
+    // is released on the first navigation away from it instead.
+    useEffect(() => {
+        if (location.pathname !== '/inbox') {
+            clearSharedText();
+        }
+    }, [location.pathname]);
 
     useEffect(() => {
         if (i18n.isInitialized) {

--- a/frontend/components/Inbox/InboxItems.tsx
+++ b/frontend/components/Inbox/InboxItems.tsx
@@ -25,6 +25,7 @@ import { createProject } from '../../utils/projectsService';
 import { createNote } from '../../utils/notesService';
 import { OfflineQueuedError } from '../../utils/authUtils';
 import { isUrl } from '../../utils/urlService';
+import { takeSharedText } from '../../utils/shareTargetService';
 import { fetchAreas } from '../../utils/areasService';
 import { fetchProjects } from '../../utils/projectsService';
 import { useStore } from '../../store/useStore';
@@ -59,6 +60,11 @@ const InboxItems: React.FC = () => {
     const location = useLocation();
 
     const [hasInitialized, setHasInitialized] = useState(false);
+
+    // Content handed over by the OS share sheet (see shareTargetService) is
+    // prefilled into the composer rather than captured straight away, so the
+    // user can still edit it or pick task/note/project
+    const [sharedDraft] = useState<string>(() => takeSharedText() || '');
 
     const { inboxItems, isLoading, pagination, trashedCount } = useStore(
         (state) => state.inboxStore
@@ -669,6 +675,7 @@ const InboxItems: React.FC = () => {
                     onTaskCreate={handleSaveTask}
                     onNoteCreate={handleSaveNote}
                     projects={projects}
+                    initialValue={sharedDraft}
                     autoFocus={true}
                     openTaskModal={handleOpenTaskModal}
                     openProjectModal={handleOpenProjectModal}

--- a/frontend/components/Inbox/QuickCaptureInput.tsx
+++ b/frontend/components/Inbox/QuickCaptureInput.tsx
@@ -187,6 +187,12 @@ const QuickCaptureInput = React.forwardRef<
         useEffect(() => {
             if (autoFocus && inputRef.current) {
                 inputRef.current.focus();
+                // Prefilled text (e.g. handed over by the OS share sheet)
+                // should leave the caret ready to keep typing
+                const caret = inputRef.current.value.length;
+                if (caret > 0) {
+                    inputRef.current.setSelectionRange(caret, caret);
+                }
             }
         }, [autoFocus]);
 
@@ -1475,6 +1481,7 @@ const QuickCaptureInput = React.forwardRef<
                                         ref={(el) => {
                                             inputRef.current = el;
                                         }}
+                                        data-testid="quick-capture-input"
                                         value={inputText}
                                         rows={3}
                                         onChange={handleChange}

--- a/frontend/index.tsx
+++ b/frontend/index.tsx
@@ -10,8 +10,13 @@ import './styles/markdown.css'; // Import markdown styles
 import { I18nextProvider } from 'react-i18next';
 import i18n from './i18n'; // Import the i18n instance with its configuration
 import { getBasePath } from './config/paths';
+import { captureSharedPayload } from './utils/shareTargetService';
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
+
+// Stash anything handed over by the OS share sheet and clean the URL before
+// the router reads it (see share_target in public/manifest.json)
+captureSharedPayload();
 
 if (!isDevelopment && 'serviceWorker' in navigator) {
     window.addEventListener('load', () => {

--- a/frontend/utils/__tests__/shareTargetService.test.ts
+++ b/frontend/utils/__tests__/shareTargetService.test.ts
@@ -1,0 +1,149 @@
+const setLocation = (url: string) => {
+    window.history.replaceState({}, '', url);
+};
+
+// The service keeps the claimed share in module scope for the lifetime of a
+// page load, so each test gets a freshly loaded module — the equivalent of the
+// PWA being launched again from the share sheet.
+let share: typeof import('../shareTargetService');
+
+beforeEach(async () => {
+    sessionStorage.clear();
+    setLocation('/inbox');
+    jest.resetModules();
+    share = await import('../shareTargetService');
+});
+
+describe('composeSharedText', () => {
+    it('joins title, text and url', () => {
+        const params = new URLSearchParams({
+            title: 'Great article',
+            text: 'Worth reading',
+            url: 'https://example.com/a',
+        });
+
+        expect(share.composeSharedText(params)).toBe(
+            'Great article Worth reading https://example.com/a'
+        );
+    });
+
+    // Chrome on Android shares a link with the same URL in both `text` and
+    // `url`; naive concatenation would duplicate it
+    it('drops duplicate and empty values', () => {
+        const params = new URLSearchParams({
+            title: '',
+            text: 'https://example.com/a',
+            url: 'https://example.com/a',
+        });
+
+        expect(share.composeSharedText(params)).toBe('https://example.com/a');
+    });
+
+    it('returns an empty string when nothing was shared', () => {
+        expect(
+            share.composeSharedText(new URLSearchParams({ text: '  ' }))
+        ).toBe('');
+    });
+});
+
+describe('captureSharedPayload', () => {
+    it('stashes the shared text and strips the share params from the URL', () => {
+        setLocation('/inbox?title=Hello&url=https%3A%2F%2Fexample.com');
+
+        share.captureSharedPayload();
+
+        expect(window.location.pathname).toBe('/inbox');
+        expect(window.location.search).toBe('');
+        expect(share.hasPendingSharedText()).toBe(true);
+        expect(share.takeSharedText()).toBe('Hello https://example.com');
+    });
+
+    it('keeps unrelated query params', () => {
+        setLocation('/inbox?loaded=40&text=Buy%20milk');
+
+        share.captureSharedPayload();
+
+        expect(window.location.search).toBe('?loaded=40');
+        expect(share.takeSharedText()).toBe('Buy milk');
+    });
+
+    it('does nothing when the URL carries no share params', () => {
+        setLocation('/inbox?loaded=40');
+
+        share.captureSharedPayload();
+
+        expect(window.location.search).toBe('?loaded=40');
+        expect(share.hasPendingSharedText()).toBe(false);
+    });
+});
+
+describe('takeSharedText', () => {
+    // Regression: Layout swaps the routed page out for a full-screen spinner
+    // while its stores make their first fetch, so the Inbox mounts, unmounts
+    // and mounts again. A read that only worked once left the surviving
+    // composer empty on every cold PWA launch.
+    it('returns the same text on a remount within the page load', () => {
+        setLocation('/inbox?text=Buy%20milk');
+        share.captureSharedPayload();
+
+        expect(share.takeSharedText()).toBe('Buy milk');
+        expect(share.takeSharedText()).toBe('Buy milk');
+    });
+
+    // ...but a reload is a new page load, and must not replay the share
+    it('drops the persisted copy as soon as it is claimed', () => {
+        setLocation('/inbox?text=Buy%20milk');
+        share.captureSharedPayload();
+
+        share.takeSharedText();
+
+        expect(sessionStorage.getItem('tududi_pending_share')).toBeNull();
+        expect(share.hasPendingSharedText()).toBe(false);
+    });
+
+    it('ignores a share older than the max age', () => {
+        setLocation('/inbox?text=Buy%20milk');
+        share.captureSharedPayload();
+
+        const elevenMinutesLater = Date.now() + 11 * 60 * 1000;
+        const nowSpy = jest
+            .spyOn(Date, 'now')
+            .mockReturnValue(elevenMinutesLater);
+
+        expect(share.hasPendingSharedText()).toBe(false);
+        expect(share.takeSharedText()).toBeNull();
+
+        nowSpy.mockRestore();
+    });
+
+    it('ignores malformed stored payloads', () => {
+        sessionStorage.setItem('tududi_pending_share', 'not json');
+
+        expect(share.hasPendingSharedText()).toBe(false);
+        expect(share.takeSharedText()).toBeNull();
+    });
+});
+
+describe('clearSharedText', () => {
+    it('stops offering a claimed share', () => {
+        setLocation('/inbox?text=Buy%20milk');
+        share.captureSharedPayload();
+        share.takeSharedText();
+
+        share.clearSharedText();
+
+        expect(share.takeSharedText()).toBeNull();
+    });
+
+    // The bounce through /login clears on every non-Inbox route, and must not
+    // eat a share that no composer has had the chance to claim yet
+    it('leaves an unclaimed share alone', () => {
+        setLocation('/inbox?text=Buy%20milk');
+        share.captureSharedPayload();
+
+        share.clearSharedText();
+
+        expect(share.hasPendingSharedText()).toBe(true);
+        expect(share.takeSharedText()).toBe('Buy milk');
+    });
+});

--- a/frontend/utils/shareTargetService.ts
+++ b/frontend/utils/shareTargetService.ts
@@ -1,0 +1,157 @@
+// Web Share Target support. When the OS share sheet (Android, or desktop
+// Chrome/Edge) hands content to the installed PWA it performs a plain GET
+// navigation to the `action` declared in `share_target` (public/manifest.json)
+// with the shared title/text/url as query params.
+//
+// The payload is stashed in sessionStorage rather than read straight off the
+// URL because the navigation may be bounced to /login when the session has
+// expired, which would otherwise drop the shared content.
+
+const STORAGE_KEY = 'tududi_pending_share';
+
+// A share that has been sitting around this long is stale — the user has moved
+// on and we should not hijack their navigation with it.
+const MAX_AGE_MS = 10 * 60 * 1000;
+
+const SHARE_PARAMS = ['title', 'text', 'url'] as const;
+
+interface PendingShare {
+    text: string;
+    ts: number;
+}
+
+// The share text, once claimed for this page load. `undefined` means it has
+// not been looked up yet; `null` means there was nothing (or it has been dealt
+// with). Kept in memory because the Inbox composer mounts more than once per
+// page load: Layout swaps the routed page out for a full-screen loader while
+// its stores run their first fetch, which unmounts and remounts the page.
+// Emptying sessionStorage on that first, discarded mount would leave the
+// surviving composer blank — exactly what a cold PWA launch from the share
+// sheet does every time.
+let claimedText: string | null | undefined;
+
+/**
+ * Builds the composer text from shared params, dropping empties and
+ * duplicates: Android apps are inconsistent about which field holds what, and
+ * Chrome commonly sends the same URL as both `text` and `url`.
+ *
+ * Returns an empty string when nothing shareable was present.
+ */
+export const composeSharedText = (params: URLSearchParams): string => {
+    const parts: string[] = [];
+
+    for (const key of SHARE_PARAMS) {
+        const value = (params.get(key) || '').trim();
+        if (value && !parts.includes(value)) {
+            parts.push(value);
+        }
+    }
+
+    return parts.join(' ');
+};
+
+const hasShareParams = (params: URLSearchParams): boolean =>
+    SHARE_PARAMS.some((key) => params.has(key));
+
+const readPendingShare = (): PendingShare | null => {
+    try {
+        const raw = sessionStorage.getItem(STORAGE_KEY);
+        if (!raw) return null;
+
+        const parsed = JSON.parse(raw) as Partial<PendingShare>;
+        if (typeof parsed?.text !== 'string' || !parsed.text) return null;
+        if (
+            typeof parsed.ts !== 'number' ||
+            Date.now() - parsed.ts > MAX_AGE_MS
+        ) {
+            sessionStorage.removeItem(STORAGE_KEY);
+            return null;
+        }
+
+        return { text: parsed.text, ts: parsed.ts };
+    } catch {
+        // Private-mode storage failures / malformed JSON: behave as "no share"
+        return null;
+    }
+};
+
+/**
+ * Reads shared content out of the current URL and stashes it, then strips the
+ * share params so a reload or a bookmark doesn't replay the same share.
+ *
+ * Called once at startup, before React renders, so the router only ever sees
+ * the cleaned URL.
+ */
+export const captureSharedPayload = (): void => {
+    const params = new URLSearchParams(window.location.search);
+    if (!hasShareParams(params)) return;
+
+    const text = composeSharedText(params);
+
+    for (const key of SHARE_PARAMS) {
+        params.delete(key);
+    }
+    const query = params.toString();
+    window.history.replaceState(
+        window.history.state,
+        '',
+        `${window.location.pathname}${query ? `?${query}` : ''}${window.location.hash}`
+    );
+
+    if (!text) return;
+
+    // A newly arrived share supersedes anything claimed earlier in this page's
+    // lifetime (only reachable in tests, where the module isn't reloaded).
+    claimedText = undefined;
+
+    try {
+        sessionStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ text, ts: Date.now() } satisfies PendingShare)
+        );
+    } catch {
+        // Nothing to fall back to — the share is simply lost
+    }
+};
+
+/**
+ * True while a captured share is still waiting for a composer to claim it —
+ * i.e. the share arrived before the Inbox could be rendered (session expired,
+ * so the navigation landed on /login).
+ */
+export const hasPendingSharedText = (): boolean => readPendingShare() !== null;
+
+/**
+ * Returns the captured share text for this page load, stable across remounts.
+ *
+ * The persisted copy is dropped on the first call so a later reload can't
+ * replay the same share; call `clearSharedText()` once the user has acted on
+ * it to stop offering it for the rest of the page load.
+ */
+export const takeSharedText = (): string | null => {
+    if (claimedText === undefined) {
+        const pending = readPendingShare();
+        claimedText = pending ? pending.text : null;
+
+        if (pending) {
+            try {
+                sessionStorage.removeItem(STORAGE_KEY);
+            } catch {
+                // Ignore: worst case the same text is offered again on reload
+            }
+        }
+    }
+
+    return claimedText;
+};
+
+/**
+ * Drops a claimed share so returning to the Inbox later in the same page load
+ * doesn't prefill it again. A share that hasn't been claimed yet is left alone:
+ * it's still waiting for the Inbox to render (see `hasPendingSharedText`).
+ */
+export const clearSharedText = (): void => {
+    if (claimedText !== undefined) {
+        claimedText = null;
+    }
+};

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -10,6 +10,15 @@
   "background_color": "#ffffff",
   "lang": "en",
   "orientation": "portrait-primary",
+  "share_target": {
+    "action": "/inbox",
+    "method": "GET",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url"
+    }
+  },
   "icons": [
     {
       "src": "/icon-logo.png",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,6 @@
-const CACHE_VERSION = 'tududi-v1';
+// v2: manifest.json gained a share_target member, and the static cache is
+// cache-first — existing installs need the stale copy evicted to pick it up
+const CACHE_VERSION = 'tududi-v2';
 const API_CACHE = 'tududi-api-v1';
 const SYNC_QUEUE = 'tududi-sync-queue';
 


### PR DESCRIPTION


<!--
Thank you for contributing to tududi!

Before submitting:
1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
2. Run: npm run pre-push (linting, formatting, tests)
3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
4. Delete sections that don't apply
-->

## Description

### Note

This is an enhancement of the PWA, following https://github.com/chrisvel/tududi/discussions/243

This evolution was done with the help of Claude. It has been tested on an Android mobile and the sharing works as expected -- this is what is available after a share of a web page:

<img width="222" height="480" alt="Screenshot_20260829_182742_Chrome" src="https://github.com/user-attachments/assets/63b5fedf-fef3-43d0-bdae-4110791b3eac" />

### The actual changes

Declares a `share_target` in the manifest so an installed tududi appears in the Android (and desktop Chrome/Edge) share sheet. The OS hands the content over as a plain GET navigation to `/inbox?title=&text=&url=`, which `captureSharedPayload()` reads before React renders: it composes one string from the three params (dropping empties and the duplicate URL that Chrome sends as both `text` and `url`), stashes it, and strips the params from the URL so a reload can't replay the same share. The Inbox composer prefills it rather than auto-saving, so the smart parsing, URL preview and task/note/project choice all still apply.

The stash is needed because a share arriving on an expired session is redirected to /login, which would drop the query params; App then bounces back to /inbox once authenticated. Shares older than 10 minutes are ignored.

The claim also has to survive a remount: Layout swaps the routed page out for a full-screen spinner while its stores run their first fetch, so the Inbox mounts, unmounts and mounts again on every cold start - exactly what a launch from the share sheet is. A one-shot read was emptying sessionStorage on that first, discarded mount, leaving the surviving composer blank every time on Android. `takeSharedText()` therefore holds the payload in module scope for the page load, and App releases it on the first navigation away from /inbox.

Also restores `data-testid="quick-capture-input"` on the composer's textarea branch. The id only ever existed on the single-line input, so the 13 Inbox e2e specs had been failing to find the element since #1351 made multiline the default.


## Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Testing

**How did you test this?**

Forwarded a running environment via USB to an Android mobile (USB debugging), installed the PWA and successfully attempted to share a web page.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines (**hopefully**)
- [x] Tests, docs, migrations, and translations updated (if applicable)

## Additional Notes

Thank you to Claude Code for lots of help on that PR, as well as Gemini for cross-checks
