### PR TITLE
fix(db): refuse to start on PostgreSQL over a populated SQLite database

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,12 @@ Tududi stores everything in a single SQLite file by default, which is all a pers
 
 ### Upgrading
 
+Every start backs up the SQLite file next to it (`db-backup-<timestamp>.sqlite3`), then runs pending migrations; the container refuses to start if a migration fails, so the backup is always the state before the upgrade.
+
+#### Upgrading to a release with PostgreSQL support
+
+SQLite stays the default and existing databases are used as they are. Make sure your `.env` does **not** contain a `DATABASE_URL` or `DB_DIALECT` left over from another application: either one switches tududi to PostgreSQL. As a safety net, the container refuses to start when PostgreSQL is selected but a populated SQLite database is present at `DB_FILE`; unset the variable to keep your data, or set `TUDUDI_ALLOW_DIALECT_SWITCH=true` if you really want an empty PostgreSQL database.
+
 #### v1.1.x to v1.2.x: Volume path change
 
 The Docker volume mount path changed in v1.2.0 from `/app/backend/db` to `/app/db`. If you are upgrading from v1.1.x and your `docker-compose.yml` still uses the old path, **new data will be lost on container recreation** because writes go to an anonymous Docker volume that is discarded when the container is recreated.

--- a/backend/migrations/20260906000001-lowercase-user-emails.js
+++ b/backend/migrations/20260906000001-lowercase-user-emails.js
@@ -1,0 +1,90 @@
+'use strict';
+
+// Migrations run on SQLite and PostgreSQL. Keep them dialect-safe:
+//   - prefer the safe* helpers in ../utils/migration-utils.js
+//   - no PRAGMA, sqlite_master, AUTOINCREMENT or backtick identifiers
+//   - compare booleans with true/false, never 0/1
+//   - branch on queryInterface.sequelize.getDialect() only when unavoidable
+// See docs/database.md, "Writing dialect-safe migrations".
+
+// Accounts created before the User model started lowercasing emails on write
+// (February 2026) still store the address as typed. Login, registration and
+// OIDC provisioning now look users up by the lowercased email, so those
+// accounts became unreachable and TUDUDI_USER_EMAIL created a second, empty
+// admin on start. Normalise the stored value; rows that would collide with
+// another account after lowercasing are left untouched and reported so an
+// administrator can merge them by hand.
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        const { sequelize } = queryInterface;
+        const { QueryTypes } = Sequelize;
+
+        const peopleColumns = await queryInterface
+            .describeTable('people')
+            .catch(() => ({}));
+        const syncSelfPerson = Boolean(
+            peopleColumns.linked_user_id && peopleColumns.email
+        );
+
+        const transaction = await sequelize.transaction();
+        try {
+            const mixedCase = await sequelize.query(
+                'SELECT id, email FROM users WHERE email IS NOT NULL AND email <> LOWER(email)',
+                { type: QueryTypes.SELECT, transaction }
+            );
+
+            let updated = 0;
+            const skipped = [];
+            for (const user of mixedCase) {
+                const lower = user.email.trim().toLowerCase();
+                const collisions = await sequelize.query(
+                    'SELECT id FROM users WHERE LOWER(email) = :lower AND id <> :id',
+                    {
+                        replacements: { lower, id: user.id },
+                        type: QueryTypes.SELECT,
+                        transaction,
+                    }
+                );
+                if (collisions.length > 0) {
+                    skipped.push({
+                        id: user.id,
+                        email: user.email,
+                        collidesWith: collisions.map((row) => row.id),
+                    });
+                    continue;
+                }
+
+                await sequelize.query(
+                    'UPDATE users SET email = :lower WHERE id = :id',
+                    { replacements: { lower, id: user.id }, transaction }
+                );
+                if (syncSelfPerson) {
+                    await sequelize.query(
+                        'UPDATE people SET email = :lower WHERE user_id = :id AND linked_user_id = :id AND email IS NOT NULL',
+                        { replacements: { lower, id: user.id }, transaction }
+                    );
+                }
+                updated++;
+            }
+
+            await transaction.commit();
+
+            if (updated > 0) {
+                console.log(`Lowercased ${updated} user email(s)`);
+            }
+            for (const entry of skipped) {
+                console.warn(
+                    `⚠️  users.id=${entry.id} keeps email "${entry.email}": lowercasing it would collide with users.id=${entry.collidesWith.join(', ')}. Merge or rename one of the accounts by hand.`
+                );
+            }
+        } catch (error) {
+            await transaction.rollback();
+            throw error;
+        }
+    },
+
+    async down() {
+        // The original casing is not recorded; lowercased emails stay valid.
+    },
+};

--- a/backend/scripts/db-prepare.js
+++ b/backend/scripts/db-prepare.js
@@ -23,6 +23,7 @@ try {
 const fs = require('fs');
 const path = require('path');
 const { DataTypes } = require('sequelize');
+const { getConfig } = require('../config/config');
 const { sequelize, Setting } = require('../models');
 
 const META_TABLE = 'SequelizeMeta';
@@ -78,9 +79,52 @@ async function seedReferenceData() {
     });
 }
 
+// A DATABASE_URL or DB_DIALECT left in the environment silently moves an
+// existing SQLite deployment onto an empty PostgreSQL schema: the app comes up
+// with no data while the SQLite file sits untouched. Refuse to continue when
+// the SQLite file that this deployment would otherwise use holds data, unless
+// the operator confirms the switch.
+function guardAgainstAccidentalDialectSwitch(dialect) {
+    if (dialect !== 'postgres') return;
+    if (process.env.TUDUDI_ALLOW_DIALECT_SWITCH === 'true') return;
+
+    const sqliteFile = getConfig().dbFile;
+    if (!sqliteFile) return;
+
+    let size = 0;
+    try {
+        size = fs.statSync(sqliteFile).size;
+    } catch (_) {
+        return;
+    }
+    if (size === 0) return;
+
+    console.error('');
+    console.error(
+        '❌ PostgreSQL is selected (DATABASE_URL or DB_DIALECT is set), but an existing SQLite database was found:'
+    );
+    console.error(`   ${sqliteFile} (${size} bytes)`);
+    console.error('');
+    console.error(
+        '   There is no automatic transfer between engines. Starting now would bring up an empty PostgreSQL'
+    );
+    console.error('   database and your SQLite data would not be visible.');
+    console.error('');
+    console.error(
+        '   To keep using SQLite: unset DATABASE_URL and DB_DIALECT.'
+    );
+    console.error(
+        '   To start on PostgreSQL anyway (fresh data, or data already imported): set TUDUDI_ALLOW_DIALECT_SWITCH=true.'
+    );
+    console.error('');
+    process.exit(1);
+}
+
 async function prepareDatabase() {
     const dialect = sequelize.getDialect();
     const queryInterface = sequelize.getQueryInterface();
+
+    guardAgainstAccidentalDialectSwitch(dialect);
 
     console.log(`Preparing ${dialect} database...`);
     await sequelize.authenticate();

--- a/backend/tests/unit/migrations/lowercase-user-emails.test.js
+++ b/backend/tests/unit/migrations/lowercase-user-emails.test.js
@@ -1,0 +1,108 @@
+const { Sequelize } = require('sequelize');
+const { sequelize, User, Person } = require('../../../models');
+const migration = require('../../../migrations/20260906000001-lowercase-user-emails');
+
+// Rows are inserted with raw SQL because the User model lowercases emails on
+// write, which is exactly the normalisation legacy rows never received.
+async function insertUser(email, name) {
+    const [result] = await sequelize.query(
+        `INSERT INTO users (uid, email, name, password_digest, created_at, updated_at)
+         VALUES (:uid, :email, :name, 'x', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+        {
+            replacements: {
+                uid: `uid-${Math.random().toString(36).slice(2, 12)}`,
+                email,
+                name,
+            },
+        }
+    );
+    const user = await User.findOne({ where: { name } });
+    expect(user).toBeTruthy();
+    return user || result;
+}
+
+async function insertSelfPerson(user, email) {
+    await sequelize.query(
+        `INSERT INTO people (uid, user_id, linked_user_id, name, email, relationship_type, archived, created_at, updated_at)
+         VALUES (:uid, :id, :id, :name, :email, 'other', false, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`,
+        {
+            replacements: {
+                uid: `puid-${Math.random().toString(36).slice(2, 12)}`,
+                id: user.id,
+                name: user.name,
+                email,
+            },
+        }
+    );
+}
+
+function runUp() {
+    return migration.up(sequelize.getQueryInterface(), Sequelize);
+}
+
+describe('migration 20260906000001-lowercase-user-emails', () => {
+    let warn;
+
+    beforeEach(() => {
+        warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    it('lowercases mixed-case emails and the linked self-person', async () => {
+        const legacy = await insertUser('Alice.Legacy@Example.COM', 'alice');
+        await insertSelfPerson(legacy, 'Alice.Legacy@Example.COM');
+        const modern = await insertUser('bob@example.com', 'bob');
+
+        await runUp();
+
+        await legacy.reload();
+        await modern.reload();
+        expect(legacy.email).toBe('alice.legacy@example.com');
+        expect(modern.email).toBe('bob@example.com');
+        const person = await Person.findOne({
+            where: { user_id: legacy.id, linked_user_id: legacy.id },
+        });
+        expect(person.email).toBe('alice.legacy@example.com');
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('leaves accounts alone when lowercasing would collide', async () => {
+        const first = await insertUser('carol@example.com', 'carol');
+        const second = await insertUser('Carol@Example.com', 'carol2');
+
+        await runUp();
+
+        await first.reload();
+        await second.reload();
+        expect(first.email).toBe('carol@example.com');
+        expect(second.email).toBe('Carol@Example.com');
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0][0]).toContain(`users.id=${second.id}`);
+        expect(warn.mock.calls[0][0]).toContain(`users.id=${first.id}`);
+    });
+
+    it('is a no-op when every email is already lowercase', async () => {
+        const user = await insertUser('dave@example.com', 'dave');
+        const before = user.updated_at;
+
+        await runUp();
+
+        await user.reload();
+        expect(user.email).toBe('dave@example.com');
+        expect(user.updated_at).toEqual(before);
+        expect(warn).not.toHaveBeenCalled();
+    });
+
+    it('makes the legacy account reachable through the login lookup', async () => {
+        await insertUser('Erin@Example.ORG', 'erin');
+        expect(
+            await User.findOne({ where: { email: 'erin@example.org' } })
+        ).toBeNull();
+
+        await runUp();
+
+        expect(
+            await User.findOne({ where: { email: 'erin@example.org' } })
+        ).not.toBeNull();
+    });
+});

--- a/backend/tests/unit/scripts/db-prepare-guard.test.js
+++ b/backend/tests/unit/scripts/db-prepare-guard.test.js
@@ -1,0 +1,114 @@
+const { spawn } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// scripts/db-prepare.js must refuse to bring up PostgreSQL when the SQLite
+// file this deployment would otherwise use still holds data. The script is
+// spawned so its config is built from a controlled environment, and the
+// PostgreSQL URL points at a closed port so the only difference between the
+// two outcomes is whether the guard fired before the connection attempt.
+
+const SCRIPT = path.join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'scripts',
+    'db-prepare.js'
+);
+const UNREACHABLE_PG = 'postgres://nobody:nothing@127.0.0.1:1/none';
+
+function runPrepare(extraEnv) {
+    return new Promise((resolve, reject) => {
+        const env = { ...process.env, NODE_ENV: 'production', ...extraEnv };
+        delete env.DB_DIALECT;
+        const child = spawn('node', [SCRIPT], {
+            cwd: path.join(__dirname, '..', '..', '..'),
+            env,
+            stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (data) => (stdout += data));
+        child.stderr.on('data', (data) => (stderr += data));
+        child.on('error', reject);
+        child.on('close', (code) => resolve({ code, stdout, stderr }));
+    });
+}
+
+describe('db-prepare dialect switch guard', () => {
+    let dir;
+    let populated;
+    let empty;
+
+    beforeAll(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'tududi-guard-'));
+        populated = path.join(dir, 'populated.sqlite3');
+        empty = path.join(dir, 'empty.sqlite3');
+        fs.writeFileSync(populated, Buffer.alloc(8192, 1));
+        fs.writeFileSync(empty, '');
+    });
+
+    afterAll(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('refuses to start PostgreSQL over a populated SQLite file', async () => {
+        const result = await runPrepare({
+            DATABASE_URL: UNREACHABLE_PG,
+            DB_FILE: populated,
+        });
+        expect(result.code).toBe(1);
+        expect(result.stderr).toContain('existing SQLite database was found');
+        expect(result.stderr).toContain(populated);
+        expect(result.stderr).toContain('TUDUDI_ALLOW_DIALECT_SWITCH=true');
+        expect(result.stderr).not.toContain('Database preparation failed');
+    }, 30000);
+
+    it('proceeds to the connection when the override is set', async () => {
+        const result = await runPrepare({
+            DATABASE_URL: UNREACHABLE_PG,
+            DB_FILE: populated,
+            TUDUDI_ALLOW_DIALECT_SWITCH: 'true',
+        });
+        expect(result.code).toBe(1);
+        expect(result.stderr).not.toContain(
+            'existing SQLite database was found'
+        );
+        expect(result.stderr).toContain('Database preparation failed');
+    }, 30000);
+
+    it('ignores an empty SQLite file left by a failed first start', async () => {
+        const result = await runPrepare({
+            DATABASE_URL: UNREACHABLE_PG,
+            DB_FILE: empty,
+        });
+        expect(result.code).toBe(1);
+        expect(result.stderr).not.toContain(
+            'existing SQLite database was found'
+        );
+        expect(result.stderr).toContain('Database preparation failed');
+    }, 30000);
+
+    it('ignores a missing SQLite file', async () => {
+        const result = await runPrepare({
+            DATABASE_URL: UNREACHABLE_PG,
+            DB_FILE: path.join(dir, 'does-not-exist.sqlite3'),
+        });
+        expect(result.code).toBe(1);
+        expect(result.stderr).not.toContain(
+            'existing SQLite database was found'
+        );
+        expect(result.stderr).toContain('Database preparation failed');
+    }, 30000);
+
+    it('does not interfere with SQLite deployments', async () => {
+        const result = await runPrepare({
+            DATABASE_URL: '',
+            DB_FILE: path.join(dir, 'fresh.sqlite3'),
+        });
+        expect(result.code).toBe(0);
+        expect(result.stdout).toContain('Preparing sqlite database');
+    }, 60000);
+});

--- a/backend/tests/upgrade/legacy-sqlite-upgrade.test.js
+++ b/backend/tests/upgrade/legacy-sqlite-upgrade.test.js
@@ -169,19 +169,14 @@ describe.each(fixtures)('upgrade from $name', (fixture) => {
                 expect(smoke.login.bob).toBe(200);
             });
 
-            // Accounts created before the lowercasing hook (Feb 2026) still carry
-            // mixed-case emails, which the current login lookup cannot find. Fixed
-            // by the follow-up data migration ("lowercase legacy emails"); flip to
-            // a plain `it` once it lands.
-            it.failing(
-                'logs in a legacy user with a mixed-case stored email',
-                () => {
-                    expect([
-                        smoke.login.aliceLower,
-                        smoke.login.aliceMixed,
-                    ]).toEqual([200, 200]);
-                }
-            );
+            // Accounts created before the lowercasing hook (Feb 2026) carry
+            // mixed-case emails; 20260906000001-lowercase-user-emails fixes them.
+            it('logs in a legacy user with a mixed-case stored email', () => {
+                expect([
+                    smoke.login.aliceLower,
+                    smoke.login.aliceMixed,
+                ]).toEqual([200, 200]);
+            });
 
             it('serves every list and metrics endpoint', () => {
                 expect(smoke.login.aliceAfterNormalise).toBe(200);

--- a/docs/16-postgresql.md
+++ b/docs/16-postgresql.md
@@ -124,6 +124,7 @@ Uploads live on disk (`TUDUDI_UPLOAD_PATH`) and need their own backup.
 | `Existing database detected` but the app reports missing tables | The database has a `users` table from another application. Point tududi at its own database. |
 | Migration failed on start | The container exits with the failing migration in the log. Restore the last dump, keep the previous image, report the migration. |
 | Container starts but `/api/health` never responds | Check `docker compose logs tududi`; a database that is not reachable shows a connection error from `db-prepare.js` before anything else. |
+| `PostgreSQL is selected ... but an existing SQLite database was found` | `DATABASE_URL` or `DB_DIALECT` is set while the SQLite file at `DB_FILE` (in Docker `/app/db/production.sqlite3`) still holds data, usually a variable left over in `.env`. Unset it to stay on SQLite, or set `TUDUDI_ALLOW_DIALECT_SWITCH=true` to start on PostgreSQL anyway (the SQLite data is not transferred). |
 
 ---
 

--- a/scripts/test-upgrade-docker.sh
+++ b/scripts/test-upgrade-docker.sh
@@ -10,7 +10,8 @@
 #      backup exists and matches the file that was there before, logins work,
 #      the data is still there, and a restart is idempotent.
 #   4. Starts the new image once more with a stray DATABASE_URL and checks it
-#      refuses to run and leaves the SQLite file untouched.
+#      refuses to run with the dialect-switch banner, before touching any
+#      database, and leaves the SQLite file untouched.
 #
 # Usage: npm run test:upgrade:docker            (or bash scripts/test-upgrade-docker.sh)
 # Env:   OLD_IMAGE   previous release image      (default chrisvel/tududi:1.4.2)
@@ -276,10 +277,11 @@ STRAY_EXIT="$(docker wait "$STRAY_NAME" 2>/dev/null || echo timeout)"
 STRAY_LOGS="$(docker logs "$STRAY_NAME" 2>&1)"
 check "$([ "$STRAY_EXIT" != "0" ]; echo $?)" "stray DATABASE_URL: container refused to start (exit $STRAY_EXIT)"
 check "$([ "$(sha "$VOL/production.sqlite3")" = "$POST_SHA" ]; echo $?)" "stray DATABASE_URL: sqlite file untouched"
-if printf '%s' "$STRAY_LOGS" | grep -qi 'existing SQLite database'; then
-    green "  ok   stray DATABASE_URL: guard banner shown"
+check "$(printf '%s' "$STRAY_LOGS" | grep -qi 'existing SQLite database was found'; echo $?)" "stray DATABASE_URL: dialect-switch guard banner shown"
+if printf '%s' "$STRAY_LOGS" | grep -qi 'Preparing postgres database'; then
+    check 1 "stray DATABASE_URL: stopped before any connection attempt"
 else
-    yellow "  note stray DATABASE_URL: failed at the connection step, no guard banner yet (added by the dialect-switch guard fix)"
+    check 0 "stray DATABASE_URL: stopped before any connection attempt"
 fi
 
 echo

--- a/scripts/test-upgrade-docker.sh
+++ b/scripts/test-upgrade-docker.sh
@@ -237,19 +237,17 @@ fi
 
 NEW_JAR="$WORK/new.jar"
 check "$([ "$(api_login "$NEW_PORT" "$BOB_EMAIL" "$NEW_JAR")" = "200" ]; echo $?)" "new image: login as $BOB_EMAIL"
-# TUDUDI_USER_EMAIL names the legacy admin in its lowercase form. Until the
-# lowercase-emails migration lands, user-create.js cannot find the mixed-case
-# row and creates a second, empty admin account instead; the user count tells
-# the two outcomes apart.
+# TUDUDI_USER_EMAIL names the legacy admin in its lowercase form. The
+# lowercase-emails migration must have normalised the stored row so
+# user-create.js updates it instead of creating a second, empty admin.
 USERS_AFTER="$(count_users)"
 ALICE_LOWER="$(api_login "$NEW_PORT" "$ADMIN_EMAIL" "$WORK/a1.jar")"
 ALICE_MIXED="$(api_login "$NEW_PORT" "$ADMIN_EMAIL_MIXED" "$WORK/a2.jar")"
+check "$([ "$ALICE_LOWER" = "200" ] && [ "$ALICE_MIXED" = "200" ]; echo $?)" "new image: legacy mixed-case admin can log in ($ALICE_LOWER / $ALICE_MIXED)"
 if [ "$USERS_BEFORE" = "?" ]; then
     yellow "  note new image: sqlite3 CLI missing, cannot verify the admin account was reused"
-elif [ "$USERS_AFTER" = "$USERS_BEFORE" ] && [ "$ALICE_LOWER" = "200" ] && [ "$ALICE_MIXED" = "200" ]; then
-    green "  ok   new image: legacy mixed-case admin reused and can log in"
 else
-    yellow "  note new image: users $USERS_BEFORE -> $USERS_AFTER, legacy admin login $ALICE_LOWER / $ALICE_MIXED (a duplicate admin means TUDUDI_USER_EMAIL did not match the mixed-case row; fixed by the lowercase-emails migration)"
+    check "$([ "$USERS_AFTER" = "$USERS_BEFORE" ]; echo $?)" "new image: no duplicate admin created (users $USERS_BEFORE -> $USERS_AFTER)"
 fi
 
 NEW_COUNT="$(api_task_count "$NEW_PORT" "" "$NEW_JAR")"


### PR DESCRIPTION
## Description

Stacked on #1468 (which is stacked on #1467). Found by the upgrade harness's stray-`DATABASE_URL` step.

Since #1466 the engine is selected purely by the environment: any `DATABASE_URL` or `DB_DIALECT` present (a leftover in `.env` from another application is enough) switches an existing SQLite deployment to PostgreSQL. The container then comes up with an empty schema while the SQLite file sits untouched, and to the user it looks like every task is gone. Today it only fails when the PostgreSQL server happens to be unreachable.

`scripts/db-prepare.js` now checks, before any connection attempt, whether PostgreSQL is selected while the SQLite file at `DB_FILE` (in Docker always `/app/db/production.sqlite3`) holds data. If so it prints what was found and how to proceed and exits 1; `start.sh` already stops the container when db-prepare fails. Empty or missing files never block PostgreSQL deployments (an empty file is what a failed first start leaves behind), and `TUDUDI_ALLOW_DIALECT_SWITCH=true` overrides the check for operators who mean it.

Docs: a note under README "Upgrading" and a row in the PostgreSQL troubleshooting table. The Docker upgrade script now requires the banner and checks that no connection was attempted.

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] Documentation/Translation update

## Testing

**How did you test this?**

- New `backend/tests/unit/scripts/db-prepare-guard.test.js` spawns the script against an unreachable PostgreSQL URL: populated file -> banner and exit 1 before connecting; override set, empty file or missing file -> proceeds to the connection error; SQLite deployments unaffected. Passes on SQLite and PostgreSQL
- `npm run backend:test:upgrade` with `DATABASE_URL` set: the PostgreSQL bootstrap in the parity test still records the baseline (no populated SQLite file in that environment)
- `npm run test:upgrade:docker` against `chrisvel/tududi:1.4.2`: all checks pass, including "guard banner shown" and "stopped before any connection attempt"
- `npm run lint`: 0 errors

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
