### PR TITLE
fix(attachments): display actual configured upload size limit

### DIFF
--- a/frontend/components/Project/BannerEditModal.tsx
+++ b/frontend/components/Project/BannerEditModal.tsx
@@ -4,6 +4,10 @@ import { useTranslation } from 'react-i18next';
 import { getPresetBanners, PresetBanner } from '../../utils/bannersService';
 import { getApiPath, getAssetPath } from '../../config/paths';
 import { getCsrfToken } from '../../utils/csrfService';
+import {
+    getServerConfig,
+    getFileUploadLimitMB,
+} from '../../utils/configService';
 
 interface BannerEditModalProps {
     isOpen: boolean;
@@ -25,6 +29,7 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
     const [isSaving, setIsSaving] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [presetBanners] = useState<PresetBanner[]>(getPresetBanners());
+    const [maxSizeMB, setMaxSizeMB] = useState(getFileUploadLimitMB());
     const fileInputRef = useRef<HTMLInputElement>(null);
     const modalRef = useRef<HTMLDivElement>(null);
     const [isClosing, setIsClosing] = useState(false);
@@ -32,6 +37,15 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
     useEffect(() => {
         setImagePreview(currentImageUrl);
     }, [currentImageUrl, isOpen]);
+
+    // Fetch the actual server-configured upload limit
+    useEffect(() => {
+        getServerConfig()
+            .then((config) => setMaxSizeMB(config.fileUploadLimitMB))
+            .catch(() => {
+                // Keep the fallback default if the config can't be fetched
+            });
+    }, []);
 
     useEffect(() => {
         const handleKeyDown = (event: KeyboardEvent) => {
@@ -59,12 +73,13 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
         const file = e.target.files?.[0];
         if (!file) return;
 
-        const maxSizeBytes = 10 * 1024 * 1024;
+        const maxSizeBytes = maxSizeMB * 1024 * 1024;
         if (file.size > maxSizeBytes) {
             setError(
                 t(
                     'errors.projectImageTooLarge',
-                    'Image is too large. Please choose a file under 10MB.'
+                    'Image is too large. Please choose a file under {{size}}MB.',
+                    { size: maxSizeMB }
                 )
             );
             if (fileInputRef.current) {
@@ -333,7 +348,8 @@ const BannerEditModal: React.FC<BannerEditModalProps> = ({
                                         <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
                                             {t(
                                                 'project.uploadImageHint',
-                                                'Upload an image for your project (max 10MB)'
+                                                'Upload an image for your project (max {{size}}MB)',
+                                                { size: maxSizeMB }
                                             )}
                                         </p>
                                     </div>

--- a/frontend/components/Task/TaskDetails/TaskAttachmentsCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskAttachmentsCard.tsx
@@ -10,6 +10,10 @@ import {
     validateFile,
     getAttachmentType,
 } from '../../../utils/attachmentsService';
+import {
+    getServerConfig,
+    getFileUploadLimitMB,
+} from '../../../utils/configService';
 import { useToast } from '../../Shared/ToastContext';
 import ConfirmDialog from '../../Shared/ConfirmDialog';
 import AttachmentCard from '../../Shared/AttachmentCard';
@@ -34,12 +38,22 @@ const TaskAttachmentsCard: React.FC<TaskAttachmentsCardProps> = ({
     const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
     const [attachmentToDelete, setAttachmentToDelete] =
         useState<Attachment | null>(null);
+    const [maxSizeMB, setMaxSizeMB] = useState(getFileUploadLimitMB());
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     // Load attachments on mount
     useEffect(() => {
         loadAttachments();
     }, [taskUid]);
+
+    // Fetch the actual server-configured upload limit
+    useEffect(() => {
+        getServerConfig()
+            .then((config) => setMaxSizeMB(config.fileUploadLimitMB))
+            .catch(() => {
+                // Keep the fallback default if the config can't be fetched
+            });
+    }, []);
 
     // Handle Escape key to close preview modal
     useEffect(() => {
@@ -229,7 +243,9 @@ const TaskAttachmentsCard: React.FC<TaskAttachmentsCardProps> = ({
                     </div>
                     <div className="p-4 flex-1 flex flex-col justify-center">
                         <p className="text-xs text-gray-500 dark:text-gray-400 text-center">
-                            {t('task.attachments.maxSize', 'Max 10MB')}
+                            {t('task.attachments.maxSize', 'Max {{size}}MB', {
+                                size: maxSizeMB,
+                            })}
                         </p>
                         <p className="text-xs text-gray-500 dark:text-gray-400 text-center mt-1">
                             {t(

--- a/frontend/components/Task/TaskForm/TaskAttachmentsSection.tsx
+++ b/frontend/components/Task/TaskForm/TaskAttachmentsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { CloudArrowUpIcon } from '@heroicons/react/24/outline';
 import { Attachment } from '../../../entities/Attachment';
@@ -8,6 +8,10 @@ import {
     downloadAttachment,
     validateFile,
 } from '../../../utils/attachmentsService';
+import {
+    getServerConfig,
+    getFileUploadLimitMB,
+} from '../../../utils/configService';
 import { useToast } from '../../Shared/ToastContext';
 import AttachmentListItem from '../../Shared/AttachmentListItem';
 import AttachmentPreview from '../../Shared/AttachmentPreview';
@@ -30,7 +34,17 @@ const TaskAttachmentsSection: React.FC<TaskAttachmentsSectionProps> = ({
     const [uploading, setUploading] = useState(false);
     const [previewAttachment, setPreviewAttachment] =
         useState<Attachment | null>(null);
+    const [maxSizeMB, setMaxSizeMB] = useState(getFileUploadLimitMB());
     const fileInputRef = useRef<HTMLInputElement>(null);
+
+    // Fetch the actual server-configured upload limit
+    useEffect(() => {
+        getServerConfig()
+            .then((config) => setMaxSizeMB(config.fileUploadLimitMB))
+            .catch(() => {
+                // Keep the fallback default if the config can't be fetched
+            });
+    }, []);
 
     const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
         const file = e.target.files?.[0];
@@ -151,7 +165,8 @@ const TaskAttachmentsSection: React.FC<TaskAttachmentsSectionProps> = ({
                 <p className="text-xs text-gray-500 dark:text-gray-400">
                     {t(
                         'task.attachments.allowedTypes',
-                        'PDF, DOC, DOCX, TXT, MD, Images, XLS, XLSX, CSV, ZIP (max 10MB)'
+                        'PDF, DOC, DOCX, TXT, MD, Images, XLS, XLSX, CSV, ZIP (max {{size}}MB)',
+                        { size: maxSizeMB }
                     )}
                 </p>
             </div>

--- a/frontend/utils/configService.ts
+++ b/frontend/utils/configService.ts
@@ -5,23 +5,36 @@ interface ServerConfig {
 }
 
 let cachedConfig: ServerConfig | null = null;
+let pendingRequest: Promise<ServerConfig> | null = null;
 
 export async function getServerConfig(): Promise<ServerConfig> {
     if (cachedConfig) {
         return cachedConfig;
     }
 
-    const response = await fetch(getApiPath('config'), {
-        method: 'GET',
-        credentials: 'include',
-    });
-
-    if (!response.ok) {
-        throw new Error('Failed to fetch server configuration');
+    if (pendingRequest) {
+        return pendingRequest;
     }
 
-    cachedConfig = await response.json();
-    return cachedConfig;
+    pendingRequest = (async () => {
+        const response = await fetch(getApiPath('config'), {
+            method: 'GET',
+            credentials: 'include',
+        });
+
+        if (!response.ok) {
+            throw new Error('Failed to fetch server configuration');
+        }
+
+        cachedConfig = await response.json();
+        return cachedConfig;
+    })();
+
+    try {
+        return await pendingRequest;
+    } finally {
+        pendingRequest = null;
+    }
 }
 
 export function getFileUploadLimitMB(): number {


### PR DESCRIPTION
## Description

The task attachment upload UI displayed a hardcoded "Max 10MB" hint regardless of the `FILE_UPLOAD_LIMIT_MB` environment variable, even though the backend (multer limits, body-parser limits) already enforced the correct configured value. The frontend's client-side `validateFile` also already used the real limit correctly, so users could see a misleading "10MB" label while actually being allowed to upload much larger files (or vice versa).

The project banner upload had the same display problem, plus its client-side size check itself was hardcoded to 10MB independent of the server config, which could incorrectly reject valid uploads when the configured limit differed from 10MB.

Both now fetch the real limit from the existing `/api/config` endpoint (via `configService.ts`) and use it for both the displayed text and the client-side size check. Also made `configService`'s fetch de-duplicate concurrent in-flight requests, since multiple components now call `getServerConfig()` on mount.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1455

## Testing

**How did you test this?**

- Verified `npx tsc --noEmit` and `npm run lint` pass with no new errors.
- Manually traced the data flow: `/api/config` already returns `fileUploadLimitMB` from `FILE_UPLOAD_LIMIT_MB`; confirmed the three UI locations (`TaskAttachmentsCard`, `TaskAttachmentsSection`, `BannerEditModal`) now read that value instead of a hardcoded `10`.
- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
