### PR TITLE
fix(auth): add hosted mode guard for implicit admin and SSO provisioning

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,6 +45,12 @@ REGISTRATION_TOKEN_EXPIRY_HOURS=24
 DISABLE_SCHEDULER=false
 DISABLE_TELEGRAM=false
 
+# Hosted mode (multi-user public instance). Leave false when self-hosting.
+# When true: the first registered user is not made admin (create the admin
+# with TUDUDI_USER_EMAIL/TUDUDI_USER_PASSWORD instead), and SSO auto-provisioning
+# respects the registration toggle.
+TUDUDI_HOSTED_MODE=false
+
 # Feature Flags
 FF_ENABLE_BACKUPS=false
 FF_ENABLE_CALDAV=false

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -74,6 +74,14 @@ const config = {
 
     disableTelegram: process.env.DISABLE_TELEGRAM === 'true',
 
+    // Hosted mode: this instance serves unrelated members of the public, so
+    // conveniences that assume a single owner (first user becomes admin,
+    // bootstrap role assignment, SSO auto-provisioning past a closed
+    // registration) are switched off. Off by default for self-hosters.
+    hosted: {
+        enabled: process.env.TUDUDI_HOSTED_MODE === 'true',
+    },
+
     email: process.env.TUDUDI_USER_EMAIL,
 
     environment,

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -262,6 +262,7 @@ module.exports = (sequelize) => {
                 afterCreate: async (user, options) => {
                     // Automatically create a role for every new user
                     const { Role } = require('./index');
+                    const { getConfig } = require('../config/config');
 
                     // Check if any admin users exist
                     const adminCount = await Role.count({
@@ -269,8 +270,12 @@ module.exports = (sequelize) => {
                         transaction: options.transaction,
                     });
 
-                    // First user becomes admin
-                    const isFirstUser = adminCount === 0;
+                    // On a self-hosted instance the first user is the owner
+                    // and becomes admin. On a hosted instance the first user
+                    // is just the first customer; the admin is created
+                    // explicitly by the bootstrap script.
+                    const hosted = getConfig().hosted?.enabled === true;
+                    const isFirstUser = adminCount === 0 && !hosted;
 
                     await Role.create(
                         {

--- a/backend/modules/admin/service.js
+++ b/backend/modules/admin/service.js
@@ -21,6 +21,7 @@ const {
     getDefaultNotificationPreferences,
 } = require('../../utils/notificationPreferences');
 const { logError } = require('../../services/logService');
+const { getConfig } = require('../../config/config');
 
 class AdminService {
     /**
@@ -37,9 +38,18 @@ class AdminService {
         }
 
         const requesterIsAdmin = await isAdmin(requester.uid);
+        if (requesterIsAdmin) {
+            return true;
+        }
+
+        // Bootstrap fallback: an instance with no roles at all lets any user
+        // claim admin so it cannot lock itself out. Never on a hosted
+        // instance, where the roles table being empty would hand the whole
+        // instance to whoever asks first.
+        const hosted = getConfig().hosted?.enabled === true;
         const existingRolesCount = await adminRepository.countRoles();
 
-        if (!requesterIsAdmin && existingRolesCount > 0) {
+        if (hosted || existingRolesCount > 0) {
             throw new ForbiddenError('Forbidden');
         }
 

--- a/backend/modules/oidc/provisioningService.js
+++ b/backend/modules/oidc/provisioningService.js
@@ -6,6 +6,7 @@ const {
 } = require('../../utils/notificationPreferences');
 const peopleService = require('../people/service');
 const { logError } = require('../../services/logService');
+const { getConfig } = require('../../config/config');
 
 function shouldBeAdmin(config, email) {
     if (!config.adminEmailDomains || config.adminEmailDomains.length === 0) {
@@ -80,10 +81,24 @@ async function provisionUser(providerSlug, claims, req) {
         let isNewUser = false;
 
         if (!user) {
+            // A self-hosted operator who turns on auto-provisioning wants
+            // everyone their IdP vouches for to get an account. On a hosted
+            // instance the IdP may be a public one (Google, GitHub), so the
+            // registration toggle still decides whether new accounts open.
+            if (getConfig().hosted?.enabled === true) {
+                const {
+                    isRegistrationEnabled,
+                } = require('../auth/registrationService');
+                if (!(await isRegistrationEnabled())) {
+                    await transaction.rollback();
+                    throw new Error('Registration is not enabled');
+                }
+            }
+
             user = await User.create(
                 {
                     email: claims.email,
-                    verified_email: true,
+                    email_verified: true,
                     password_digest: null,
                     notification_preferences:
                         getDefaultNotificationPreferences(),

--- a/backend/modules/users/userService.js
+++ b/backend/modules/users/userService.js
@@ -10,7 +10,14 @@ const _ = require('lodash');
  * @param {string} password - User password (plain text)
  * @returns {Promise<{user: User, created: boolean}>} User object and creation status
  */
-async function createOrUpdateUser(email, password) {
+// Creates the user if missing. An existing user's password is only replaced
+// when updatePassword is set: the Docker entrypoint runs this on every boot
+// and must not keep resetting a password the owner has since changed.
+async function createOrUpdateUser(
+    email,
+    password,
+    { updatePassword = false } = {}
+) {
     const normalizedEmail = email.trim().toLowerCase();
     const hashedPassword = await bcrypt.hash(password, 10);
 
@@ -22,12 +29,13 @@ async function createOrUpdateUser(email, password) {
         },
     });
 
-    // User exists, update password
-    if (!created) {
+    let passwordUpdated = false;
+    if (!created && updatePassword) {
         await user.update({ password_digest: hashedPassword });
+        passwordUpdated = true;
     }
 
-    return { user, created };
+    return { user, created, passwordUpdated };
 }
 
 /**

--- a/backend/scripts/user-create.js
+++ b/backend/scripts/user-create.js
@@ -1,11 +1,9 @@
 #!/usr/bin/env node
 
-/**
- * User Creation Script
- * Creates a new user with email and password.
- * If user exists, updated password.
- * Usage: node user-create.js <email> <password> [is_admin]
- */
+// User creation script.
+// Creates a user with email and password. An existing user is left as is
+// (the admin flag is still applied) unless --update-password is given.
+// Usage: node user-create.js <email> <password> [is_admin] [--update-password]
 
 try {
     require('dotenv').config();
@@ -18,11 +16,15 @@ const {
 const { Role } = require('../models');
 
 async function createUser() {
-    const [email, password, isAdminArg] = process.argv.slice(2);
+    const args = process.argv.slice(2);
+    const updatePassword = args.includes('--update-password');
+    const [email, password, isAdminArg] = args.filter(
+        (arg) => !arg.startsWith('--')
+    );
 
     if (!email || password === undefined) {
         console.error(
-            'Usage: npm run user:create <email> <password> [is_admin]'
+            'Usage: npm run user:create <email> <password> [is_admin] [--update-password]'
         );
         console.error(
             'Example: npm run user:create admin@example.com mypassword123 true'
@@ -50,7 +52,11 @@ async function createUser() {
 
         console.log(`Creating user with email: ${email}`);
 
-        const { user, created } = await createOrUpdateUser(email, password);
+        const { user, created, passwordUpdated } = await createOrUpdateUser(
+            email,
+            password,
+            { updatePassword }
+        );
 
         // Optionally grant admin role
         const shouldBeAdmin = String(isAdminArg).toLowerCase() === 'true';
@@ -68,10 +74,14 @@ async function createUser() {
             }
         }
 
-        if (!created) {
+        if (created) {
+            console.log('User created successfully');
+        } else if (passwordUpdated) {
             console.log('User exists, password updated');
         } else {
-            console.log('User created successfully');
+            console.log(
+                'User exists, password left unchanged (pass --update-password to replace it)'
+            );
         }
 
         console.log(`Email: ${user.email}`);

--- a/backend/tests/integration/hosted-mode-bootstrap.test.js
+++ b/backend/tests/integration/hosted-mode-bootstrap.test.js
@@ -1,0 +1,90 @@
+const request = require('supertest');
+const app = require('../../app');
+const { User, Role } = require('../../models');
+const { getConfig } = require('../../config/config');
+const { createTestUser } = require('../helpers/testUtils');
+
+// Hosted mode is a config flag read at call time, so it can be flipped on
+// the live config object for these tests only.
+describe('Hosted mode: admin bootstrap is never implicit', () => {
+    const config = getConfig();
+
+    beforeEach(async () => {
+        await Role.destroy({ where: {}, force: true });
+        await User.destroy({ where: {}, force: true });
+        config.hosted.enabled = true;
+    });
+
+    afterEach(() => {
+        config.hosted.enabled = false;
+    });
+
+    it('does not make the first user admin', async () => {
+        const first = await createTestUser({
+            email: `first_${Date.now()}@example.com`,
+        });
+
+        const role = await Role.findOne({ where: { user_id: first.id } });
+        expect(role).not.toBeNull();
+        expect(role.is_admin).toBe(false);
+    });
+
+    it('refuses bootstrap role assignment even when no roles exist', async () => {
+        const user = await createTestUser({
+            email: `claimant_${Date.now()}@example.com`,
+        });
+        await Role.destroy({ where: {}, force: true });
+
+        const agent = request.agent(app);
+        await agent
+            .post('/api/login')
+            .send({ email: user.email, password: 'password123' });
+
+        const res = await agent
+            .post('/api/admin/set-admin-role')
+            .send({ user_id: user.id, is_admin: true });
+
+        expect(res.status).toBe(403);
+        const roles = await Role.count({ where: { is_admin: true } });
+        expect(roles).toBe(0);
+    });
+
+    it('still lets an explicit admin manage roles', async () => {
+        const admin = await createTestUser({
+            email: `admin_${Date.now()}@example.com`,
+        });
+        await Role.update({ is_admin: true }, { where: { user_id: admin.id } });
+        const other = await createTestUser({
+            email: `other_${Date.now()}@example.com`,
+        });
+
+        const agent = request.agent(app);
+        await agent
+            .post('/api/login')
+            .send({ email: admin.email, password: 'password123' });
+
+        const res = await agent
+            .post('/api/admin/set-admin-role')
+            .send({ user_id: other.id, is_admin: true });
+
+        expect(res.status).toBe(200);
+        const role = await Role.findOne({ where: { user_id: other.id } });
+        expect(role.is_admin).toBe(true);
+    });
+});
+
+describe('Self-hosted (default): first user is the owner', () => {
+    beforeEach(async () => {
+        await Role.destroy({ where: {}, force: true });
+        await User.destroy({ where: {}, force: true });
+    });
+
+    it('makes the first user admin when hosted mode is off', async () => {
+        const first = await createTestUser({
+            email: `owner_${Date.now()}@example.com`,
+        });
+
+        const role = await Role.findOne({ where: { user_id: first.id } });
+        expect(role.is_admin).toBe(true);
+    });
+});

--- a/backend/tests/integration/user-create-script.test.js
+++ b/backend/tests/integration/user-create-script.test.js
@@ -1,6 +1,6 @@
 const { execSync, spawn } = require('child_process');
 const path = require('path');
-const { User } = require('../../models');
+const { User, Role } = require('../../models');
 
 describe('User Create Script', () => {
     const scriptPath = path.join(__dirname, '../../scripts/user-create.js');
@@ -165,17 +165,36 @@ describe('User Create Script', () => {
                 password_digest: await require('bcrypt').hash(password, 10),
             });
 
-            // Try to create same user again (should update password)
-            const result = await runUserCreateScript([email, newPassword]);
+            // Without the flag the existing password must survive: the Docker
+            // entrypoint runs this script on every boot.
+            const untouched = await runUserCreateScript([
+                email,
+                newPassword,
+                'true',
+            ]);
+            expect(untouched.code).toBe(0);
+
+            const bcrypt = require('bcrypt');
+            const unchangedUser = await User.findOne({ where: { email } });
+            expect(
+                await bcrypt.compare(password, unchangedUser.password_digest)
+            ).toBe(true);
+            const role = await Role.findOne({
+                where: { user_id: unchangedUser.id },
+            });
+            expect(role.is_admin).toBe(true);
+
+            // With --update-password the password is replaced
+            const result = await runUserCreateScript([
+                email,
+                newPassword,
+                '--update-password',
+            ]);
 
             expect(result.code).toBe(0);
 
-            // Verify user still exists and password was updated
             const updatedUser = await User.findOne({ where: { email } });
             expect(updatedUser).toBeTruthy();
-
-            // Verify the password was updated
-            const bcrypt = require('bcrypt');
             const isValid = await bcrypt.compare(
                 newPassword,
                 updatedUser.password_digest

--- a/backend/tests/unit/modules/oidc/provisioningService.test.js
+++ b/backend/tests/unit/modules/oidc/provisioningService.test.js
@@ -1,6 +1,13 @@
-const { sequelize, User, OIDCIdentity, Role } = require('../../../../models');
+const {
+    sequelize,
+    User,
+    OIDCIdentity,
+    Role,
+    Setting,
+} = require('../../../../models');
 const provisioningService = require('../../../../modules/oidc/provisioningService');
 const providerConfig = require('../../../../modules/oidc/providerConfig');
+const { getConfig } = require('../../../../config/config');
 
 jest.mock('../../../../modules/oidc/providerConfig');
 
@@ -139,6 +146,83 @@ describe('OIDC Provisioning Service', () => {
             await expect(
                 provisioningService.provisionUser('test-provider', claims, {})
             ).rejects.toThrow('Auto-provisioning is disabled');
+        });
+
+        describe('hosted mode', () => {
+            const config = getConfig();
+
+            beforeEach(async () => {
+                config.hosted.enabled = true;
+                await Setting.destroy({ where: {}, force: true });
+            });
+
+            afterEach(() => {
+                config.hosted.enabled = false;
+            });
+
+            it('refuses to provision a new user while registration is disabled', async () => {
+                await Setting.upsert({
+                    key: 'registration_enabled',
+                    value: 'false',
+                });
+
+                await expect(
+                    provisioningService.provisionUser(
+                        'test-provider',
+                        { sub: 'sub-hosted-1', email: 'closed@example.com' },
+                        {}
+                    )
+                ).rejects.toThrow('Registration is not enabled');
+
+                const user = await User.findOne({
+                    where: { email: 'closed@example.com' },
+                });
+                expect(user).toBeNull();
+            });
+
+            it('provisions a new user once registration is enabled', async () => {
+                await Setting.upsert({
+                    key: 'registration_enabled',
+                    value: 'true',
+                });
+
+                const result = await provisioningService.provisionUser(
+                    'test-provider',
+                    { sub: 'sub-hosted-2', email: 'open@example.com' },
+                    {}
+                );
+
+                expect(result.isNewUser).toBe(true);
+                expect(result.user.email_verified).toBe(true);
+            });
+
+            it('still signs in an existing identity while registration is disabled', async () => {
+                await Setting.upsert({
+                    key: 'registration_enabled',
+                    value: 'false',
+                });
+                const existing = await User.create({
+                    email: 'member@example.com',
+                    password_digest: null,
+                });
+                await OIDCIdentity.create({
+                    user_id: existing.id,
+                    provider_slug: 'test-provider',
+                    subject: 'sub-hosted-3',
+                    email: 'member@example.com',
+                    first_login_at: new Date(),
+                    last_login_at: new Date(),
+                });
+
+                const result = await provisioningService.provisionUser(
+                    'test-provider',
+                    { sub: 'sub-hosted-3', email: 'member@example.com' },
+                    {}
+                );
+
+                expect(result.isNewUser).toBe(false);
+                expect(result.user.id).toBe(existing.id);
+            });
         });
 
         it('should throw error when email claim is missing', async () => {

--- a/docs/08-user-management.md
+++ b/docs/08-user-management.md
@@ -229,6 +229,19 @@ to an account, so it cannot be used to discover who has signed up - Declining re
 
 ## **Admin User Management**
 
+### Who becomes admin
+
+29a. **Self-hosted (default):** the first user created on the instance is
+    the owner and gets the admin role automatically.
+
+29b. **Hosted (`TUDUDI_HOSTED_MODE=true`):** no user is made admin
+    implicitly, and the bootstrap fallback of `POST /api/admin/set-admin-role`
+    is disabled. The admin account comes from `TUDUDI_USER_EMAIL` and
+    `TUDUDI_USER_PASSWORD`, which the entrypoint creates if missing and
+    grants the admin role. An existing account's password is left unchanged;
+    run `node scripts/user-create.js <email> <password> true --update-password`
+    to reset it.
+
 ### User CRUD Operations
 
 30. **Admins can create new users directly**

--- a/docs/10-oidc-sso.md
+++ b/docs/10-oidc-sso.md
@@ -114,6 +114,13 @@ OIDC_AUTO_PROVISION=true
 OIDC_ADMIN_EMAIL_DOMAINS=example.com,mycompany.com
 ```
 
+Auto-provisioning creates an account for anyone the provider authenticates,
+regardless of the admin "registration enabled" toggle. That is the intent on
+a self-hosted instance where the IdP is the company directory. On a hosted
+instance (`TUDUDI_HOSTED_MODE=true`) the provider may be a public one such as
+Google, so new accounts are only provisioned while registration is enabled;
+existing users keep signing in either way.
+
 **Required Variables:**
 - `OIDC_PROVIDER_NAME`: Display name shown to users (e.g., "Google", "Company SSO")
 - `OIDC_PROVIDER_SLUG`: URL-safe identifier (e.g., "google", "okta")

--- a/docs/16-postgresql.md
+++ b/docs/16-postgresql.md
@@ -37,7 +37,7 @@ Passwords with special characters must be URL-encoded inside `DATABASE_URL` (`@`
 1. Connects and authenticates.
 2. If the `users` table is missing, the database is treated as new: `sequelize.sync()` creates every table, index and foreign key from the models, and all existing migration files are recorded in `SequelizeMeta` as already applied (the *baseline*). The default `registration_enabled=false` setting is seeded.
 3. `sequelize-cli db:migrate` then runs whatever migrations were added after the baseline. On a brand-new install this prints "No migrations were executed".
-4. If `TUDUDI_USER_EMAIL` and `TUDUDI_USER_PASSWORD` are set, that user is created or updated.
+4. If `TUDUDI_USER_EMAIL` and `TUDUDI_USER_PASSWORD` are set, that user is created (if missing) and made admin. An existing user's password is left unchanged.
 
 The historical migrations contain SQLite-only SQL and are never replayed on PostgreSQL; the models are the source of truth for a fresh PostgreSQL schema. On an existing database, step 2 is skipped and only pending migrations run, so restarts and upgrades behave exactly as with SQLite.
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -107,6 +107,8 @@ Create `/backend/.env` file (not tracked in git):
 TUDUDI_SESSION_SECRET=your-random-secret-here-use-openssl-rand-hex-64
 TUDUDI_USER_EMAIL=admin@example.com
 TUDUDI_USER_PASSWORD=your-secure-password
+# The admin user is created on startup if missing. An existing user's
+# password is not overwritten (see scripts/user-create.js --update-password).
 
 # Optional - Server config
 NODE_ENV=development


### PR DESCRIPTION
## Description

Second step of preparing tududi for a shared multi-user instance (follows #1472). Introduces the `TUDUDI_HOSTED_MODE` flag (off by default, so self-hosters see no change) and uses it to switch off three single-owner conveniences:

- **First user becomes admin** (`User.afterCreate` hook): on a hosted instance the first registered user is just the first customer, so they get a regular role. Self-hosted behaviour is unchanged.
- **Bootstrap role assignment** (`POST /api/admin/set-admin-role` with an empty roles table): disabled in hosted mode, where an empty table would hand the instance to whoever asks first.
- **OIDC auto-provisioning ignores the registration toggle**: on a self-hosted instance that is intentional (the IdP is the company directory). In hosted mode the IdP may be public (Google), so new accounts are only provisioned while registration is enabled. Existing identities keep signing in.

Independent of the flag:

- **The entrypoint reset the admin password on every boot.** `scripts/user-create.js` now creates the user if missing and applies the admin role; an existing password is only replaced with `--update-password`. `TUDUDI_USER_PASSWORD` in a long-lived `.env` no longer silently undoes a password change.
- The OIDC provisioner set a non-existent `verified_email` column; it now sets `email_verified`.

Docs updated: `08-user-management.md` (who becomes admin), `10-oidc-sso.md` (auto-provisioning in hosted mode), `16-postgresql.md`, `development-workflow.md`, `backend/.env.example`.

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [x] Documentation/Translation update

## Testing

- New `backend/tests/integration/hosted-mode-bootstrap.test.js`: first user not admin in hosted mode, bootstrap refused with an empty roles table, explicit admins still manage roles, default (self-hosted) still promotes the first user.
- New hosted-mode cases in `tests/unit/modules/oidc/provisioningService.test.js`: refused while registration is disabled, provisioned once enabled, existing identity signs in regardless.
- `user-create-script.test.js` now asserts the password survives a plain rerun (with the admin flag still applied) and is replaced with `--update-password`.
- `npm test`: 1843 passed; the 4 failures in the parallel run (uploads-static, subtasks, caldav-protocol) pass in isolation and are the known parallel flakes.
- `npm run lint`: 0 errors.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)