### PR TITLE
fix(habits): respect first day of week setting in habit calendars

### DIFF
--- a/frontend/components/Habits/HabitDetails.tsx
+++ b/frontend/components/Habits/HabitDetails.tsx
@@ -24,6 +24,10 @@ import {
     TrashIcon,
 } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
+import {
+    getFirstDayOfWeek,
+    getLocaleFirstDayOfWeek,
+} from '../../utils/profileService';
 
 const mapHabitToEditableValues = (task: Task) => ({
     name: task.name || '',
@@ -57,6 +61,7 @@ const HabitDetails: React.FC = () => {
         null
     );
     const [savingField, setSavingField] = useState<EditableField | null>(null);
+    const [firstDayOfWeek, setFirstDayOfWeek] = useState(0);
     const HISTORY_DAYS = 90;
     const DAYS_PER_CALENDAR = 30;
     const editingFieldRef = useRef<EditableField | null>(null);
@@ -165,6 +170,18 @@ const HabitDetails: React.FC = () => {
             setEditingField('name');
         }
     }, [uid]);
+
+    useEffect(() => {
+        const loadFirstDayOfWeek = async () => {
+            try {
+                const firstDay = await getFirstDayOfWeek();
+                setFirstDayOfWeek(firstDay);
+            } catch {
+                setFirstDayOfWeek(getLocaleFirstDayOfWeek(navigator.language));
+            }
+        };
+        loadFirstDayOfWeek();
+    }, []);
 
     useEffect(() => {
         editingFieldRef.current = editingField;
@@ -598,11 +615,20 @@ const HabitDetails: React.FC = () => {
         const normalizedEnd = new Date(rangeEnd);
         normalizedEnd.setHours(23, 59, 59, 999);
         const firstDay = new Date(normalizedStart);
-        firstDay.setDate(firstDay.getDate() - firstDay.getDay());
+        firstDay.setDate(
+            firstDay.getDate() - ((firstDay.getDay() - firstDayOfWeek + 7) % 7)
+        );
         const lastDay = new Date(normalizedEnd);
-        lastDay.setDate(lastDay.getDate() + (6 - lastDay.getDay()));
+        lastDay.setDate(
+            lastDay.getDate() +
+                (6 - ((lastDay.getDay() - firstDayOfWeek + 7) % 7))
+        );
 
-        const dayLabels = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+        const allDayLabels = ['S', 'M', 'T', 'W', 'T', 'F', 'S'];
+        const dayLabels = [
+            ...allDayLabels.slice(firstDayOfWeek),
+            ...allDayLabels.slice(0, firstDayOfWeek),
+        ];
         const calendarDays = [];
         const currentDate = new Date(firstDay);
 


### PR DESCRIPTION
## Description

The habit detail page calendars always rendered with Sunday as the first column, ignoring the user's start-of-week profile setting. This change loads the setting via `getFirstDayOfWeek()` (with the same locale-based fallback used by `DatePicker`) and rotates both the day labels and the leading/trailing grid padding so the calendars start on the configured day.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1454

## Testing

**How did you test this?**

- Frontend Jest suite: 15 suites, 106 tests passing
- `tsc --noEmit`, ESLint, and Prettier all clean
- Verified the grid math: the leading offset is computed as `(startDay - firstDayOfWeek + 7) % 7` and labels are rotated to match, mirroring the existing `DatePicker` and calendar view implementations

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)