### PR TITLE
fix: exclude someday-tagged tasks from Today page's In Progress section

### DIFF
--- a/backend/modules/tasks/queries/metrics-computation.js
+++ b/backend/modules/tasks/queries/metrics-computation.js
@@ -252,7 +252,7 @@ async function computeTaskMetrics(
     ] = await Promise.all([
         countTotalOpenTasks(visibleTasksWhere),
         countTasksPendingOverMonth(visibleTasksWhere),
-        fetchTasksInProgress(visibleTasksWhere),
+        fetchTasksInProgress(visibleTasksWhere, somedayExcludedIds),
         fetchTodayPlanTasks(visibleTasksWhere, somedayExcludedIds),
         fetchTasksDueToday(
             visibleTasksWhere,

--- a/backend/modules/tasks/queries/metrics-queries.js
+++ b/backend/modules/tasks/queries/metrics-queries.js
@@ -58,19 +58,27 @@ async function countTasksPendingOverMonth(visibleTasksWhere) {
     });
 }
 
-async function fetchTasksInProgress(visibleTasksWhere) {
+async function fetchTasksInProgress(
+    visibleTasksWhere,
+    somedayExcludedIds = []
+) {
     const now = new Date();
+    const statusFilter = {
+        status: {
+            [Op.in]: [Task.STATUS.IN_PROGRESS, 'in_progress'],
+        },
+        parent_task_id: null,
+        recurring_parent_id: null,
+    };
+    if (somedayExcludedIds.length > 0) {
+        statusFilter.id = { [Op.notIn]: somedayExcludedIds };
+    }
+
     return await Task.findAll({
         where: {
             [Op.and]: [
                 visibleTasksWhere,
-                {
-                    status: {
-                        [Op.in]: [Task.STATUS.IN_PROGRESS, 'in_progress'],
-                    },
-                    parent_task_id: null,
-                    recurring_parent_id: null,
-                },
+                statusFilter,
                 // Exclude tasks deferred to the future
                 {
                     [Op.or]: [

--- a/backend/tests/integration/tasks-metrics.test.js
+++ b/backend/tests/integration/tasks-metrics.test.js
@@ -1,4 +1,4 @@
-const { Task, Project } = require('../../models');
+const { Task, Project, Tag } = require('../../models');
 const { createTestUser } = require('../helpers/testUtils');
 const {
     getTaskMetrics,
@@ -245,5 +245,58 @@ describe('Task Metrics Overdue and Due Today Tasks', () => {
         // WAITING task should be in today plan, not in overdue
         expect(overdueNames).not.toContain('Overdue Waiting');
         expect(todayPlanNames).toContain('Overdue Waiting');
+    });
+});
+
+describe('Task Metrics Someday Exclusion', () => {
+    let user;
+    let somedayTag;
+
+    const createTask = async (overrides = {}) => {
+        const { priority, status, ...rest } = overrides;
+        return await Task.create({
+            name: rest.name || 'Test task',
+            user_id: user.id,
+            status:
+                typeof status === 'string'
+                    ? Task.getStatusValue(status)
+                    : (status ?? Task.STATUS.NOT_STARTED),
+            priority:
+                typeof priority === 'string'
+                    ? Task.getPriorityValue(priority)
+                    : (priority ?? Task.PRIORITY.LOW),
+            parent_task_id: null,
+            recurring_parent_id: null,
+            ...rest,
+        });
+    };
+
+    beforeEach(async () => {
+        user = await createTestUser({ email: 'someday-test@example.com' });
+        // The 'someday' system tag is auto-seeded when a user is created
+        somedayTag = await Tag.findOne({
+            where: { user_id: user.id, name: 'someday' },
+        });
+    });
+
+    it('excludes someday-tagged in-progress tasks from tasks_in_progress', async () => {
+        const somedayTask = await createTask({
+            name: 'Someday In Progress',
+            status: Task.STATUS.IN_PROGRESS,
+        });
+        await somedayTask.addTag(somedayTag);
+
+        await createTask({
+            name: 'Regular In Progress',
+            status: Task.STATUS.IN_PROGRESS,
+        });
+
+        const metrics = await getTaskMetrics(user.id, 'UTC');
+        const inProgressNames = metrics.tasks_in_progress.map(
+            (task) => task.name
+        );
+
+        expect(inProgressNames).not.toContain('Someday In Progress');
+        expect(inProgressNames).toContain('Regular In Progress');
     });
 });


### PR DESCRIPTION
## Description

Tasks tagged `#someday` are supposed to be excluded from the Today page entirely. That exclusion was correctly wired into the Planned, Due Today, and Overdue sections (via a `somedayExcludedIds` list passed into their query functions), but `fetchTasksInProgress` never received it, so a `#someday`-tagged task set to "In Progress" still showed up in the Today page's In Progress section.

This threads `somedayExcludedIds` into `fetchTasksInProgress`, matching the pattern already used by the other three metrics queries.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1452

## Testing

**How did you test this?**

- Added a regression test verifying a someday-tagged in-progress task is excluded from `tasks_in_progress` while a regular in-progress task is still included.
- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
