### PR TITLE
fix(security): full account erasure, self-service delete, CalDAV auth hardening, flag cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,12 @@ jobs:
       env:
         FF_ENABLE_BACKUPS: 'true'
         FF_ENABLE_CALDAV: 'true'
-        FF_ENABLE_CALENDAR: 'true'
 
     - name: Upgrade legacy SQLite databases and check schema parity
       run: npm run backend:test:upgrade
       env:
         FF_ENABLE_BACKUPS: 'true'
         FF_ENABLE_CALDAV: 'true'
-        FF_ENABLE_CALENDAR: 'true'
 
     - name: Build frontend
       run: npm run build
@@ -94,7 +92,6 @@ jobs:
       env:
         FF_ENABLE_BACKUPS: 'true'
         FF_ENABLE_CALDAV: 'true'
-        FF_ENABLE_CALENDAR: 'true'
 
     # Legacy fixtures are always SQLite; with DATABASE_URL set the parity test
     # also compares the PostgreSQL schema produced by db-prepare.
@@ -103,4 +100,3 @@ jobs:
       env:
         FF_ENABLE_BACKUPS: 'true'
         FF_ENABLE_CALDAV: 'true'
-        FF_ENABLE_CALENDAR: 'true'

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,9 +128,7 @@ ENV NODE_ENV=production \
     TUDUDI_UPLOAD_PATH="/app/uploads" \
     SWAGGER_ENABLED=false \
     FF_ENABLE_BACKUPS=false \
-    FF_ENABLE_CALDAV=false \
-    FF_ENABLE_CALENDAR=false \
-    FF_ENABLE_HABITS=false
+    FF_ENABLE_CALDAV=false
 
 HEALTHCHECK --interval=60s --timeout=3s --start-period=10s --retries=2 \
     CMD ["wget", "-q", "--spider", "http://127.0.0.1:3002/api/health"]

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -56,8 +56,6 @@ TUDUDI_HOSTED_MODE=false
 # Feature Flags
 FF_ENABLE_BACKUPS=false
 FF_ENABLE_CALDAV=false
-FF_ENABLE_CALENDAR=false
-FF_ENABLE_HABITS=false
 FF_ENABLE_MCP=false
 
 # Trust Proxy Configuration

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -207,6 +207,11 @@ const config = {
             max: parseInt(process.env.RATE_LIMIT_AUTH_EMAIL_MAX) || 10,
         },
 
+        // CalDAV Basic-auth attempts, per IP + username, per auth window
+        caldavAuth: {
+            max: parseInt(process.env.RATE_LIMIT_CALDAV_AUTH_MAX) || 20,
+        },
+
         // General API for unauthenticated requests
         api: {
             windowMs:

--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -175,7 +175,31 @@ const apiKeyManagementLimiter = rateLimit({
     },
 });
 
+// CalDAV clients authenticate with Basic auth on every request, outside the
+// /api limiters. Keyed by IP plus the attempted username so a password
+// guess against one account is throttled without blocking a whole office.
+const caldavAuthLimiter = rateLimit({
+    windowMs: rateLimitConfig.auth.windowMs,
+    max: rateLimitConfig.caldavAuth.max,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: skipInTest,
+    keyGenerator: (req) => {
+        const username = (req.caldavUsername || '').trim().toLowerCase();
+        return `${ipKeyGenerator(req.ip)}|${username}`;
+    },
+    handler: (req, res) => {
+        res.status(429)
+            .set('WWW-Authenticate', 'Basic realm="Tududi CalDAV"')
+            .json({
+                error: 'Too many authentication attempts',
+                retryAfter: Math.ceil(req.rateLimit.resetTime / 1000),
+            });
+    },
+});
+
 module.exports = {
+    caldavAuthLimiter,
     authLimiter,
     authEmailLimiter,
     authEmailKey,

--- a/backend/modules/admin/repository.js
+++ b/backend/modules/admin/repository.js
@@ -1,23 +1,7 @@
 'use strict';
 
-const {
-    User,
-    Role,
-    Area,
-    Project,
-    Task,
-    Tag,
-    Note,
-    InboxItem,
-    TaskEvent,
-    Action,
-    Permission,
-    View,
-    ApiToken,
-    Notification,
-    RecurringCompletion,
-    sequelize,
-} = require('../../models');
+const { User, Role } = require('../../models');
+const { eraseUserAccount } = require('../../services/accountErasureService');
 
 class AdminRepository {
     /**
@@ -93,95 +77,27 @@ class AdminRepository {
     /**
      * Delete a user and all associated data in a transaction.
      */
-    async deleteUserWithData(userId, requesterId) {
-        const transaction = await sequelize.transaction();
-
-        try {
-            const user = await User.findByPk(userId, { transaction });
-            if (!user) {
-                await transaction.rollback();
-                return { success: false, error: 'User not found', status: 404 };
-            }
-
-            // Prevent deleting the last remaining admin
-            const targetRole = await Role.findOne({
-                where: { user_id: userId },
-                transaction,
-            });
-            if (targetRole?.is_admin) {
-                const adminCount = await Role.count({
-                    where: { is_admin: true },
-                    transaction,
-                });
-                if (adminCount <= 1) {
-                    await transaction.rollback();
-                    return {
-                        success: false,
-                        error: 'Cannot delete the last remaining admin',
-                        status: 400,
-                    };
-                }
-            }
-
-            // Delete all associated data
-            await TaskEvent.destroy({
-                where: { user_id: userId },
-                transaction,
-            });
-
-            const userTasks = await Task.findAll({
-                where: { user_id: userId },
-                attributes: ['id'],
-                transaction,
-            });
-            const taskIds = userTasks.map((t) => t.id);
-            if (taskIds.length > 0) {
-                await RecurringCompletion.destroy({
-                    where: { task_id: taskIds },
-                    transaction,
-                });
-            }
-
-            await Task.destroy({ where: { user_id: userId }, transaction });
-            await Note.destroy({ where: { user_id: userId }, transaction });
-            await Project.destroy({ where: { user_id: userId }, transaction });
-            await Area.destroy({ where: { user_id: userId }, transaction });
-            await Tag.destroy({ where: { user_id: userId }, transaction });
-            await InboxItem.destroy({
-                where: { user_id: userId },
-                transaction,
-            });
-            await View.destroy({ where: { user_id: userId }, transaction });
-            await Notification.destroy({
-                where: { user_id: userId },
-                transaction,
-            });
-            await ApiToken.destroy({ where: { user_id: userId }, transaction });
-            await Permission.destroy({
-                where: { user_id: userId },
-                transaction,
-            });
-            await Permission.destroy({
-                where: { granted_by_user_id: userId },
-                transaction,
-            });
-            await Action.destroy({
-                where: { actor_user_id: userId },
-                transaction,
-            });
-            await Action.destroy({
-                where: { target_user_id: userId },
-                transaction,
-            });
-            await Role.destroy({ where: { user_id: userId }, transaction });
-            await user.destroy({ transaction });
-
-            await transaction.commit();
-            return { success: true };
-        } catch (error) {
-            await transaction.rollback();
-            throw error;
+    async deleteUserWithData(userId) {
+        const user = await User.findByPk(userId);
+        if (!user) {
+            return { success: false, error: 'User not found', status: 404 };
         }
+
+        // Prevent deleting the last remaining admin
+        const targetRole = await Role.findOne({ where: { user_id: userId } });
+        if (targetRole?.is_admin) {
+            const adminCount = await Role.count({ where: { is_admin: true } });
+            if (adminCount <= 1) {
+                return {
+                    success: false,
+                    error: 'Cannot delete the last remaining admin',
+                    status: 400,
+                };
+            }
+        }
+
+        await eraseUserAccount(userId);
+        return { success: true };
     }
 }
 

--- a/backend/modules/admin/service.js
+++ b/backend/modules/admin/service.js
@@ -263,10 +263,7 @@ class AdminService {
             throw new ValidationError('Cannot delete your own account');
         }
 
-        const result = await adminRepository.deleteUserWithData(
-            id,
-            requesterId
-        );
+        const result = await adminRepository.deleteUserWithData(id);
 
         if (!result.success) {
             if (result.status === 404) {

--- a/backend/modules/auth/controller.js
+++ b/backend/modules/auth/controller.js
@@ -52,11 +52,9 @@ const authController = {
             if (error.statusCode === 403) {
                 return res.status(403).json({ error: error.message });
             }
-            if (
-                error.message ===
-                'Failed to send verification email. Please try again later.'
-            ) {
-                return res.status(500).json({ error: error.message });
+            if (error.statusCode === 503) {
+                logError('Registration email failure:', error);
+                return res.status(503).json({ error: error.message });
             }
             logError('Registration error:', error);
             res.status(500).json({
@@ -123,6 +121,15 @@ const authController = {
             }
             logError('Login error:', error);
             res.status(500).json({ error: 'Internal server error' });
+        }
+    },
+
+    async resendVerification(req, res, next) {
+        try {
+            const result = await authService.resendVerification(req.body.email);
+            res.json(result);
+        } catch (error) {
+            next(error);
         }
     },
 

--- a/backend/modules/auth/registrationService.js
+++ b/backend/modules/auth/registrationService.js
@@ -89,6 +89,27 @@ const isVerificationTokenValid = (token, expiresAt) => {
     return now <= expiration;
 };
 
+// Issues a fresh verification token for an unverified account and emails
+// it. Verified or unknown addresses are ignored so the caller's response can
+// stay identical in every case.
+const resendVerificationEmail = async (email) => {
+    const user = await User.findOne({
+        where: { email: String(email).trim().toLowerCase() },
+    });
+    if (!user || user.email_verified) {
+        return { sent: false };
+    }
+
+    const verificationToken = generateVerificationToken();
+    await user.update({
+        email_verification_token: verificationToken,
+        email_verification_token_expires_at: getTokenExpirationDate(),
+    });
+
+    const result = await sendVerificationEmail(user, verificationToken);
+    return { sent: !!result.success };
+};
+
 const verifyUserEmail = async (token) => {
     if (!token) {
         throw new Error('Verification token is required');
@@ -241,6 +262,7 @@ module.exports = {
     createUnverifiedUser,
     verifyUserEmail,
     sendVerificationEmail,
+    resendVerificationEmail,
     isVerificationTokenValid,
     cleanupExpiredTokens,
 };

--- a/backend/modules/auth/routes.js
+++ b/backend/modules/auth/routes.js
@@ -21,6 +21,12 @@ router.get(
 router.get('/csrf-token', csrfMiddleware, authController.getCsrfToken);
 router.post('/register', authLimiter, authController.register);
 router.get('/verify-email', authLimiter, authController.verifyEmail);
+router.post(
+    '/resend-verification',
+    authLimiter,
+    authEmailLimiter,
+    authController.resendVerification
+);
 router.get('/current_user', authController.getCurrentUser);
 router.post('/login', authLimiter, authEmailLimiter, authController.login);
 router.post(

--- a/backend/modules/auth/service.js
+++ b/backend/modules/auth/service.js
@@ -10,6 +10,7 @@ const {
     createUnverifiedUser,
     sendVerificationEmail,
     verifyUserEmail,
+    resendVerificationEmail,
 } = require('./registrationService');
 const {
     requestPasswordReset,
@@ -23,6 +24,7 @@ const {
     NotFoundError,
     UnauthorizedError,
     ForbiddenError,
+    ServiceUnavailableError,
 } = require('../../shared/errors');
 
 class AuthService {
@@ -66,14 +68,17 @@ class AuthService {
                 verificationToken
             );
 
+            // Without a verification email the account could never be
+            // used, so the user row is not kept. Say why, and say it as a
+            // temporary condition: the address itself is fine.
             if (!emailResult.success) {
                 await transaction.rollback();
                 logError(
                     new Error(emailResult.reason),
                     'Email sending failed during registration, rolling back user creation'
                 );
-                throw new Error(
-                    'Failed to send verification email. Please try again later.'
+                throw new ServiceUnavailableError(
+                    'Registration is temporarily unavailable because verification emails cannot be sent. Please try again later.'
                 );
             }
 
@@ -105,6 +110,26 @@ class AuthService {
             }
             throw error;
         }
+    }
+
+    // Same response whether the address is unknown, already verified, or
+    // just got a new link.
+    async resendVerification(email) {
+        if (!isPasswordAuthEnabled()) {
+            throw new ForbiddenError(
+                'Password registration is disabled. Please use SSO to sign in.'
+            );
+        }
+        if (!email || typeof email !== 'string') {
+            throw new ValidationError('Email is required');
+        }
+
+        await resendVerificationEmail(email);
+
+        return {
+            message:
+                'If that address belongs to an unverified account, a new verification email has been sent.',
+        };
     }
 
     async verifyEmail(token) {

--- a/backend/modules/caldav/middleware/caldav-auth.js
+++ b/backend/modules/caldav/middleware/caldav-auth.js
@@ -1,6 +1,7 @@
 const bcrypt = require('bcrypt');
 const { User } = require('../../../models');
 const { findValidTokenByValue } = require('../../users/apiTokenService');
+const { caldavAuthLimiter } = require('../../../middleware/rateLimiter');
 
 async function caldavAuth(req, res, next) {
     try {
@@ -52,19 +53,24 @@ async function caldavAuth(req, res, next) {
         const username = credentials.substring(0, colonIndex);
         const password = credentials.substring(colonIndex + 1);
 
-        const user = await User.findOne({ where: { email: username } });
-        if (!user) {
-            return res
-                .status(401)
-                .set('WWW-Authenticate', 'Basic realm="Tududi CalDAV"')
-                .json({ error: 'Invalid credentials' });
-        }
-
-        const isValidPassword = await bcrypt.compare(
-            password,
-            user.password_digest
+        // Basic auth is a password login outside the /api limiters, so it
+        // gets its own throttle keyed by IP and the attempted username.
+        req.caldavUsername = username;
+        const limited = await new Promise((resolve) =>
+            caldavAuthLimiter(req, res, (err) => resolve(err || null))
         );
-        if (!isValidPassword) {
+        if (res.headersSent) return;
+        if (limited) throw limited;
+
+        const user = await User.findOne({
+            where: { email: String(username).trim().toLowerCase() },
+        });
+        // Accounts created through SSO have no password; bcrypt.compare
+        // against null would throw and turn a bad login into a 500.
+        const isValidPassword = user?.password_digest
+            ? await bcrypt.compare(password, user.password_digest)
+            : false;
+        if (!user || !isValidPassword) {
             return res
                 .status(401)
                 .set('WWW-Authenticate', 'Basic realm="Tududi CalDAV"')

--- a/backend/modules/caldav/routes.js
+++ b/backend/modules/caldav/routes.js
@@ -28,6 +28,23 @@ const { generateCTag } = require('./utils/ctag-generator');
 
 const router = express.Router();
 
+// The whole protocol surface is off unless the operator turned CalDAV on;
+// otherwise a hidden feature would still expose a Basic-auth login endpoint.
+router.use((req, res, next) => {
+    const { isCalDAVEnabled } = require('../feature-flags/service');
+    if (isCalDAVEnabled()) return next();
+
+    const caldavPath =
+        req.path.startsWith('/caldav/') ||
+        req.path.startsWith('/.well-known/caldav') ||
+        req.path.startsWith('/api/caldav') ||
+        (req.method === 'PROPFIND' &&
+            (req.path === '/' || req.path === '/principals/'));
+    if (!caldavPath) return next();
+
+    return res.status(404).json({ error: 'CalDAV is not enabled' });
+});
+
 // GET redirects to /caldav/ per RFC 6764; PROPFIND returns root discovery for iOS accountsd
 router.all('/.well-known/caldav', (req, res, next) => {
     if (req.method === 'GET') return handleWellKnown(req, res, next);

--- a/backend/modules/caldav/services/sync-scheduler.js
+++ b/backend/modules/caldav/services/sync-scheduler.js
@@ -17,9 +17,11 @@ class SyncScheduler {
             return;
         }
 
-        const enabled = process.env.CALDAV_ENABLED !== 'false';
-        if (!enabled) {
-            logger.logInfo('CalDAV sync scheduler disabled via CALDAV_ENABLED');
+        const { isCalDAVEnabled } = require('../../feature-flags/service');
+        if (!isCalDAVEnabled()) {
+            logger.logInfo(
+                'CalDAV sync scheduler not started: set FF_ENABLE_CALDAV=true to enable CalDAV'
+            );
             return;
         }
 

--- a/backend/modules/feature-flags/service.js
+++ b/backend/modules/feature-flags/service.js
@@ -1,5 +1,11 @@
 'use strict';
 
+// One definition of "CalDAV is on" for the routes, the sync scheduler, and
+// the flag the UI reads. CALDAV_ENABLED is the older name and still works.
+const isCalDAVEnabled = () =>
+    process.env.FF_ENABLE_CALDAV === 'true' ||
+    process.env.CALDAV_ENABLED === 'true';
+
 class FeatureFlagsService {
     /**
      * Get all feature flags.
@@ -7,12 +13,13 @@ class FeatureFlagsService {
     getAll() {
         return {
             backups: process.env.FF_ENABLE_BACKUPS === 'true',
-            caldav:
-                process.env.FF_ENABLE_CALDAV === 'true' ||
-                process.env.CALDAV_ENABLED === 'true',
+            caldav: isCalDAVEnabled(),
             mcp: process.env.FF_ENABLE_MCP === 'true',
         };
     }
 }
 
-module.exports = new FeatureFlagsService();
+const featureFlagsService = new FeatureFlagsService();
+featureFlagsService.isCalDAVEnabled = isCalDAVEnabled;
+
+module.exports = featureFlagsService;

--- a/backend/modules/users/controller.js
+++ b/backend/modules/users/controller.js
@@ -115,6 +115,26 @@ const usersController = {
      * POST /api/profile/change-password
      * Change password.
      */
+    // DELETE /api/profile
+    // Erase the caller's own account. Requires the current password, or the
+    // typed email for accounts that have no password.
+    async deleteAccount(req, res, next) {
+        try {
+            const userId = requireUserId(req);
+            const { password, confirm_email } = req.body || {};
+            await usersService.deleteAccount(userId, {
+                password,
+                confirmEmail: confirm_email,
+            });
+            if (req.session) {
+                req.session.destroy(() => {});
+            }
+            res.status(204).end();
+        } catch (error) {
+            next(error);
+        }
+    },
+
     async changePassword(req, res, next) {
         try {
             const userId = requireUserId(req);

--- a/backend/modules/users/routes.js
+++ b/backend/modules/users/routes.js
@@ -60,6 +60,7 @@ router.get('/users', usersController.list);
 // Profile routes
 router.get('/profile', usersController.getProfile);
 router.patch('/profile', usersController.updateProfile);
+router.delete('/profile', usersController.deleteAccount);
 
 // Avatar routes
 router.post(

--- a/backend/modules/users/service.js
+++ b/backend/modules/users/service.js
@@ -42,8 +42,9 @@ const {
     ValidationError,
     ForbiddenError,
 } = require('../../shared/errors');
-const { User } = require('../../models');
+const { User, Role } = require('../../models');
 const { isAdmin } = require('../../services/rolesService');
+const { eraseUserAccount } = require('../../services/accountErasureService');
 const {
     createApiToken,
     revokeApiToken,
@@ -315,6 +316,50 @@ class UsersService {
     /**
      * Change password.
      */
+    async deleteAccount(userId, { password, confirmEmail } = {}) {
+        const user = await usersRepository.findByIdWithPassword(userId);
+        if (!user) {
+            throw new NotFoundError('User not found');
+        }
+
+        if (user.password_digest) {
+            if (!password) {
+                throw new ValidationError(
+                    'Current password is required',
+                    'password'
+                );
+            }
+            const ok = await User.checkPassword(password, user.password_digest);
+            if (!ok) {
+                throw new ValidationError(
+                    'Current password is incorrect',
+                    'password'
+                );
+            }
+        } else if (
+            !confirmEmail ||
+            String(confirmEmail).trim().toLowerCase() !== user.email
+        ) {
+            throw new ValidationError(
+                'Type your email address to confirm',
+                'confirm_email'
+            );
+        }
+
+        const role = await Role.findOne({ where: { user_id: userId } });
+        if (role?.is_admin) {
+            const admins = await Role.count({ where: { is_admin: true } });
+            if (admins <= 1) {
+                throw new ValidationError(
+                    'The last administrator cannot delete their own account. Promote another user first.'
+                );
+            }
+        }
+
+        await eraseUserAccount(userId);
+        return { success: true };
+    }
+
     async changePassword(userId, currentPassword, newPassword) {
         if (!newPassword) {
             throw new ValidationError('New password is required');

--- a/backend/services/accountErasureService.js
+++ b/backend/services/accountErasureService.js
@@ -1,0 +1,196 @@
+const path = require('path');
+const fs = require('fs').promises;
+const { Op } = require('sequelize');
+const {
+    sequelize,
+    User,
+    Role,
+    Area,
+    Goal,
+    Project,
+    Task,
+    Tag,
+    Note,
+    InboxItem,
+    TaskEvent,
+    Action,
+    Permission,
+    View,
+    ApiToken,
+    Notification,
+    RecurringCompletion,
+    TaskAttachment,
+    Backup,
+    OIDCIdentity,
+    AuthAuditLog,
+    CalDAVCalendar,
+    CalDAVSyncState,
+    CalDAVOccurrenceOverride,
+    CalDAVRemoteCalendar,
+    CalendarToken,
+    Person,
+    UserProjectArea,
+} = require('../models');
+const { getConfig } = require('../config/config');
+const { getBackupsDirectory } = require('./backupService');
+const { destroyUserSessions } = require('./sessionService');
+const { logError } = require('./logService');
+
+const config = getConfig();
+
+// Deletes a file only if it lives under `baseDir`; a bad path in the
+// database must not turn into an arbitrary unlink.
+async function unlinkWithin(baseDir, relativeOrAbsolute) {
+    if (!relativeOrAbsolute) return;
+    const resolvedBase = path.resolve(baseDir);
+    const resolved = path.resolve(resolvedBase, relativeOrAbsolute);
+    const relative = path.relative(resolvedBase, resolved);
+    if (relative.startsWith('..') || path.isAbsolute(relative)) {
+        logError('Refusing to delete file outside its directory:', resolved);
+        return;
+    }
+    await fs.unlink(resolved).catch(() => {});
+}
+
+// Removes every row that belongs to a user, and every file those rows
+// point at. Used for admin deletion and for self-service account deletion.
+// Rows go inside one transaction; files are removed only after it commits,
+// so a rollback never leaves rows pointing at missing files.
+async function eraseUserAccount(userId) {
+    const filesToDelete = [];
+    const transaction = await sequelize.transaction();
+
+    try {
+        const user = await User.findByPk(userId, { transaction });
+        if (!user) {
+            await transaction.rollback();
+            return false;
+        }
+
+        const tx = { transaction };
+        const byUser = { where: { user_id: userId }, ...tx };
+
+        const attachments = await TaskAttachment.findAll({
+            where: { user_id: userId },
+            attributes: ['file_path'],
+            raw: true,
+            ...tx,
+        });
+        for (const a of attachments) {
+            filesToDelete.push([config.uploadPath, a.file_path]);
+        }
+
+        const backups = await Backup.findAll({
+            where: { user_id: userId },
+            attributes: ['file_path'],
+            raw: true,
+            ...tx,
+        });
+        if (backups.length > 0) {
+            const backupsDir = await getBackupsDirectory();
+            for (const b of backups) {
+                filesToDelete.push([backupsDir, b.file_path]);
+            }
+        }
+
+        if (user.avatar_image) {
+            filesToDelete.push([
+                path.join(config.uploadPath, 'avatars'),
+                path.basename(user.avatar_image),
+            ]);
+        }
+
+        const userTasks = await Task.findAll({
+            where: { user_id: userId },
+            attributes: ['id'],
+            raw: true,
+            ...tx,
+        });
+        const taskIds = userTasks.map((t) => t.id);
+        if (taskIds.length > 0) {
+            await RecurringCompletion.destroy({
+                where: { task_id: taskIds },
+                ...tx,
+            });
+        }
+
+        const calendars = await CalDAVCalendar.findAll({
+            where: { user_id: userId },
+            attributes: ['id'],
+            raw: true,
+            ...tx,
+        });
+        const calendarIds = calendars.map((c) => c.id);
+        if (calendarIds.length > 0) {
+            await CalDAVSyncState.destroy({
+                where: { calendar_id: calendarIds },
+                ...tx,
+            });
+            await CalDAVOccurrenceOverride.destroy({
+                where: { calendar_id: calendarIds },
+                ...tx,
+            });
+        }
+        await CalDAVRemoteCalendar.destroy(byUser);
+        await CalDAVCalendar.destroy(byUser);
+        await CalendarToken.destroy(byUser);
+
+        await TaskEvent.destroy(byUser);
+        await TaskAttachment.destroy(byUser);
+        await Task.destroy(byUser);
+        await Note.destroy(byUser);
+        await UserProjectArea.destroy(byUser);
+        await Project.destroy(byUser);
+        await Goal.destroy(byUser);
+        await Area.destroy(byUser);
+        await Tag.destroy(byUser);
+        await InboxItem.destroy(byUser);
+        await View.destroy(byUser);
+        await Notification.destroy(byUser);
+        await ApiToken.destroy(byUser);
+        await Backup.destroy(byUser);
+        await OIDCIdentity.destroy(byUser);
+        await AuthAuditLog.destroy(byUser);
+
+        // Other people's contact cards that pointed at this account keep
+        // their own data but lose the link.
+        await Person.update(
+            { linked_user_id: null },
+            { where: { linked_user_id: userId }, ...tx }
+        );
+        await Person.destroy(byUser);
+
+        await Permission.destroy({
+            where: {
+                [Op.or]: [{ user_id: userId }, { granted_by_user_id: userId }],
+            },
+            ...tx,
+        });
+        await Action.destroy({
+            where: {
+                [Op.or]: [
+                    { actor_user_id: userId },
+                    { target_user_id: userId },
+                ],
+            },
+            ...tx,
+        });
+
+        await Role.destroy(byUser);
+        await user.destroy(tx);
+
+        await transaction.commit();
+    } catch (error) {
+        await transaction.rollback();
+        throw error;
+    }
+
+    await destroyUserSessions(userId);
+    for (const [baseDir, file] of filesToDelete) {
+        await unlinkWithin(baseDir, file);
+    }
+
+    return true;
+}
+
+module.exports = { eraseUserAccount };

--- a/backend/services/sessionService.js
+++ b/backend/services/sessionService.js
@@ -4,7 +4,7 @@ const { logError } = require('./logService');
 
 // connect-session-sequelize stores each session's JSON in a `data` column,
 // so a user's sessions are the rows whose JSON carries their id. Used to
-// sign a user out everywhere after a password reset.
+// sign a user out everywhere after a password reset or account deletion.
 async function destroyUserSessions(userId, { exceptSid = null } = {}) {
     const Session = sequelize.models.Session;
     if (!Session) return 0;

--- a/backend/shared/errors/index.js
+++ b/backend/shared/errors/index.js
@@ -32,6 +32,12 @@ class ForbiddenError extends AppError {
     }
 }
 
+class ServiceUnavailableError extends AppError {
+    constructor(message = 'Service temporarily unavailable') {
+        super(message, 503, 'SERVICE_UNAVAILABLE');
+    }
+}
+
 module.exports = {
     AppError,
     NotFoundError,
@@ -39,4 +45,5 @@ module.exports = {
     ConflictError,
     UnauthorizedError,
     ForbiddenError,
+    ServiceUnavailableError,
 };

--- a/backend/tests/helpers/setup.js
+++ b/backend/tests/helpers/setup.js
@@ -8,6 +8,12 @@
 
 const { testDatabaseName } = require('./test-db');
 
+// CalDAV routes 404 unless the flag is on; the CalDAV suites expect it on
+// unless a test turns it off deliberately.
+if (process.env.FF_ENABLE_CALDAV === undefined) {
+    process.env.FF_ENABLE_CALDAV = 'true';
+}
+
 if (process.env.DATABASE_URL || process.env.DB_DIALECT) {
     const workerDb = testDatabaseName(process.env.JEST_WORKER_ID || '1');
     if (process.env.DATABASE_URL) {

--- a/backend/tests/integration/account-erasure.test.js
+++ b/backend/tests/integration/account-erasure.test.js
@@ -1,0 +1,272 @@
+const request = require('supertest');
+const path = require('path');
+const fs = require('fs').promises;
+const app = require('../../app');
+const {
+    User,
+    Role,
+    Project,
+    Task,
+    Note,
+    Goal,
+    Person,
+    TaskAttachment,
+    Backup,
+    OIDCIdentity,
+    AuthAuditLog,
+    CalDAVCalendar,
+    CalDAVSyncState,
+    CalendarToken,
+    Permission,
+    sequelize,
+} = require('../../models');
+const { getConfig } = require('../../config/config');
+const { getBackupsDirectory } = require('../../services/backupService');
+const { createTestUser } = require('../helpers/testUtils');
+
+const config = getConfig();
+
+const login = async (user) => {
+    const agent = request.agent(app);
+    await agent
+        .post('/api/login')
+        .send({ email: user.email, password: 'password123' });
+    return agent;
+};
+
+// Creates one row of everything that hangs off a user, plus the files on
+// disk that some of those rows point at.
+async function seedEverything(user, other) {
+    const project = await Project.create({
+        name: 'Erase me',
+        user_id: user.id,
+    });
+    const task = await Task.create({
+        name: 'Erase me too',
+        user_id: user.id,
+        project_id: project.id,
+    });
+    await Note.create({ title: 'n', content: 'c', user_id: user.id });
+    await Goal.create({ title: 'g', user_id: user.id });
+    await Person.create({ name: 'Contact', user_id: user.id });
+
+    // Another user's contact card linked to this account
+    const theirCard = await Person.create({
+        name: 'Me as seen by other',
+        user_id: other.id,
+        linked_user_id: user.id,
+    });
+
+    const tasksDir = path.join(config.uploadPath, 'tasks');
+    await fs.mkdir(tasksDir, { recursive: true });
+    const attachmentName = `erase-${Date.now()}.txt`;
+    await fs.writeFile(path.join(tasksDir, attachmentName), 'bytes');
+    await TaskAttachment.create({
+        task_id: task.id,
+        user_id: user.id,
+        original_filename: 'a.txt',
+        stored_filename: attachmentName,
+        file_path: `tasks/${attachmentName}`,
+        file_size: 5,
+        mime_type: 'text/plain',
+    });
+
+    const backupsDir = await getBackupsDirectory();
+    const backupName = `backup-user-${user.id}-${Date.now()}.json.gz`;
+    await fs.writeFile(path.join(backupsDir, backupName), 'gz');
+    await Backup.create({
+        user_id: user.id,
+        file_path: backupName,
+        file_size: 2,
+        version: '1.0',
+        item_counts: {},
+    });
+
+    await OIDCIdentity.create({
+        user_id: user.id,
+        provider_slug: 'test',
+        subject: `sub-${user.id}`,
+        email: user.email,
+        first_login_at: new Date(),
+        last_login_at: new Date(),
+    });
+    await AuthAuditLog.create({
+        user_id: user.id,
+        event_type: 'login_success',
+        auth_method: 'email_password',
+    });
+    const calendar = await CalDAVCalendar.create({
+        user_id: user.id,
+        name: 'cal',
+        url: 'https://example.com/cal',
+        username: 'u',
+        password_encrypted: 'x',
+    });
+    await CalDAVSyncState.create({
+        calendar_id: calendar.id,
+        task_id: task.id,
+        remote_uid: 'r',
+        remote_href: '/r.ics',
+        etag: 'etag',
+        last_modified: new Date(),
+    });
+    await CalendarToken.create({
+        user_id: user.id,
+        provider: 'google',
+        access_token: 'a',
+        refresh_token: 'r',
+    });
+    await Permission.create({
+        user_id: other.id,
+        resource_type: 'project',
+        resource_uid: project.uid,
+        access_level: 'ro',
+        propagation: 'direct',
+        granted_by_user_id: user.id,
+    });
+
+    return {
+        attachmentPath: path.join(tasksDir, attachmentName),
+        backupPath: path.join(backupsDir, backupName),
+        theirCardId: theirCard.id,
+        calendarId: calendar.id,
+    };
+}
+
+const exists = (p) =>
+    fs
+        .access(p)
+        .then(() => true)
+        .catch(() => false);
+
+describe('Account erasure', () => {
+    let admin, user, other;
+
+    beforeEach(async () => {
+        admin = await createTestUser({
+            email: `admin_${Date.now()}@example.com`,
+        });
+        await Role.update({ is_admin: true }, { where: { user_id: admin.id } });
+        user = await createTestUser({
+            email: `victim_${Date.now()}@example.com`,
+        });
+        other = await createTestUser({
+            email: `other_${Date.now()}@example.com`,
+        });
+    });
+
+    const expectFullyErased = async (seeded) => {
+        expect(await User.findByPk(user.id)).toBeNull();
+        for (const [Model, label] of [
+            [Task, 'tasks'],
+            [Note, 'notes'],
+            [Project, 'projects'],
+            [Goal, 'goals'],
+            [Person, 'people'],
+            [TaskAttachment, 'attachments'],
+            [Backup, 'backups'],
+            [OIDCIdentity, 'oidc identities'],
+            [AuthAuditLog, 'audit log'],
+            [CalDAVCalendar, 'caldav calendars'],
+            [CalendarToken, 'calendar tokens'],
+            [Role, 'roles'],
+        ]) {
+            const count = await Model.count({ where: { user_id: user.id } });
+            expect({ [label]: count }).toEqual({ [label]: 0 });
+        }
+        expect(
+            await CalDAVSyncState.count({
+                where: { calendar_id: seeded.calendarId },
+            })
+        ).toBe(0);
+        expect(
+            await Permission.count({ where: { granted_by_user_id: user.id } })
+        ).toBe(0);
+
+        const theirCard = await Person.findByPk(seeded.theirCardId);
+        expect(theirCard).not.toBeNull();
+        expect(theirCard.linked_user_id).toBeNull();
+
+        expect(await exists(seeded.attachmentPath)).toBe(false);
+        expect(await exists(seeded.backupPath)).toBe(false);
+    };
+
+    it('admin deletion removes every row and file of the user', async () => {
+        const seeded = await seedEverything(user, other);
+        const adminAgent = await login(admin);
+
+        const res = await adminAgent.delete(`/api/admin/users/${user.id}`);
+        expect(res.status).toBe(204);
+
+        await expectFullyErased(seeded);
+    });
+
+    it('self-service deletion requires the password and ends the session', async () => {
+        const seeded = await seedEverything(user, other);
+        const agent = await login(user);
+
+        const wrong = await agent
+            .delete('/api/profile')
+            .send({ password: 'not-it' });
+        expect(wrong.status).toBe(400);
+        expect(await User.findByPk(user.id)).not.toBeNull();
+
+        const missing = await agent.delete('/api/profile').send({});
+        expect(missing.status).toBe(400);
+
+        const ok = await agent
+            .delete('/api/profile')
+            .send({ password: 'password123' });
+        expect(ok.status).toBe(204);
+
+        await expectFullyErased(seeded);
+
+        const after = await agent.get('/api/current_user');
+        expect(after.body.user).toBeNull();
+    });
+
+    it('a passwordless account confirms with its email address', async () => {
+        const sso = await User.create({
+            email: `sso_${Date.now()}@example.com`,
+            password_digest: null,
+        });
+        const Session = sequelize.models.Session;
+        expect(Session).toBeDefined();
+
+        // No password to log in with, so drive the endpoint through a
+        // session row written directly.
+        const agent = request.agent(app);
+        const csrf = await agent.get('/api/csrf-token');
+        expect(csrf.status).toBe(200);
+        const sid = csrf.headers['set-cookie']
+            ?.find((c) => c.startsWith('connect.sid'))
+            ?.split(';')[0]
+            .split('=')[1];
+        const rawSid = decodeURIComponent(sid).slice(2).split('.')[0];
+        const row = await Session.findByPk(rawSid);
+        const data = JSON.parse(row.data);
+        data.userId = sso.id;
+        await row.update({ data: JSON.stringify(data) });
+
+        const wrong = await agent
+            .delete('/api/profile')
+            .send({ confirm_email: 'someone-else@example.com' });
+        expect(wrong.status).toBe(400);
+
+        const ok = await agent
+            .delete('/api/profile')
+            .send({ confirm_email: sso.email.toUpperCase() });
+        expect(ok.status).toBe(204);
+        expect(await User.findByPk(sso.id)).toBeNull();
+    });
+
+    it('the last admin cannot delete their own account', async () => {
+        const adminAgent = await login(admin);
+
+        const res = await adminAgent
+            .delete('/api/profile')
+            .send({ password: 'password123' });
+        expect(res.status).toBe(400);
+        expect(await User.findByPk(admin.id)).not.toBeNull();
+    });
+});

--- a/backend/tests/integration/api-tokens.test.js
+++ b/backend/tests/integration/api-tokens.test.js
@@ -293,14 +293,20 @@ describe('API Token Authentication', () => {
                 .get('/api/tasks')
                 .set('Authorization', `Bearer ${rawToken}`);
 
-            // Check that last_used_at was updated
-            const tokensAfter = await agent.get('/api/profile/api-keys');
-            const tokenAfter = tokensAfter.body.find(
-                (t) => t.name === 'Test Token'
-            );
+            // last_used_at is written after the response is sent (see
+            // middleware/auth.js), so poll briefly instead of racing it.
+            let tokenAfter;
+            for (let attempt = 0; attempt < 30; attempt++) {
+                const tokensAfter = await agent.get('/api/profile/api-keys');
+                tokenAfter = tokensAfter.body.find(
+                    (t) => t.name === 'Test Token'
+                );
+                if (tokenAfter?.last_used_at) break;
+                await new Promise((resolve) => setTimeout(resolve, 100));
+            }
 
             // Verify last_used_at is set and is a recent timestamp
-            expect(tokenAfter.last_used_at).toBeDefined();
+            expect(tokenAfter.last_used_at).toBeTruthy();
             const lastUsedDate = new Date(tokenAfter.last_used_at);
             const now = new Date();
             expect(lastUsedDate.getTime()).toBeLessThanOrEqual(now.getTime());

--- a/backend/tests/integration/caldav-auth-hardening.test.js
+++ b/backend/tests/integration/caldav-auth-hardening.test.js
@@ -1,0 +1,75 @@
+const request = require('supertest');
+const app = require('../../app');
+const { User } = require('../../models');
+const { createTestUser } = require('../helpers/testUtils');
+
+const basic = (email, password) =>
+    `Basic ${Buffer.from(`${email}:${password}`).toString('base64')}`;
+
+describe('CalDAV Basic auth hardening', () => {
+    it('rejects a passwordless (SSO) account with 401, not 500', async () => {
+        const sso = await User.create({
+            email: `caldav_sso_${Date.now()}@example.com`,
+            password_digest: null,
+        });
+
+        const res = await request(app)
+            .propfind(`/caldav/${sso.email}/`)
+            .set('Authorization', basic(sso.email, 'anything'))
+            .set('Content-Type', 'application/xml')
+            .send('<?xml version="1.0"?><D:propfind xmlns:D="DAV:"/>');
+
+        expect(res.status).toBe(401);
+    });
+
+    it('matches the username case-insensitively', async () => {
+        const user = await createTestUser({
+            email: `caldav_case_${Date.now()}@example.com`,
+        });
+
+        const res = await request(app)
+            .options(`/caldav/${user.email}/`)
+            .set(
+                'Authorization',
+                basic(user.email.toUpperCase(), 'password123')
+            );
+
+        expect([200, 204]).toContain(res.status);
+    });
+});
+
+describe('CalDAV feature flag', () => {
+    let previous;
+
+    beforeEach(() => {
+        previous = process.env.FF_ENABLE_CALDAV;
+        process.env.FF_ENABLE_CALDAV = 'false';
+        delete process.env.CALDAV_ENABLED;
+    });
+
+    afterEach(() => {
+        process.env.FF_ENABLE_CALDAV = previous;
+    });
+
+    it('hides the protocol endpoints when CalDAV is off', async () => {
+        const user = await createTestUser({
+            email: `caldav_off_${Date.now()}@example.com`,
+        });
+
+        const wellKnown = await request(app).get('/.well-known/caldav');
+        expect(wellKnown.status).toBe(404);
+
+        const calendar = await request(app)
+            .options(`/caldav/${user.email}/`)
+            .set('Authorization', basic(user.email, 'password123'));
+        expect(calendar.status).toBe(404);
+
+        const flags = await request(app).get('/api/feature-flags');
+        expect(flags.body.featureFlags.caldav).toBe(false);
+    });
+
+    it('leaves the rest of the app alone', async () => {
+        const res = await request(app).get('/api/health');
+        expect(res.status).toBe(200);
+    });
+});

--- a/backend/tests/integration/registration-email.test.js
+++ b/backend/tests/integration/registration-email.test.js
@@ -1,0 +1,97 @@
+const request = require('supertest');
+
+let mockEmailEnabled = true;
+const mockSentEmails = [];
+jest.mock('../../services/emailService', () => ({
+    isEmailEnabled: () => mockEmailEnabled,
+    initializeEmailService: () => {},
+    verifyEmailConnection: async () => ({ success: true }),
+    sendEmail: async (message) => {
+        mockSentEmails.push(message);
+        return { success: true, messageId: 'test' };
+    },
+}));
+
+const app = require('../../app');
+const { User, Setting } = require('../../models');
+
+describe('Registration when email cannot be sent', () => {
+    beforeEach(async () => {
+        mockSentEmails.length = 0;
+        mockEmailEnabled = true;
+        await Setting.upsert({ key: 'registration_enabled', value: 'true' });
+    });
+
+    it('answers 503 and keeps no account when the email service is off', async () => {
+        mockEmailEnabled = false;
+        const email = `noemail_${Date.now()}@example.com`;
+
+        const res = await request(app)
+            .post('/api/register')
+            .send({ email, password: 'password123' });
+
+        expect(res.status).toBe(503);
+        expect(res.body.error).toMatch(/temporarily unavailable/);
+        expect(await User.findOne({ where: { email } })).toBeNull();
+    });
+
+    it('registers normally when email works', async () => {
+        const email = `ok_${Date.now()}@example.com`;
+
+        const res = await request(app)
+            .post('/api/register')
+            .send({ email, password: 'password123' });
+
+        expect(res.status).toBe(201);
+        expect(mockSentEmails).toHaveLength(1);
+    });
+});
+
+describe('POST /api/resend-verification', () => {
+    beforeEach(async () => {
+        mockSentEmails.length = 0;
+        mockEmailEnabled = true;
+        await Setting.upsert({ key: 'registration_enabled', value: 'true' });
+    });
+
+    it('issues a new token for an unverified account', async () => {
+        const email = `pending_${Date.now()}@example.com`;
+        await request(app)
+            .post('/api/register')
+            .send({ email, password: 'password123' });
+        const before = await User.findOne({ where: { email } });
+        const oldToken = before.email_verification_token;
+
+        const res = await request(app)
+            .post('/api/resend-verification')
+            .send({ email: email.toUpperCase() });
+
+        expect(res.status).toBe(200);
+        expect(mockSentEmails).toHaveLength(2);
+        await before.reload();
+        expect(before.email_verification_token).not.toBe(oldToken);
+        expect(mockSentEmails[1].text).toContain(
+            before.email_verification_token
+        );
+    });
+
+    it('responds identically for verified and unknown addresses without sending', async () => {
+        const verified = await User.create({
+            email: `verified_${Date.now()}@example.com`,
+            password: 'password123',
+            email_verified: true,
+        });
+
+        const known = await request(app)
+            .post('/api/resend-verification')
+            .send({ email: verified.email });
+        const unknown = await request(app)
+            .post('/api/resend-verification')
+            .send({ email: `ghost_${Date.now()}@example.com` });
+
+        expect(known.status).toBe(200);
+        expect(unknown.status).toBe(200);
+        expect(known.body).toEqual(unknown.body);
+        expect(mockSentEmails).toHaveLength(0);
+    });
+});

--- a/docs/08-user-management.md
+++ b/docs/08-user-management.md
@@ -17,7 +17,13 @@ This document explains how user management works in tududi from a user behavior 
     - When a user registers, they receive a verification email
     - The email contains a unique link that expires in 24 hours (configurable)
     - Users cannot log in until they verify their email address
-    - If email service is disabled, users must be verified manually by an admin
+    - If the verification email cannot be sent (email service disabled or
+      failing), registration answers `503` and no account is kept, so the
+      user can simply try again later; admins can still create accounts
+      directly
+    - An unverified user can ask for a new link from the login page
+      (`POST /api/resend-verification`); the response is the same whether or
+      not the address belongs to an unverified account
 
 3. **The first user becomes an admin automatically**
     - When no admin users exist in the system, the first user to register becomes an admin
@@ -275,13 +281,20 @@ to an account, so it cannot be used to discover who has signed up - Declining re
 
 33. **Admins can delete users**
     - Cannot delete their own account (prevents lockout)
-    - Deleting a user also deletes their data:
-        - Tasks are deleted (cascades to subtasks, attachments, etc.)
-        - Projects are deleted (cascades to tasks within)
-        - Notes are deleted
-        - Permissions granted by/to the user are removed
-        - API tokens are deleted
-        - Shared resources are unshared
+    - Deletion is a full erasure (`services/accountErasureService.js`):
+      tasks, subtasks, attachments and their files, notes, projects, areas,
+      goals, tags, inbox items, views, notifications, API tokens, backups
+      and their files, OIDC identities, CalDAV calendars and sync state,
+      calendar tokens, contacts, the avatar file, permissions granted to
+      or by the user, the auth audit log, sessions, and the role row
+    - Other users' contact cards that were linked to the account keep
+      their data but lose the link
+
+33a. **Users can delete their own account** (`DELETE /api/profile`, Profile > Security)
+    - Requires the current password, or the typed email address for accounts
+      that have no password (SSO)
+    - Runs the same erasure as admin deletion and ends the session
+    - The last remaining administrator cannot delete their own account
 
 34. **Admin bootstrapping:**
     - Every user gets a role row on creation, and the first user created on

--- a/docs/11-caldav-sync.md
+++ b/docs/11-caldav-sync.md
@@ -270,7 +270,7 @@ npm start              # For standalone
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `CALDAV_ENABLED` | Yes | `false` | Enable/disable CalDAV feature |
+| `FF_ENABLE_CALDAV` | Yes | `false` | Enable the CalDAV feature: the `/caldav/*` endpoints, the sync scheduler, and the profile tab. `CALDAV_ENABLED=true` is accepted as an older spelling. While off, the protocol endpoints answer 404. |
 | `CALDAV_PROJECTS_AS_CALENDARS` | No | `false` | Serve one CalDAV calendar **per project** (plus a "(No Project)" calendar) instead of a single combined `tasks/` calendar. With it on, clients such as Apple Reminders show one list per project. |
 | `ENCRYPTION_KEY` | Recommended | `SECRET_KEY` | AES-256-GCM encryption key for passwords |
 | `CALDAV_DEFAULT_SYNC_INTERVAL` | No | `15` | Default sync interval in minutes |

--- a/frontend/components/Login.tsx
+++ b/frontend/components/Login.tsx
@@ -11,6 +11,8 @@ const Login: React.FC = () => {
     const [error, setError] = useState<string | null>(null);
     const [successMessage, setSuccessMessage] = useState<string | null>(null);
     const [registrationEnabled, setRegistrationEnabled] = useState(false);
+    const [unverifiedEmail, setUnverifiedEmail] = useState<string | null>(null);
+    const [resendState, setResendState] = useState<'idle' | 'sent'>('idle');
     const [passwordAuthEnabled, setPasswordAuthEnabled] = useState(true);
     const [oidcProviders, setOidcProviders] = useState<
         Array<{ slug: string; name: string }>
@@ -130,8 +132,25 @@ const Login: React.FC = () => {
         checkPasswordAuth();
     }, []);
 
+    const handleResendVerification = async () => {
+        if (!unverifiedEmail) return;
+        try {
+            await fetch(getApiPath('resend-verification'), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ email: unverifiedEmail }),
+                credentials: 'include',
+            });
+        } catch (err) {
+            console.error('Error resending verification email:', err);
+        }
+        setResendState('sent');
+    };
+
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
+        setUnverifiedEmail(null);
+        setResendState('idle');
 
         try {
             const response = await fetch(getApiPath('login'), {
@@ -157,6 +176,7 @@ const Login: React.FC = () => {
                 navigate('/today');
             } else {
                 if (data.email_not_verified) {
+                    setUnverifiedEmail(email);
                     setError(
                         t(
                             'auth.email_not_verified',
@@ -211,6 +231,30 @@ const Login: React.FC = () => {
                             {error && (
                                 <div className="mb-4 text-center text-red-500">
                                     {error}
+                                </div>
+                            )}
+                            {unverifiedEmail && (
+                                <div className="mb-4 text-center text-sm">
+                                    {resendState === 'sent' ? (
+                                        <span className="text-gray-600 dark:text-gray-400">
+                                            {t(
+                                                'auth.verification_resent',
+                                                'If that address belongs to an unverified account, a new verification email is on its way.'
+                                            )}
+                                        </span>
+                                    ) : (
+                                        <button
+                                            type="button"
+                                            onClick={handleResendVerification}
+                                            className="text-blue-500 hover:text-blue-600"
+                                            data-testid="login-resend-verification"
+                                        >
+                                            {t(
+                                                'auth.resend_verification',
+                                                'Resend verification email'
+                                            )}
+                                        </button>
+                                    )}
                                 </div>
                             )}
 
@@ -294,6 +338,87 @@ const Login: React.FC = () => {
                                             )}
                                         </Link>
                                     </div>
+                                </form>
+                            )}
+
+                            {!passwordAuthEnabled &&
+                                oidcProviders.length === 0 && (
+                                    <div className="text-center text-gray-600 dark:text-gray-400">
+                                        {t(
+                                            'auth.no_auth_methods',
+                                            'No authentication methods available. Please contact your administrator.'
+                                        )}
+                                    </div>
+                                )}
+
+                            <OIDCProviderButtons providers={oidcProviders} />
+
+                            {oidcProviders.length > 0 &&
+                                passwordAuthEnabled && (
+                                    <div className="relative mb-6">
+                                        <div className="absolute inset-0 flex items-center">
+                                            <div className="w-full border-t border-gray-300 dark:border-gray-600"></div>
+                                        </div>
+                                        <div className="relative flex justify-center text-sm">
+                                            <span className="px-2 bg-gray-100 dark:bg-gray-900 text-gray-500 dark:text-gray-400">
+                                                {t(
+                                                    'auth.or_continue_with_email',
+                                                    'Or continue with email'
+                                                )}
+                                            </span>
+                                        </div>
+                                    </div>
+                                )}
+
+                            {passwordAuthEnabled && (
+                                <form onSubmit={handleSubmit}>
+                                    <div className="mb-4">
+                                        <label
+                                            htmlFor="email"
+                                            className="block text-gray-600 dark:text-gray-300 mb-1"
+                                        >
+                                            {t('auth.email', 'Email')}
+                                        </label>
+                                        <input
+                                            type="email"
+                                            id="email"
+                                            name="email"
+                                            value={email}
+                                            onChange={(e) =>
+                                                setEmail(e.target.value)
+                                            }
+                                            className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                                            data-testid="login-email"
+                                            required
+                                        />
+                                    </div>
+                                    <div className="mb-4">
+                                        <label
+                                            htmlFor="password"
+                                            className="block text-gray-600 dark:text-gray-300 mb-1"
+                                        >
+                                            {t('auth.password', 'Password')}
+                                        </label>
+                                        <input
+                                            type="password"
+                                            id="password"
+                                            name="password"
+                                            value={password}
+                                            onChange={(e) =>
+                                                setPassword(e.target.value)
+                                            }
+                                            className="w-full px-4 py-2 border dark:border-gray-600 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                                            data-testid="login-password"
+                                            required
+                                        />
+                                    </div>
+                                    <button
+                                        type="submit"
+                                        className="w-full bg-blue-500 text-white py-2 rounded-lg hover:bg-blue-600 transition-colors"
+                                        data-testid="login-submit"
+                                    >
+                                        {t('auth.login', 'Login')}
+                                    </button>
                                 </form>
                             )}
 

--- a/frontend/components/Profile/tabs/SecurityTab.tsx
+++ b/frontend/components/Profile/tabs/SecurityTab.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent } from 'react';
+import React, { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
     ShieldCheckIcon,
@@ -6,8 +6,11 @@ import {
     EyeIcon,
     EyeSlashIcon,
     InformationCircleIcon,
+    TrashIcon,
 } from '@heroicons/react/24/outline';
 import type { ProfileFormData } from '../types';
+import { deleteAccount } from '../../../utils/profileService';
+import { getCurrentUser } from '../../../utils/userUtils';
 
 interface SecurityTabProps {
     isActive: boolean;
@@ -35,6 +38,26 @@ const SecurityTab: React.FC<SecurityTabProps> = ({
     onToggleConfirmPassword,
 }) => {
     const { t } = useTranslation();
+    const [confirmingDelete, setConfirmingDelete] = useState(false);
+    const [deleteSecret, setDeleteSecret] = useState('');
+    const [deleting, setDeleting] = useState(false);
+    const [deleteError, setDeleteError] = useState<string | null>(null);
+
+    const handleDeleteAccount = async () => {
+        setDeleteError(null);
+        setDeleting(true);
+        try {
+            await deleteAccount(
+                hasPassword
+                    ? { password: deleteSecret }
+                    : { confirm_email: deleteSecret }
+            );
+            window.location.href = '/login';
+        } catch (err: any) {
+            setDeleteError(err.message || 'Failed to delete account');
+            setDeleting(false);
+        }
+    };
 
     if (!isActive) return null;
 
@@ -80,7 +103,9 @@ const SecurityTab: React.FC<SecurityTabProps> = ({
                             <div className="relative">
                                 <input
                                     type={
-                                        showCurrentPassword ? 'text' : 'password'
+                                        showCurrentPassword
+                                            ? 'text'
+                                            : 'password'
                                     }
                                     name="currentPassword"
                                     value={formData.currentPassword || ''}
@@ -176,6 +201,85 @@ const SecurityTab: React.FC<SecurityTabProps> = ({
                         )}
                     </div>
                 </div>
+            </div>
+
+            <div className="mt-6 p-4 border border-red-200 dark:border-red-800 rounded-lg">
+                <h4 className="text-lg font-medium text-red-700 dark:text-red-400 mb-2 flex items-center">
+                    <TrashIcon className="w-5 h-5 mr-2" />
+                    {t('profile.deleteAccount', 'Delete account')}
+                </h4>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                    {t(
+                        'profile.deleteAccountInfo',
+                        'This permanently removes your account and everything in it: tasks, projects, notes, attachments, backups, and integrations. It cannot be undone.'
+                    )}
+                </p>
+                {!confirmingDelete ? (
+                    <button
+                        type="button"
+                        onClick={() => setConfirmingDelete(true)}
+                        className="px-4 py-2 rounded border border-red-300 text-red-700 hover:bg-red-50 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/30"
+                        data-testid="delete-account-start"
+                    >
+                        {t('profile.deleteAccount', 'Delete account')}
+                    </button>
+                ) : (
+                    <div className="space-y-3">
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                            {hasPassword
+                                ? t(
+                                      'profile.deleteAccountConfirmPassword',
+                                      'Enter your password to confirm'
+                                  )
+                                : t(
+                                      'profile.deleteAccountConfirmEmail',
+                                      'Type your email address to confirm'
+                                  )}
+                        </label>
+                        <input
+                            type={hasPassword ? 'password' : 'email'}
+                            value={deleteSecret}
+                            onChange={(e) => setDeleteSecret(e.target.value)}
+                            placeholder={
+                                hasPassword ? '' : getCurrentUser()?.email || ''
+                            }
+                            className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm px-3 py-2 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-red-500 focus:border-red-500"
+                            data-testid="delete-account-secret"
+                        />
+                        {deleteError && (
+                            <div className="text-sm text-red-500">
+                                {deleteError}
+                            </div>
+                        )}
+                        <div className="flex space-x-2">
+                            <button
+                                type="button"
+                                onClick={handleDeleteAccount}
+                                disabled={deleting || !deleteSecret}
+                                className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+                                data-testid="delete-account-confirm"
+                            >
+                                {deleting
+                                    ? t('common.deleting', 'Deleting...')
+                                    : t(
+                                          'profile.deleteAccountConfirm',
+                                          'Permanently delete my account'
+                                      )}
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setConfirmingDelete(false);
+                                    setDeleteSecret('');
+                                    setDeleteError(null);
+                                }}
+                                className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200"
+                            >
+                                {t('common.cancel', 'Cancel')}
+                            </button>
+                        </div>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/frontend/utils/profileService.ts
+++ b/frontend/utils/profileService.ts
@@ -94,7 +94,10 @@ export const updateProfile = async (
     profileCache = updatedProfile;
     profileCacheExpiry = Date.now() + PROFILE_CACHE_TTL_MS;
 
-    if (profileData.features && 'task_intelligence_enabled' in profileData.features) {
+    if (
+        profileData.features &&
+        'task_intelligence_enabled' in profileData.features
+    ) {
         localStorage.removeItem('taskIntelligenceEnabled');
     }
 
@@ -341,4 +344,27 @@ export const getLocaleFirstDayOfWeek = (locale: string): number => {
     } else {
         return 0; // Sunday (default for US, CA, JP, etc.)
     }
+};
+
+export const deleteAccount = async (payload: {
+    password?: string;
+    confirm_email?: string;
+}): Promise<void> => {
+    const response = await fetch(getApiPath('profile'), {
+        method: 'DELETE',
+        credentials: 'include',
+        headers: await getPostHeadersWithCsrf(),
+        body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+        let message = 'Failed to delete account';
+        try {
+            const body = await response.json();
+            if (body?.error) message = body.error;
+        } catch {
+            // ignore non-JSON error bodies
+        }
+        throw new Error(message);
+    }
+    invalidateProfileCache();
 };

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "deleting": "Deleting...",
     "save": "Save",
     "cancel": "Cancel",
     "delete": "Delete",
@@ -509,6 +510,11 @@
       "prevConflict": "Previous"
     },
     "security": "Security Settings",
+    "deleteAccount": "Delete account",
+    "deleteAccountInfo": "This permanently removes your account and everything in it: tasks, projects, notes, attachments, backups, and integrations. It cannot be undone.",
+    "deleteAccountConfirmPassword": "Enter your password to confirm",
+    "deleteAccountConfirmEmail": "Type your email address to confirm",
+    "deleteAccountConfirm": "Permanently delete my account",
     "changePassword": "Change Password",
     "currentPassword": "Current Password",
     "newPassword": "New Password",
@@ -716,6 +722,8 @@
     "reset_link_missing": "This reset link is incomplete. Request a new one.",
     "request_new_link": "Request a new link",
     "password_too_short": "Password must be at least {{count}} characters long",
+    "resend_verification": "Resend verification email",
+    "verification_resent": "If that address belongs to an unverified account, a new verification email is on its way.",
     "newPassword": "New Password",
     "rememberMe": "Remember Me",
     "loginSuccess": "Login Successful",


### PR DESCRIPTION
## Description

Fourth step of preparing tududi for a shared multi-user instance (follows #1472, #1473, #1474).

**Account erasure is complete now.** Admin deletion left Person, Goal, TaskAttachment (rows and files), Backup (rows and files), OIDCIdentity, CalDAV tables, CalendarToken, AuthAuditLog, sessions, and the avatar file behind. A single `services/accountErasureService.js` now removes all of it, inside one transaction for rows with files unlinked only after commit. Other users' contact cards that were linked to the account keep their data but lose the link.

**Self-service deletion** (`DELETE /api/profile`, Profile > Security > Delete account): requires the current password, or the typed email address for passwordless SSO accounts; runs the same erasure; ends the session; the last remaining admin is refused.

**CalDAV Basic auth hardening**
- A passwordless (SSO) account made `bcrypt.compare` throw and answered 500; now 401.
- Basic-auth attempts get their own limiter keyed by IP + username (`RATE_LIMIT_CALDAV_AUTH_MAX`, default 20 per 15 min). They were outside every `/api` limiter.
- Username matched case-insensitively, like every other login.
- The whole protocol surface (`/caldav/*`, `/.well-known/caldav`, `/api/caldav`, root PROPFIND) answers 404 unless `FF_ENABLE_CALDAV=true`. Previously the flag only hid the profile tab while the endpoints stayed live.
- One `isCalDAVEnabled()` (feature-flags service) drives the routes, the UI flag, and the sync scheduler. The scheduler was opt-out via `CALDAV_ENABLED` while the flag was opt-in; it is opt-in now. `CALDAV_ENABLED=true` still works as the older spelling.

**Registration**
- When the verification email cannot be sent, the response is `503` with a clear "temporarily unavailable" message and no account is kept (was a generic 500).
- `POST /api/resend-verification` issues a new link for an unverified account, same response for known and unknown addresses. The login page offers it when login fails with "verify your email".

**Flag cleanup**: `FF_ENABLE_CALENDAR` and `FF_ENABLE_HABITS` were set in the Dockerfile, CI, and `.env.example` but read by nothing. Removed.

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [x] Breaking change (breaks existing functionality)
- [x] Documentation/Translation update

Breaking: CalDAV endpoints require `FF_ENABLE_CALDAV=true` (or `CALDAV_ENABLED=true`); the sync scheduler no longer runs by default.

## Testing

- New `account-erasure.test.js`: seeds one row of every user-linked model plus files on disk, then asserts admin deletion and self-service deletion remove all of it (and unlink files, and unlink other users' contact cards); wrong password / missing confirmation refused; passwordless account confirms by email; last admin refused.
- New `caldav-auth-hardening.test.js`: passwordless account gets 401 not 500; case-insensitive username; endpoints 404 when the flag is off and `/api/feature-flags` reports it.
- New `registration-email.test.js`: 503 and no account when email is off; normal registration; resend issues a fresh token and same response for verified/unknown addresses without sending.
- Test setup defaults `FF_ENABLE_CALDAV=true` so the existing CalDAV suites keep running locally.
- `npm test`: 1851 passed (one permissions-tasks parallel flake passes in isolation). `npm run frontend:test`: 117 passed. `tsc --noEmit` clean. `npm run lint`: 0 errors.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)