### PR TITLE
fix(inbox): remove duplicate success toast when saving note from inbox

### DIFF
--- a/frontend/components/Inbox/InboxItems.tsx
+++ b/frontend/components/Inbox/InboxItems.tsx
@@ -571,9 +571,6 @@ const InboxItems: React.FC = () => {
             }
 
             await createNote(note);
-            showSuccessToast(
-                t('note.createSuccess', 'Note created successfully')
-            );
 
             if (currentConversionItemUid !== null) {
                 await handleProcessItem(currentConversionItemUid, false);


### PR DESCRIPTION
## Description

Saving an inbox item as a note showed the "Note created successfully" toast twice. `InboxItems.handleSaveNote` fired its own success toast after `createNote()`, and then `NoteModal`'s own submit handler also fired a success toast once `onSave()` resolved. Removed the redundant toast in `InboxItems`, leaving `NoteModal` as the single source of the toast, the same pattern already used by the plain Notes page.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Testing

**How did you test this?**

- Traced the two toast call sites (`InboxItems.tsx` and `NoteModal.tsx`) and confirmed only `NoteModal`'s toast remains on the inbox-to-note conversion path.
- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)