### PR TITLE
fix(markdown): detect Obsidian-style callouts past leading whitespace nodes

### DIFF
--- a/frontend/components/Shared/MarkdownRenderer.tsx
+++ b/frontend/components/Shared/MarkdownRenderer.tsx
@@ -4,7 +4,8 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeHighlight from 'rehype-highlight';
 import hljs from 'highlight.js';
-import CalloutBlock, { CalloutType } from './CalloutBlock';
+import CalloutBlock from './CalloutBlock';
+import { detectCallout } from '../../utils/calloutParser';
 import { useStore } from '../../store/useStore';
 
 const WIKILINK_PREFIX = '/__wikilink__/';
@@ -17,10 +18,16 @@ function preprocessWikilinks(content: string): string {
 }
 
 function slugify(text: string): string {
-    return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+    return text
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
 }
 
-const CodeBlock: React.FC<React.HTMLAttributes<HTMLPreElement>> = ({ children, ...props }) => {
+const CodeBlock: React.FC<React.HTMLAttributes<HTMLPreElement>> = ({
+    children,
+    ...props
+}) => {
     const preRef = useRef<HTMLPreElement>(null);
     const [copied, setCopied] = useState(false);
 
@@ -326,8 +333,12 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
                     // Customize link styles — wikilinks get a note-chip style
                     a: ({ href, children, ...props }) => {
                         if (href?.startsWith(WIKILINK_PREFIX)) {
-                            const title = decodeURIComponent(href.slice(WIKILINK_PREFIX.length));
-                            const slug = noteTitleToSlug.get(title.toLowerCase());
+                            const title = decodeURIComponent(
+                                href.slice(WIKILINK_PREFIX.length)
+                            );
+                            const slug = noteTitleToSlug.get(
+                                title.toLowerCase()
+                            );
                             const to = slug ? `/note/${slug}` : null;
                             const badge = (
                                 <span className="inline-flex items-stretch rounded overflow-hidden align-middle border border-blue-200 dark:border-blue-700/70 mt-2">
@@ -344,7 +355,10 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
                                     {badge}
                                 </Link>
                             ) : (
-                                <span className="cursor-default" title="Note not found">
+                                <span
+                                    className="cursor-default"
+                                    title="Note not found"
+                                >
                                     {badge}
                                 </span>
                             );
@@ -404,24 +418,49 @@ const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
 
                     // Customize blockquote styles — detect Obsidian-style callouts
                     blockquote: ({ node, children, ...props }) => {
-                        const firstHastChild = (node as any)?.children?.[0];
-                        if (firstHastChild?.type === 'element' && firstHastChild?.tagName === 'p') {
-                            const firstText = firstHastChild?.children?.[0];
-                            if (firstText?.type === 'text') {
-                                const match = (firstText.value as string)?.match(
-                                    /^\[!(NOTE|WARNING|TIP|IMPORTANT|DANGER)\](?:\s+(.*))?$/i
-                                );
-                                if (match) {
-                                    const calloutType = match[1].toUpperCase() as CalloutType;
-                                    const title = match[2]?.trim();
-                                    const contentChildren = React.Children.toArray(children).slice(1);
-                                    return (
-                                        <CalloutBlock type={calloutType} title={title}>
-                                            {contentChildren.length > 0 ? contentChildren : null}
-                                        </CalloutBlock>
+                        const callout = detectCallout(node);
+                        if (callout) {
+                            const blockChildren =
+                                React.Children.toArray(children);
+                            const markerIndex = blockChildren.findIndex((c) =>
+                                React.isValidElement(c)
+                            );
+                            const contentChildren = blockChildren.slice(
+                                markerIndex + 1
+                            );
+                            const markerParagraph = blockChildren[markerIndex];
+                            if (React.isValidElement(markerParagraph)) {
+                                // Keep soft-wrapped body text that shares the marker's
+                                // paragraph (e.g. "> [!NOTE]\n> body" with no blank line)
+                                const inlineRest = React.Children.toArray(
+                                    (markerParagraph.props as any).children
+                                ).slice(1);
+                                const leadChildren = [
+                                    ...(callout.remainderText
+                                        ? [callout.remainderText]
+                                        : []),
+                                    ...inlineRest,
+                                ];
+                                if (leadChildren.length > 0) {
+                                    contentChildren.unshift(
+                                        React.cloneElement(
+                                            markerParagraph,
+                                            undefined,
+                                            ...leadChildren
+                                        )
                                     );
                                 }
                             }
+                            return (
+                                <CalloutBlock
+                                    type={callout.type}
+                                    title={callout.title}
+                                >
+                                    {contentChildren.length > 0
+                                        ? contentChildren
+                                        : null}
+                                </CalloutBlock>
+                            );
                         }
                         return (
                             <blockquote

--- a/frontend/utils/__tests__/calloutParser.test.ts
+++ b/frontend/utils/__tests__/calloutParser.test.ts
@@ -1,0 +1,122 @@
+import { detectCallout } from '../calloutParser';
+
+const text = (value: string) => ({ type: 'text', value });
+const paragraph = (...children: any[]) => ({
+    type: 'element',
+    tagName: 'p',
+    children,
+});
+const blockquote = (...children: any[]) => ({
+    type: 'element',
+    tagName: 'blockquote',
+    children,
+});
+
+describe('detectCallout', () => {
+    it('detects a callout when a whitespace text node precedes the paragraph', () => {
+        const node = blockquote(
+            text('\n'),
+            paragraph(text('[!NOTE]')),
+            text('\n'),
+            paragraph(text('Body text.')),
+            text('\n')
+        );
+
+        expect(detectCallout(node)).toEqual({
+            type: 'NOTE',
+            title: undefined,
+            remainderText: '',
+        });
+    });
+
+    it('detects a callout when the paragraph is the first child', () => {
+        const node = blockquote(paragraph(text('[!WARNING]')));
+
+        expect(detectCallout(node)).toMatchObject({ type: 'WARNING' });
+    });
+
+    it('extracts the title from the marker line', () => {
+        const node = blockquote(
+            text('\n'),
+            paragraph(text('[!WARNING] Watch out'))
+        );
+
+        expect(detectCallout(node)).toEqual({
+            type: 'WARNING',
+            title: 'Watch out',
+            remainderText: '',
+        });
+    });
+
+    it('keeps soft-wrapped lines after the marker as remainder text', () => {
+        const node = blockquote(
+            text('\n'),
+            paragraph(text('[!NOTE]\nline one\nline two'))
+        );
+
+        expect(detectCallout(node)).toEqual({
+            type: 'NOTE',
+            title: undefined,
+            remainderText: 'line one\nline two',
+        });
+    });
+
+    it('separates a same-line title from soft-wrapped body lines', () => {
+        const node = blockquote(
+            text('\n'),
+            paragraph(text('[!TIP] My title\nbody line'))
+        );
+
+        expect(detectCallout(node)).toEqual({
+            type: 'TIP',
+            title: 'My title',
+            remainderText: 'body line',
+        });
+    });
+
+    it('matches markers case-insensitively and normalizes the type', () => {
+        const node = blockquote(text('\n'), paragraph(text('[!important]')));
+
+        expect(detectCallout(node)).toMatchObject({ type: 'IMPORTANT' });
+    });
+
+    it('returns null for a plain blockquote', () => {
+        const node = blockquote(text('\n'), paragraph(text('just a quote')));
+
+        expect(detectCallout(node)).toBeNull();
+    });
+
+    it('returns null for unknown callout types', () => {
+        const node = blockquote(text('\n'), paragraph(text('[!FOO]\nbody')));
+
+        expect(detectCallout(node)).toBeNull();
+    });
+
+    it('returns null when the first element is not a paragraph', () => {
+        const node = blockquote(text('\n'), {
+            type: 'element',
+            tagName: 'ul',
+            children: [],
+        });
+
+        expect(detectCallout(node)).toBeNull();
+    });
+
+    it('returns null when the paragraph starts with a non-text node', () => {
+        const node = blockquote(
+            text('\n'),
+            paragraph({
+                type: 'element',
+                tagName: 'strong',
+                children: [text('[!NOTE]')],
+            })
+        );
+
+        expect(detectCallout(node)).toBeNull();
+    });
+
+    it('returns null for empty or missing nodes', () => {
+        expect(detectCallout(undefined)).toBeNull();
+        expect(detectCallout(blockquote())).toBeNull();
+    });
+});

--- a/frontend/utils/calloutParser.ts
+++ b/frontend/utils/calloutParser.ts
@@ -1,0 +1,41 @@
+import type { CalloutType } from '../components/Shared/CalloutBlock';
+
+export interface CalloutMatch {
+    type: CalloutType;
+    title?: string;
+    remainderText: string;
+}
+
+const CALLOUT_MARKER_REGEX =
+    /^\[!(NOTE|WARNING|TIP|IMPORTANT|DANGER)\](?:\s+(.*))?$/i;
+
+export function detectCallout(blockquoteNode: any): CalloutMatch | null {
+    const children = blockquoteNode?.children ?? [];
+    // remark/rehype insert whitespace text nodes (e.g. "\n") between block
+    // children, so the paragraph is not necessarily at index 0
+    const firstElement = children.find((c: any) => c?.type === 'element');
+    if (!firstElement || firstElement.tagName !== 'p') {
+        return null;
+    }
+    const firstText = firstElement.children?.[0];
+    if (firstText?.type !== 'text' || typeof firstText.value !== 'string') {
+        return null;
+    }
+    // Only the first line carries the marker and optional title; any
+    // soft-wrapped lines after it belong to the callout body
+    const newlineIndex = firstText.value.indexOf('\n');
+    const firstLine =
+        newlineIndex === -1
+            ? firstText.value
+            : firstText.value.slice(0, newlineIndex);
+    const match = firstLine.match(CALLOUT_MARKER_REGEX);
+    if (!match) {
+        return null;
+    }
+    return {
+        type: match[1].toUpperCase() as CalloutType,
+        title: match[2]?.trim() || undefined,
+        remainderText:
+            newlineIndex === -1 ? '' : firstText.value.slice(newlineIndex + 1),
+    };
+}


### PR DESCRIPTION
## Description

`MarkdownRenderer`'s blockquote override detects Obsidian-style callouts (`> [!NOTE]`, `> [!WARNING]`, etc.) by checking the blockquote's first HAST child. remark/rehype insert a leading whitespace text node before the actual `<p>` element, so `node.children[0]` was never the paragraph and the callout marker was always rendered as plain blockquote text instead of a styled `CalloutBlock`.

The detection logic is pulled out into `frontend/utils/calloutParser.ts`, which scans for the first *element* child instead of assuming index 0, and also preserves soft-wrapped body text that shares the marker's paragraph (e.g. `> [!NOTE]\n> body` with no blank line in between).

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1450

## Testing

**How did you test this?**

- Added `frontend/utils/__tests__/calloutParser.test.ts` covering the whitespace-node case from the issue, title extraction, soft-wrapped body lines, case-insensitive matching, and the various null/non-match paths.
- `npm run pre-push` passes
- Manually verified the repro from the issue renders as a styled Note callout instead of a plain blockquote.

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
