### PR TITLE
fix(auth): lowercase legacy user emails so old accounts can log in

### DIFF
--- a/backend/migrations/20260906000001-lowercase-user-emails.js
+++ b/backend/migrations/20260906000001-lowercase-user-emails.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// Migrations run on SQLite and PostgreSQL. Keep them dialect-safe:
+//   - prefer the safe* helpers in ../utils/migration-utils.js
+//   - no PRAGMA, sqlite_master, AUTOINCREMENT or backtick identifiers
+//   - compare booleans with true/false, never 0/1
+//   - branch on queryInterface.sequelize.getDialect() only when unavoidable
+// See docs/database.md, "Writing dialect-safe migrations".
+
+// Accounts created before the User model started lowercasing emails on write
+// (February 2026) still store the address as typed. Login, registration and
+// OIDC provisioning now look users up by the lowercased email, so those
+// accounts became unreachable and TUDUDI_USER_EMAIL created a second, empty
+// admin on start. Normalise the stored value; rows that would collide with
+// another account after lowercasing are left untouched and reported so an
+// administrator can merge them by hand.
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const { sequelize } = queryInterface;
+        const { QueryTypes } = Sequelize;
+
+        const peopleColumns = await queryInterface
+            .describeTable('people')
+            .catch(() => ({}));
+        const syncSelfPerson = Boolean(
+            peopleColumns.linked_user_id && peopleColumns.email
+        );
+
+        const transaction = await sequelize.transaction();
+        try {
+            const mixedCase = await sequelize.query(
+                'SELECT id, email FROM users WHERE email IS NOT NULL AND email <> LOWER(email)',
+                { type: QueryTypes.SELECT, transaction }
+            );
+
+            let updated = 0;
+            const skipped = [];
+            for (const user of mixedCase) {
+                const lower = user.email.trim().toLowerCase();
+                const collisions = await sequelize.query(
+                    'SELECT id FROM users WHERE LOWER(email) = :lower AND id <> :id',
+                    {
+                        replacements: { lower, id: user.id },
+                        type: QueryTypes.SELECT,
+                        transaction,
+                    }
+                );
+                if (collisions.length > 0) {
+                    skipped.push({
+                        id: user.id,
+                        email: user.email,
+                        collidesWith: collisions.map((row) => row.id),
+                    });
+                    continue;
+                }
+
+                await sequelize.query(
+                    'UPDATE users SET email = :lower WHERE id = :id',
+                    { replacements: { lower, id: user.id }, transaction }
+                );
+                if (syncSelfPerson) {
+                    await sequelize.query(
+                        'UPDATE people SET email = :lower WHERE user_id = :id AND linked_user_id = :id AND email IS NOT NULL',
+                        { replacements: { lower, id: user.id }, transaction }
+                    );
+                }
+                updated++;
+            }
+
+            await transaction.commit();
+
+            if (updated > 0) {
+                console.log(`Lowercased ${updated} user email(s)`);
+            }
+            for (const entry of skipped) {
+                console.warn(
+                    `⚠️  users.id=${entry.id} keeps email "${entry.email}": lowercasing it would collide with users.id=${entry.collidesWith.join(', ')}. Merge or rename one of the accounts by hand.`
+                );
+            }
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+
+    async down() {
+        // The original casing is not recorded; lowercased emails stay valid.
+    },
+};

--- a/backend/tests/unit/migrations/lowercase-user-emails.test.js
+++ b/backend/tests/unit/migrations/lowercase-user-emails.test.js
@@ -1,0 +1,108 @@
+const { Sequelize } = require('sequelize');
+const { sequelize, User, Person } = require('../../../models');
+const migration = require('../../../migrations/20260906000001-lowercase-user-emails');
+
+// Rows are inserted with raw SQL because the User model lowercases emails on
+// write, which is exactly the normalisation legacy rows never received.
+async function insertUser(email, name) {
+    const [result] = await sequelize.query(
+        `INSERT INTO users (uid, email, name, password_digest, created_at, updated_at)
+         VALUES (:uid, :email, :name, 'x', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+        {
+            replacements: {
+                uid: `uid-${Math.random().toString(36).slice(2, 12)}`,
+                email,
+                name,
+            },
+        }
+    );
+    const user = await User.findOne({ where: { name } });
+    expect(user).toBeTruthy();
+    return user || result;
+}
+
+async function insertSelfPerson(user, email) {
+    await sequelize.query(
+        `INSERT INTO people (uid, user_id, linked_user_id, name, email, relationship_type, archived, created_at, updated_at)
+         VALUES (:uid, :id, :id, :name, :email, 'other', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+        {
+            replacements: {
+                uid: `puid-${Math.random().toString(36).slice(2, 12)}`,
+                id: user.id,
+                name: user.name,
+                email,
+            },
+        }
+    );
+}
+
+function runUp() {
+    return migration.up(sequelize.getQueryInterface(), Sequelize);
+}
+
+describe('migration 20260906000001-lowercase-user-emails', () => {
+    let warn;
+
+    beforeEach(() => {
+        warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    it('lowercases mixed-case emails and the linked self-person', async () => {
+        const legacy = await insertUser('Alice.Legacy@Example.COM', 'alice');
+        await insertSelfPerson(legacy, 'Alice.Legacy@Example.COM');
+        const modern = await insertUser('bob@example.com', 'bob');
+
+        await runUp();
+
+        await legacy.reload();
+        await modern.reload();
+        expect(legacy.email).toBe('alice.legacy@example.com');
+        expect(modern.email).toBe('bob@example.com');
+        const person = await Person.findOne({
+            where: { user_id: legacy.id, linked_user_id: legacy.id },
+        });
+        expect(person.email).toBe('alice.legacy@example.com');
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('leaves accounts alone when lowercasing would collide', async () => {
+        const first = await insertUser('carol@example.com', 'carol');
+        const second = await insertUser('Carol@Example.com', 'carol2');
+
+        await runUp();
+
+        await first.reload();
+        await second.reload();
+        expect(first.email).toBe('carol@example.com');
+        expect(second.email).toBe('Carol@Example.com');
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0][0]).toContain(`users.id=${second.id}`);
+        expect(warn.mock.calls[0][0]).toContain(`users.id=${first.id}`);
+    });
+
+    it('is a no-op when every email is already lowercase', async () => {
+        const user = await insertUser('dave@example.com', 'dave');
+        const before = user.updated_at;
+
+        await runUp();
+
+        await user.reload();
+        expect(user.email).toBe('dave@example.com');
+        expect(user.updated_at).toEqual(before);
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('makes the legacy account reachable through the login lookup', async () => {
+        await insertUser('Erin@Example.ORG', 'erin');
+        expect(
+            await User.findOne({ where: { email: 'erin@example.org' } })
+        ).toBeNull();
+
+        await runUp();
+
+        expect(
+            await User.findOne({ where: { email: 'erin@example.org' } })
+        ).not.toBeNull();
+    });
+});

--- a/backend/tests/upgrade/legacy-sqlite-upgrade.test.js
+++ b/backend/tests/upgrade/legacy-sqlite-upgrade.test.js
@@ -169,19 +169,14 @@ describe.each(fixtures)('upgrade from $name', (fixture) => {
                 expect(smoke.login.bob).toBe(200);
             });
 
-            // Accounts created before the lowercasing hook (Feb 2026) still carry
-            // mixed-case emails, which the current login lookup cannot find. Fixed
-            // by the follow-up data migration ("lowercase legacy emails"); flip to
-            // a plain `it` once it lands.
-            it.failing(
-                'logs in a legacy user with a mixed-case stored email',
-                () => {
-                    expect([
-                        smoke.login.aliceLower,
-                        smoke.login.aliceMixed,
-                    ]).toEqual([200, 200]);
-                }
-            );
+            // Accounts created before the lowercasing hook (Feb 2026) carry
+            // mixed-case emails; 20260906000001-lowercase-user-emails fixes them.
+            it('logs in a legacy user with a mixed-case stored email', () => {
+                expect([
+                    smoke.login.aliceLower,
+                    smoke.login.aliceMixed,
+                ]).toEqual([200, 200]);
+            });
 
             it('serves every list and metrics endpoint', () => {
                 expect(smoke.login.aliceAfterNormalise).toBe(200);

--- a/scripts/test-upgrade-docker.sh
+++ b/scripts/test-upgrade-docker.sh
@@ -237,19 +237,17 @@ fi
 
 NEW_JAR="$WORK/new.jar"
 check "$([ "$(api_login "$NEW_PORT" "$BOB_EMAIL" "$NEW_JAR")" = "200" ]; echo $?)" "new image: login as $BOB_EMAIL"
-# TUDUDI_USER_EMAIL names the legacy admin in its lowercase form. Until the
-# lowercase-emails migration lands, user-create.js cannot find the mixed-case
-# row and creates a second, empty admin account instead; the user count tells
-# the two outcomes apart.
+# TUDUDI_USER_EMAIL names the legacy admin in its lowercase form. The
+# lowercase-emails migration must have normalised the stored row so
+# user-create.js updates it instead of creating a second, empty admin.
 USERS_AFTER="$(count_users)"
 ALICE_LOWER="$(api_login "$NEW_PORT" "$ADMIN_EMAIL" "$WORK/a1.jar")"
 ALICE_MIXED="$(api_login "$NEW_PORT" "$ADMIN_EMAIL_MIXED" "$WORK/a2.jar")"
+check "$([ "$ALICE_LOWER" = "200" ] && [ "$ALICE_MIXED" = "200" ]; echo $?)" "new image: legacy mixed-case admin can log in ($ALICE_LOWER / $ALICE_MIXED)"
 if [ "$USERS_BEFORE" = "?" ]; then
     yellow "  note new image: sqlite3 CLI missing, cannot verify the admin account was reused"
-elif [ "$USERS_AFTER" = "$USERS_BEFORE" ] && [ "$ALICE_LOWER" = "200" ] && [ "$ALICE_MIXED" = "200" ]; then
-    green "  ok   new image: legacy mixed-case admin reused and can log in"
 else
-    yellow "  note new image: users $USERS_BEFORE -> $USERS_AFTER, legacy admin login $ALICE_LOWER / $ALICE_MIXED (a duplicate admin means TUDUDI_USER_EMAIL did not match the mixed-case row; fixed by the lowercase-emails migration)"
+    check "$([ "$USERS_AFTER" = "$USERS_BEFORE" ]; echo $?)" "new image: no duplicate admin created (users $USERS_BEFORE -> $USERS_AFTER)"
 fi
 
 NEW_COUNT="$(api_task_count "$NEW_PORT" "" "$NEW_JAR")"


### PR DESCRIPTION
## Description

Stacked on #1467 (the upgrade harness), which found this.

Login, registration and OIDC provisioning look users up by the lowercased email since #1466, but accounts created before the `User` model started lowercasing on write (February 2026) still store the address as typed. After upgrading, those accounts cannot log in, and with `TUDUDI_USER_EMAIL` set, `scripts/user-create.js` creates a second, empty admin account on every start (the Docker upgrade run showed users going from 2 to 3 and the admin landing in an empty account).

This adds `20260906000001-lowercase-user-emails.js`, a dialect-safe data migration that lowercases `users.email` and the linked self-person's email inside a transaction. Rows that would collide with another account after lowercasing are left untouched and reported with both ids so an administrator can merge them by hand; `down` is a no-op. Because it is newer than the PostgreSQL baseline it also runs on fresh PostgreSQL installs, where it is a no-op.

The upgrade suite's mixed-case login check is now a plain assertion (it was `it.failing`), and the Docker upgrade script fails when a duplicate admin appears.

## Type of Change

- [x] Bug fix (fixes an issue)

## Testing

**How did you test this?**

- New `backend/tests/unit/migrations/lowercase-user-emails.test.js` (lowercases, syncs the self-person, skips collisions with a warning, no-op when clean, login lookup finds the account) passes on SQLite and PostgreSQL
- `npm run backend:test:upgrade`: 64/64, the legacy admin now logs in on every fixture (v1.2.4 through v1.4.2) and the v1.4.0 fixture's case-collision pair survives untouched
- `npm run test:upgrade:docker` from the v1.4.2 fixture and with `--seed-api` against `chrisvel/tududi:1.4.2`: the mixed-case admin logs in and no duplicate admin is created (users 2 -> 2)
- `npm run lint`: 0 errors

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
