### PR TITLE
fix(habits): align habit history calendars to calendar months so headings match grids

### DIFF
--- a/frontend/components/Habits/HabitDetails.tsx
+++ b/frontend/components/Habits/HabitDetails.tsx
@@ -62,8 +62,7 @@ const HabitDetails: React.FC = () => {
     );
     const [savingField, setSavingField] = useState<EditableField | null>(null);
     const [firstDayOfWeek, setFirstDayOfWeek] = useState(0);
-    const HISTORY_DAYS = 90;
-    const DAYS_PER_CALENDAR = 30;
+    const CALENDAR_MONTHS = 3;
     const editingFieldRef = useRef<EditableField | null>(null);
     const titleInputRef = useRef<HTMLInputElement | null>(null);
     const targetFrequencyContainerRef = useRef<HTMLDivElement | null>(null);
@@ -249,8 +248,9 @@ const HabitDetails: React.FC = () => {
         if (!uid || isNewHabit) return [];
         try {
             const startDate = new Date();
+            startDate.setDate(1);
+            startDate.setMonth(startDate.getMonth() - (CALENDAR_MONTHS - 1));
             startDate.setHours(0, 0, 0, 0);
-            startDate.setDate(startDate.getDate() - (HISTORY_DAYS - 1));
 
             const endDate = new Date();
             endDate.setHours(23, 59, 59, 999);
@@ -594,20 +594,23 @@ const HabitDetails: React.FC = () => {
     };
 
     const today = new Date();
-    const calendarRanges = Array.from(
-        { length: Math.ceil(HISTORY_DAYS / DAYS_PER_CALENDAR) },
-        (_, idx) => {
-            const rangeEnd = new Date(today);
-            rangeEnd.setDate(rangeEnd.getDate() - idx * DAYS_PER_CALENDAR);
-            const rangeStart = new Date(rangeEnd);
-            rangeStart.setDate(rangeEnd.getDate() - (DAYS_PER_CALENDAR - 1));
-            const monthLabel = rangeEnd.toLocaleString(undefined, {
-                month: 'long',
-                year: 'numeric',
-            });
-            return { rangeStart, rangeEnd, monthLabel };
-        }
-    );
+    const calendarRanges = Array.from({ length: CALENDAR_MONTHS }, (_, idx) => {
+        const rangeStart = new Date(
+            today.getFullYear(),
+            today.getMonth() - idx,
+            1
+        );
+        const rangeEnd = new Date(
+            today.getFullYear(),
+            today.getMonth() - idx + 1,
+            0
+        );
+        const monthLabel = rangeStart.toLocaleString(undefined, {
+            month: 'long',
+            year: 'numeric',
+        });
+        return { rangeStart, rangeEnd, monthLabel };
+    });
 
     const renderCalendar = (rangeStart: Date, rangeEnd: Date) => {
         const normalizedStart = new Date(rangeStart);
@@ -1096,7 +1099,7 @@ const HabitDetails: React.FC = () => {
                 {!isNewHabit && (
                     <div className="bg-white dark:bg-gray-900 rounded-lg shadow p-6 mb-8">
                         <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
-                            {t('habits.history', 'Last 90 Days')}
+                            {t('habits.history', 'Last 3 Months')}
                         </h2>
                         <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                             {t(


### PR DESCRIPTION
## Description

In the habit detail page, the "Last 90 Days" section rendered three rolling 30-day windows (ending today, today-30, today-60) but labelled each grid with the month of the window's end date. Since almost every day in such a window belongs to the previous month, each heading named the month after the one actually rendered (for example, on 1 September the newest grid was effectively August but was headed "September").

Rather than relabelling the rolling windows (which can genuinely span two months, so no single-month heading is ever correct), the grids are now aligned to real calendar months: the current month plus the two previous ones. Each heading is derived from the same month as its grid, so they can no longer drift apart.

Also:
- Completions are now fetched from the first day of the oldest displayed month, so the oldest grid is always fully covered.
- The section title default changed from "Last 90 Days" to "Last 3 Months" to match the new layout (no locale defines `habits.history`, so this is a single inline default).

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1451

## Testing

**How did you test this?**

- Verified the month math: each grid's range is the 1st through the last day of its month, and the heading is formatted from the range start, so heading and grid always agree (including on the 1st of a month, the reported case).
- `npx tsc --noEmit` passes.
- `npm run lint` passes (0 errors).
- Frontend Jest suite passes (15 suites, 106 tests).

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)