### PR TITLE
feat(ops): coordinate multiple app processes through PostgreSQL

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -46,6 +46,8 @@ PASSWORD_RESET_TOKEN_EXPIRY_MINUTES=60
 
 DISABLE_SCHEDULER=false
 DISABLE_TELEGRAM=false
+# Bots polled in parallel per Telegram tick (default 10)
+# TELEGRAM_POLL_CONCURRENCY=10
 
 # Hosted mode (multi-user public instance). Leave false when self-hosting.
 # When true: the first registered user is not made admin (create the admin

--- a/backend/app.js
+++ b/backend/app.js
@@ -445,6 +445,10 @@ async function startServer() {
         const { validateAuthConfiguration } = require('./config/authConfig');
         validateAuthConfiguration();
 
+        // A hosted instance must not come up half-configured
+        const { assertHostedConfig } = require('./config/hostedConfig');
+        assertHostedConfig();
+
         const server = app.listen(config.port, config.host, () => {
             console.log(`Server running on port ${config.port}`);
             console.log(`Server listening on http://localhost:${config.port}`);

--- a/backend/cmd/start.sh
+++ b/backend/cmd/start.sh
@@ -119,14 +119,16 @@ fi
 
 # Verify the connection and create the schema when the database is empty
 echo "Preparing database..."
-if ! node scripts/db-prepare.js; then
+# Both steps run under a PostgreSQL advisory lock so that several app
+# containers booting together cannot create the schema or migrate twice.
+if ! node scripts/with-db-lock.js node scripts/db-prepare.js; then
   echo "❌ Database preparation failed. Check the connection settings above."
   exit 1
 fi
 
 # Run database migrations automatically
 echo "Running database migrations..."
-if ! npx sequelize-cli db:migrate --config config/database.js; then
+if ! node scripts/with-db-lock.js npx sequelize-cli db:migrate --config config/database.js; then
   echo "❌ Migration failed. Container cannot start with an incomplete schema."
   echo "   Check the migration error above and restore from backup if needed."
   exit 1

--- a/backend/config/hostedConfig.js
+++ b/backend/config/hostedConfig.js
@@ -1,0 +1,66 @@
+const { getConfig } = require('./config');
+
+const isLocal = (url) =>
+    !url || /^https?:\/\/(localhost|127\.0\.0\.1|0\.0\.0\.0)(:|\/|$)/.test(url);
+
+// Returns the list of things that would make a public, multi-user instance
+// unsafe or unusable. Empty when hosted mode is off or everything is set.
+function hostedConfigProblems(env = process.env, config = getConfig()) {
+    if (!config.hosted?.enabled) return [];
+
+    const problems = [];
+
+    if (!env.TUDUDI_SESSION_SECRET) {
+        problems.push(
+            'TUDUDI_SESSION_SECRET is not set: every restart would sign everyone out and a second process could not share sessions'
+        );
+    }
+    if (!config.trustProxy) {
+        problems.push(
+            'TUDUDI_TRUST_PROXY is off: behind a reverse proxy the session cookie loses its Secure flag and every user shares one rate-limit bucket'
+        );
+    }
+    if (!env.TUDUDI_ALLOWED_ORIGINS) {
+        problems.push(
+            'TUDUDI_ALLOWED_ORIGINS is not set: CORS would only allow localhost'
+        );
+    }
+    if (isLocal(env.FRONTEND_URL)) {
+        problems.push(
+            'FRONTEND_URL is unset or points at localhost: emailed links (verification, password reset) would be unusable'
+        );
+    }
+    if (isLocal(env.BACKEND_URL || env.BASE_URL)) {
+        problems.push(
+            'BACKEND_URL (or BASE_URL) is unset or points at localhost: verification links would be unusable'
+        );
+    }
+    if (!config.emailConfig?.enabled || !config.emailConfig?.smtp?.host) {
+        problems.push(
+            'ENABLE_EMAIL=true with EMAIL_SMTP_HOST is required: registration and password reset depend on email'
+        );
+    }
+    if (config.db?.dialect !== 'postgres') {
+        problems.push(
+            'DATABASE_URL must point at PostgreSQL: SQLite cannot serve several processes or many concurrent users'
+        );
+    }
+
+    return problems;
+}
+
+function assertHostedConfig(env = process.env, config = getConfig()) {
+    const problems = hostedConfigProblems(env, config);
+    if (problems.length === 0) return;
+
+    console.error(
+        'TUDUDI_HOSTED_MODE=true but the instance is not configured for it:'
+    );
+    for (const problem of problems) {
+        console.error(`  - ${problem}`);
+    }
+    console.error('Fix the settings above or unset TUDUDI_HOSTED_MODE.');
+    process.exit(1);
+}
+
+module.exports = { hostedConfigProblems, assertHostedConfig };

--- a/backend/middleware/rateLimitStore.js
+++ b/backend/middleware/rateLimitStore.js
@@ -1,0 +1,90 @@
+const { Op } = require('sequelize');
+const { sequelize, RateLimit } = require('../models');
+const { isPostgres } = require('../utils/db-dialect');
+const { logError } = require('../services/logService');
+
+// express-rate-limit Store backed by the rate_limits table. The default
+// MemoryStore keeps counters per process, so limits multiply by the number
+// of app processes and vanish on restart. One row per (limiter, client).
+//
+// increment() is a single upsert: a row past its reset time starts a new
+// window at 1, anything else adds one, and both branches happen inside the
+// database so concurrent processes never lose a hit.
+class DatabaseRateLimitStore {
+    constructor(prefix) {
+        this.prefix = `${prefix}:`;
+        this.windowMs = 60 * 1000;
+        this.localKeys = false;
+    }
+
+    init(options) {
+        this.windowMs = options.windowMs;
+    }
+
+    async increment(key) {
+        const now = new Date();
+        const reset = new Date(now.getTime() + this.windowMs);
+        const [rows] = await sequelize.query(
+            `INSERT INTO rate_limits (key, hits, reset_at, created_at, updated_at)
+             VALUES (:key, 1, :reset, :now, :now)
+             ON CONFLICT (key) DO UPDATE SET
+                 hits = CASE WHEN rate_limits.reset_at <= :now THEN 1 ELSE rate_limits.hits + 1 END,
+                 reset_at = CASE WHEN rate_limits.reset_at <= :now THEN :reset ELSE rate_limits.reset_at END,
+                 updated_at = :now
+             RETURNING hits, reset_at`,
+            { replacements: { key: this.prefix + key, reset, now } }
+        );
+        const row = rows[0];
+        return {
+            totalHits: Number(row.hits),
+            resetTime: new Date(row.reset_at),
+        };
+    }
+
+    async get(key) {
+        const row = await RateLimit.findByPk(this.prefix + key, { raw: true });
+        if (!row || new Date(row.reset_at) <= new Date()) return undefined;
+        return { totalHits: row.hits, resetTime: new Date(row.reset_at) };
+    }
+
+    async decrement(key) {
+        await RateLimit.decrement('hits', {
+            by: 1,
+            where: { key: this.prefix + key, hits: { [Op.gt]: 0 } },
+        });
+    }
+
+    async resetKey(key) {
+        await RateLimit.destroy({ where: { key: this.prefix + key } });
+    }
+
+    async resetAll() {
+        await RateLimit.destroy({
+            where: { key: { [Op.like]: `${this.prefix}%` } },
+        });
+    }
+}
+
+// Returns a shared store when the database can host one, otherwise
+// undefined so express-rate-limit falls back to its in-memory store.
+function createRateLimitStore(prefix) {
+    if (!isPostgres()) return undefined;
+    return new DatabaseRateLimitStore(prefix);
+}
+
+async function cleanupExpiredRateLimits() {
+    try {
+        return await RateLimit.destroy({
+            where: { reset_at: { [Op.lte]: new Date() } },
+        });
+    } catch (error) {
+        logError('Failed to clean up expired rate limit rows:', error);
+        return 0;
+    }
+}
+
+module.exports = {
+    DatabaseRateLimitStore,
+    createRateLimitStore,
+    cleanupExpiredRateLimits,
+};

--- a/backend/middleware/rateLimiter.js
+++ b/backend/middleware/rateLimiter.js
@@ -1,6 +1,7 @@
 const rateLimit = require('express-rate-limit');
 const { ipKeyGenerator } = require('express-rate-limit');
 const { getConfig } = require('../config/config');
+const { createRateLimitStore } = require('./rateLimitStore');
 
 const config = getConfig();
 const rateLimitConfig = config.rateLimiting;
@@ -13,6 +14,7 @@ const skipInTest = (req) => !rateLimitConfig.enabled;
  * Prevents brute force attacks on login/register
  */
 const authLimiter = rateLimit({
+    store: createRateLimitStore('auth'),
     windowMs: rateLimitConfig.auth.windowMs,
     max: rateLimitConfig.auth.max,
     message: {
@@ -44,6 +46,7 @@ const authEmailKey = (req) => {
 };
 
 const authEmailLimiter = rateLimit({
+    store: createRateLimitStore('auth-email'),
     windowMs: rateLimitConfig.authEmail.windowMs,
     max: rateLimitConfig.authEmail.max,
     standardHeaders: true,
@@ -64,6 +67,7 @@ const authEmailLimiter = rateLimit({
  * General API rate limiting for unauthenticated requests
  */
 const apiLimiter = rateLimit({
+    store: createRateLimitStore('api'),
     windowMs: rateLimitConfig.api.windowMs,
     max: rateLimitConfig.api.max,
     message: {
@@ -92,6 +96,7 @@ const apiLimiter = rateLimit({
  * More lenient limits for authenticated users
  */
 const authenticatedApiLimiter = rateLimit({
+    store: createRateLimitStore('api-auth'),
     windowMs: rateLimitConfig.authenticatedApi.windowMs,
     max: rateLimitConfig.authenticatedApi.max,
     standardHeaders: true,
@@ -126,6 +131,7 @@ const authenticatedApiLimiter = rateLimit({
  * Prevents spam and abuse
  */
 const createResourceLimiter = rateLimit({
+    store: createRateLimitStore('create'),
     windowMs: rateLimitConfig.createResource.windowMs,
     max: rateLimitConfig.createResource.max,
     standardHeaders: true,
@@ -153,6 +159,7 @@ const createResourceLimiter = rateLimit({
  * Very strict to prevent abuse
  */
 const apiKeyManagementLimiter = rateLimit({
+    store: createRateLimitStore('api-keys'),
     windowMs: rateLimitConfig.apiKeyManagement.windowMs,
     max: rateLimitConfig.apiKeyManagement.max,
     standardHeaders: true,
@@ -179,6 +186,7 @@ const apiKeyManagementLimiter = rateLimit({
 // /api limiters. Keyed by IP plus the attempted username so a password
 // guess against one account is throttled without blocking a whole office.
 const caldavAuthLimiter = rateLimit({
+    store: createRateLimitStore('caldav-auth'),
     windowMs: rateLimitConfig.auth.windowMs,
     max: rateLimitConfig.caldavAuth.max,
     standardHeaders: true,

--- a/backend/migrations/20260907000003-create-rate-limits.js
+++ b/backend/migrations/20260907000003-create-rate-limits.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const { safeCreateTable, safeAddIndex } = require('../utils/migration-utils');
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await safeCreateTable(queryInterface, 'rate_limits', {
+            key: {
+                type: Sequelize.STRING(512),
+                primaryKey: true,
+                allowNull: false,
+            },
+            hits: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                defaultValue: 0,
+            },
+            reset_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+            },
+            created_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+            },
+            updated_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+            },
+        });
+
+        await safeAddIndex(queryInterface, 'rate_limits', ['reset_at'], {
+            name: 'rate_limits_reset_at',
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable('rate_limits');
+    },
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -84,6 +84,7 @@ const CalendarToken = require('./calendar_token')(sequelize);
 const Goal = require('./goal')(sequelize);
 const Person = require('./person')(sequelize);
 const UserProjectArea = require('./user_project_area')(sequelize);
+const RateLimit = require('./rate_limit')(sequelize);
 
 User.hasMany(Area, { foreignKey: 'user_id' });
 Area.belongsTo(User, { foreignKey: 'user_id' });
@@ -475,4 +476,5 @@ module.exports = {
     CalendarToken,
     Person,
     UserProjectArea,
+    RateLimit,
 };

--- a/backend/models/rate_limit.js
+++ b/backend/models/rate_limit.js
@@ -1,0 +1,34 @@
+const { DataTypes } = require('sequelize');
+
+// Hit counters for express-rate-limit when several app processes share one
+// PostgreSQL database. Rows expire at reset_at and are swept by the daily
+// cleanup job.
+module.exports = (sequelize) => {
+    const RateLimit = sequelize.define(
+        'RateLimit',
+        {
+            key: {
+                type: DataTypes.STRING(512),
+                primaryKey: true,
+                allowNull: false,
+            },
+            hits: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                defaultValue: 0,
+            },
+            reset_at: {
+                type: DataTypes.DATE,
+                allowNull: false,
+            },
+        },
+        {
+            tableName: 'rate_limits',
+            timestamps: true,
+            underscored: true,
+            indexes: [{ fields: ['reset_at'] }],
+        }
+    );
+
+    return RateLimit;
+};

--- a/backend/modules/caldav/services/sync-scheduler.js
+++ b/backend/modules/caldav/services/sync-scheduler.js
@@ -35,7 +35,8 @@ class SyncScheduler {
         const cronExpression = this._getCronExpression(syncIntervalMinutes);
 
         this.globalJob = cron.schedule(cronExpression, async () => {
-            await this.syncAllDueCalendars();
+            const { withJobLock } = require('../../../services/jobLock');
+            await withJobLock('caldav-sync', () => this.syncAllDueCalendars());
         });
 
         this.isInitialized = true;

--- a/backend/modules/tasks/taskScheduler.js
+++ b/backend/modules/tasks/taskScheduler.js
@@ -37,7 +37,7 @@ const getCronExpression = (frequency) => {
     return expressions[frequency];
 };
 
-const createJobHandler = (frequency) => async () => {
+const runJob = async (frequency) => {
     if (frequency === 'cleanup_tokens') {
         await cleanupExpiredTokens();
     } else if (frequency === 'deferred_tasks') {
@@ -49,6 +49,13 @@ const createJobHandler = (frequency) => async () => {
     } else {
         await processSummariesForFrequency(frequency);
     }
+};
+
+// Each tick takes a per-job lock so that with several app processes only
+// one of them sends the summaries or notifications for that tick.
+const createJobHandler = (frequency) => async () => {
+    const { withJobLock } = require('../../services/jobLock');
+    await withJobLock(`task-scheduler:${frequency}`, () => runJob(frequency));
 };
 
 const createJobEntries = () => {
@@ -124,15 +131,17 @@ const processSummariesForFrequency = async (frequency) => {
 };
 
 const cleanupExpiredTokens = async () => {
-    try {
-        const {
-            cleanupExpiredTokens: cleanup,
-        } = require('./registrationService');
-        const count = await cleanup();
-        return count;
-    } catch (error) {
-        throw error;
-    }
+    const {
+        cleanupExpiredTokens: cleanup,
+    } = require('../auth/registrationService');
+    const count = await cleanup();
+
+    const {
+        cleanupExpiredRateLimits,
+    } = require('../../middleware/rateLimitStore');
+    await cleanupExpiredRateLimits();
+
+    return count;
 };
 
 const processDeferredTasks = async () => {

--- a/backend/modules/telegram/telegramInitializer.js
+++ b/backend/modules/telegram/telegramInitializer.js
@@ -11,8 +11,18 @@ async function initializeTelegramPolling() {
     // Add a delay before starting Telegram polling to allow the system to settle
     // and prevent immediate error floods if Telegram is temporarily unreachable
     const startupDelay = 10000; // 10 seconds
+    const leaderRetryDelay = 60000; // 1 minute
 
-    setTimeout(async () => {
+    // Telegram's getUpdates confirms updates by offset, and the offsets live
+    // in this process's memory, so exactly one process may poll. Whoever
+    // holds the leader lock polls; the others retry in case it goes away.
+    const { tryBecomeLeader } = require('../../services/jobLock');
+
+    const startWhenLeader = async () => {
+        if (!(await tryBecomeLeader('telegram-poller'))) {
+            setTimeout(startWhenLeader, leaderRetryDelay);
+            return;
+        }
         try {
             // Find users with configured Telegram tokens
             const usersWithTelegram = await User.findAll({
@@ -38,7 +48,9 @@ async function initializeTelegramPolling() {
                 error.message
             );
         }
-    }, startupDelay);
+    };
+
+    setTimeout(startWhenLeader, startupDelay);
 }
 
 module.exports = { initializeTelegramPolling };

--- a/backend/modules/telegram/telegramPoller.js
+++ b/backend/modules/telegram/telegramPoller.js
@@ -502,17 +502,29 @@ const processUpdates = async (user, updates) => {
     }
 };
 
+// How many bots are polled at the same time. The old loop polled every
+// user one after another, so a few hundred users turned a 5-second tick
+// into a minutes-long serial crawl.
+const POLL_CONCURRENCY = Math.max(
+    1,
+    parseInt(process.env.TELEGRAM_POLL_CONCURRENCY || '10', 10) || 10
+);
+
 // Function to poll updates for all users (contains side effects)
 const pollUpdates = async () => {
-    for (const user of pollerState.usersToPool) {
-        const token = user.telegram_bot_token;
-        if (!token) continue;
+    const dueUsers = pollerState.usersToPool.filter(
+        (user) => user.telegram_bot_token && shouldPollUser(user.id)
+    );
 
-        // Check if we should poll this user based on backoff state
-        if (!shouldPollUser(user.id)) {
-            continue;
-        }
+    for (let i = 0; i < dueUsers.length; i += POLL_CONCURRENCY) {
+        const batch = dueUsers.slice(i, i + POLL_CONCURRENCY);
+        await Promise.all(batch.map((user) => pollUser(user)));
+    }
+};
 
+const pollUser = async (user) => {
+    const token = user.telegram_bot_token;
+    {
         try {
             const lastUpdateId =
                 pollerState.userStatus[user.id]?.lastUpdateId || 0;

--- a/backend/scripts/with-db-lock.js
+++ b/backend/scripts/with-db-lock.js
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+
+// Runs a command while holding a PostgreSQL advisory lock, so two app
+// containers starting at the same time cannot both create the schema or run
+// migrations. On SQLite (one process by definition) the command just runs.
+//
+// Usage: node scripts/with-db-lock.js <command> [args...]
+
+try {
+    require('dotenv').config();
+} catch (_) {}
+
+const { spawn } = require('child_process');
+const { Sequelize } = require('sequelize');
+const { buildSequelizeOptions } = require('../config/db');
+const { getConfig } = require('../config/config');
+
+// Any fixed key works; it only has to be the same in every process.
+const SCHEMA_LOCK_KEY = 7263001;
+
+function runCommand(argv) {
+    return new Promise((resolve) => {
+        const child = spawn(argv[0], argv.slice(1), {
+            stdio: 'inherit',
+            shell: process.platform === 'win32',
+        });
+        child.on('exit', (code) => resolve(code ?? 1));
+        child.on('error', () => resolve(1));
+    });
+}
+
+async function main() {
+    const argv = process.argv.slice(2);
+    if (argv.length === 0) {
+        console.error('Usage: with-db-lock.js <command> [args...]');
+        process.exit(2);
+    }
+
+    const config = getConfig();
+    if (config.db.dialect !== 'postgres') {
+        process.exit(await runCommand(argv));
+    }
+
+    const sequelize = new Sequelize(buildSequelizeOptions({ logging: false }));
+    let exitCode = 1;
+    try {
+        await sequelize.authenticate();
+        const tx = await sequelize.transaction();
+        console.log('Waiting for the schema lock...');
+        await sequelize.query('SELECT pg_advisory_xact_lock(:key)', {
+            replacements: { key: SCHEMA_LOCK_KEY },
+            transaction: tx,
+        });
+        console.log('Schema lock acquired');
+        try {
+            exitCode = await runCommand(argv);
+        } finally {
+            await tx.rollback();
+        }
+    } catch (error) {
+        console.error('Could not take the schema lock:', error.message);
+        exitCode = 1;
+    } finally {
+        await sequelize.close().catch(() => {});
+    }
+    process.exit(exitCode);
+}
+
+main();

--- a/backend/services/jobLock.js
+++ b/backend/services/jobLock.js
@@ -1,0 +1,116 @@
+const crypto = require('crypto');
+const { sequelize } = require('../models');
+const { isPostgres } = require('../utils/db-dialect');
+const { logError, logInfo } = require('./logService');
+
+// Background jobs (task summaries, due-task notifications, CalDAV sync,
+// Telegram polling) used to run in every process. With two app containers
+// that means duplicate notifications and stolen Telegram updates. On
+// PostgreSQL an advisory lock makes exactly one process run each job; on
+// SQLite there is only ever one process, so a local mutex is enough.
+
+// Stable 32-bit key for pg advisory locks, derived from the job name.
+const lockKey = (name) =>
+    crypto.createHash('sha256').update(name).digest().readInt32BE(0);
+
+const runningLocally = new Set();
+
+// Runs `fn` if no other process (or this one) is already running the job
+// named `name`. Returns { ran: true, result } or { ran: false }.
+async function withJobLock(name, fn) {
+    if (runningLocally.has(name)) {
+        return { ran: false };
+    }
+
+    if (!isPostgres()) {
+        runningLocally.add(name);
+        try {
+            return { ran: true, result: await fn() };
+        } finally {
+            runningLocally.delete(name);
+        }
+    }
+
+    // A transaction-scoped advisory lock releases itself when the
+    // transaction ends, even if the process dies mid-job.
+    const tx = await sequelize.transaction();
+    try {
+        const [[{ locked }]] = await sequelize.query(
+            'SELECT pg_try_advisory_xact_lock(:key) AS locked',
+            { replacements: { key: lockKey(name) }, transaction: tx }
+        );
+        if (!locked) {
+            await tx.rollback();
+            return { ran: false };
+        }
+
+        runningLocally.add(name);
+        try {
+            const result = await fn();
+            return { ran: true, result };
+        } finally {
+            runningLocally.delete(name);
+            await tx.rollback();
+        }
+    } catch (error) {
+        if (!tx.finished) {
+            await tx.rollback().catch(() => {});
+        }
+        throw error;
+    }
+}
+
+// Long-lived leadership for jobs that must not switch processes between
+// runs (the Telegram poller keeps per-bot update offsets in memory). The
+// lock is held by an open transaction for as long as the process lives.
+const leaderTransactions = new Map();
+
+async function tryBecomeLeader(name) {
+    if (leaderTransactions.has(name)) {
+        return true;
+    }
+
+    if (!isPostgres()) {
+        leaderTransactions.set(name, null);
+        return true;
+    }
+
+    const tx = await sequelize.transaction();
+    try {
+        const [[{ locked }]] = await sequelize.query(
+            'SELECT pg_try_advisory_xact_lock(:key) AS locked',
+            { replacements: { key: lockKey(name) }, transaction: tx }
+        );
+        if (!locked) {
+            await tx.rollback();
+            return false;
+        }
+        leaderTransactions.set(name, tx);
+        logInfo(`This process is now the leader for "${name}"`);
+        return true;
+    } catch (error) {
+        await tx.rollback().catch(() => {});
+        logError(`Failed to acquire leader lock for "${name}":`, error);
+        return false;
+    }
+}
+
+async function releaseLeadership(name) {
+    const tx = leaderTransactions.get(name);
+    leaderTransactions.delete(name);
+    if (tx && !tx.finished) {
+        await tx.rollback().catch(() => {});
+    }
+}
+
+function isLeader(name) {
+    return leaderTransactions.has(name);
+}
+
+module.exports = {
+    withJobLock,
+    tryBecomeLeader,
+    releaseLeadership,
+    isLeader,
+    _lockKey: lockKey,
+};

--- a/backend/tests/helpers/setup.js
+++ b/backend/tests/helpers/setup.js
@@ -44,6 +44,7 @@ const CLEANUP_TABLES = [
     'caldav_remote_calendars',
     'caldav_calendars',
     'calendar_tokens',
+    'rate_limits',
     'notifications',
     'permissions',
     // actions and the audit/identity tables reference users; on PostgreSQL

--- a/backend/tests/unit/config/hostedConfig.test.js
+++ b/backend/tests/unit/config/hostedConfig.test.js
@@ -1,0 +1,65 @@
+const { hostedConfigProblems } = require('../../../config/hostedConfig');
+
+const fullEnv = {
+    TUDUDI_SESSION_SECRET: 'x'.repeat(64),
+    TUDUDI_ALLOWED_ORIGINS: 'https://app.example.com',
+    FRONTEND_URL: 'https://app.example.com',
+    BACKEND_URL: 'https://app.example.com',
+};
+
+const fullConfig = {
+    hosted: { enabled: true },
+    trustProxy: 1,
+    emailConfig: { enabled: true, smtp: { host: 'smtp.example.com' } },
+    db: { dialect: 'postgres' },
+};
+
+describe('hostedConfigProblems', () => {
+    it('reports nothing when hosted mode is off, whatever else is set', () => {
+        expect(
+            hostedConfigProblems({}, { hosted: { enabled: false } })
+        ).toEqual([]);
+    });
+
+    it('reports nothing for a fully configured hosted instance', () => {
+        expect(hostedConfigProblems(fullEnv, fullConfig)).toEqual([]);
+    });
+
+    it('accepts BASE_URL in place of BACKEND_URL', () => {
+        const env = { ...fullEnv };
+        delete env.BACKEND_URL;
+        env.BASE_URL = 'https://app.example.com';
+        expect(hostedConfigProblems(env, fullConfig)).toEqual([]);
+    });
+
+    it('lists every missing piece of a bare instance', () => {
+        const problems = hostedConfigProblems(
+            {},
+            {
+                hosted: { enabled: true },
+                trustProxy: false,
+                emailConfig: { enabled: false, smtp: {} },
+                db: { dialect: 'sqlite' },
+            }
+        );
+
+        const text = problems.join('\n');
+        expect(text).toMatch(/TUDUDI_SESSION_SECRET/);
+        expect(text).toMatch(/TUDUDI_TRUST_PROXY/);
+        expect(text).toMatch(/TUDUDI_ALLOWED_ORIGINS/);
+        expect(text).toMatch(/FRONTEND_URL/);
+        expect(text).toMatch(/BACKEND_URL/);
+        expect(text).toMatch(/ENABLE_EMAIL/);
+        expect(text).toMatch(/PostgreSQL/);
+        expect(problems).toHaveLength(7);
+    });
+
+    it('treats localhost URLs as unset', () => {
+        const problems = hostedConfigProblems(
+            { ...fullEnv, FRONTEND_URL: 'http://localhost:8080' },
+            fullConfig
+        );
+        expect(problems).toHaveLength(1);
+        expect(problems[0]).toMatch(/FRONTEND_URL/);
+    });
+});

--- a/backend/tests/unit/middleware/rateLimitStore.test.js
+++ b/backend/tests/unit/middleware/rateLimitStore.test.js
@@ -1,0 +1,93 @@
+const { sequelize, RateLimit } = require('../../../models');
+const { isPostgres } = require('../../../utils/db-dialect');
+const {
+    DatabaseRateLimitStore,
+    createRateLimitStore,
+    cleanupExpiredRateLimits,
+} = require('../../../middleware/rateLimitStore');
+
+// The upsert uses ON CONFLICT ... RETURNING, so most of this is only
+// exercised against a real PostgreSQL (DATABASE_URL in the environment).
+const describePg = isPostgres() ? describe : describe.skip;
+const describeSqlite = isPostgres() ? describe.skip : describe;
+
+describeSqlite('createRateLimitStore on SQLite', () => {
+    it('returns undefined so express-rate-limit uses its memory store', () => {
+        expect(createRateLimitStore('unit')).toBeUndefined();
+    });
+});
+
+describePg('createRateLimitStore on PostgreSQL', () => {
+    it('returns the shared database store', () => {
+        expect(createRateLimitStore('unit')).toBeInstanceOf(
+            DatabaseRateLimitStore
+        );
+    });
+});
+
+describePg('DatabaseRateLimitStore (PostgreSQL)', () => {
+    let store;
+
+    beforeAll(async () => {
+        await sequelize.sync();
+    });
+
+    beforeEach(async () => {
+        await RateLimit.destroy({ where: {} });
+        store = new DatabaseRateLimitStore('unit');
+        store.init({ windowMs: 60 * 1000 });
+    });
+
+    it('counts hits within a window and namespaces by prefix', async () => {
+        const first = await store.increment('1.2.3.4');
+        const second = await store.increment('1.2.3.4');
+        expect(first.totalHits).toBe(1);
+        expect(second.totalHits).toBe(2);
+        expect(second.resetTime.getTime()).toBe(first.resetTime.getTime());
+
+        const other = new DatabaseRateLimitStore('other');
+        other.init({ windowMs: 60 * 1000 });
+        expect((await other.increment('1.2.3.4')).totalHits).toBe(1);
+    });
+
+    it('starts a new window once the old one has expired', async () => {
+        await store.increment('k');
+        await RateLimit.update(
+            { reset_at: new Date(Date.now() - 1000) },
+            { where: { key: 'unit:k' } }
+        );
+
+        const res = await store.increment('k');
+        expect(res.totalHits).toBe(1);
+        expect(res.resetTime.getTime()).toBeGreaterThan(Date.now());
+        expect(await store.get('k')).toMatchObject({ totalHits: 1 });
+    });
+
+    it('decrements, resets one key, and resets all keys of the prefix', async () => {
+        await store.increment('a');
+        await store.increment('a');
+        await store.decrement('a');
+        expect((await store.get('a')).totalHits).toBe(1);
+
+        await store.resetKey('a');
+        expect(await store.get('a')).toBeUndefined();
+
+        await store.increment('b');
+        await store.increment('c');
+        await store.resetAll();
+        expect(await RateLimit.count()).toBe(0);
+    });
+
+    it('sweeps expired rows', async () => {
+        await store.increment('old');
+        await store.increment('fresh');
+        await RateLimit.update(
+            { reset_at: new Date(Date.now() - 1000) },
+            { where: { key: 'unit:old' } }
+        );
+
+        const removed = await cleanupExpiredRateLimits();
+        expect(removed).toBe(1);
+        expect(await RateLimit.count()).toBe(1);
+    });
+});

--- a/backend/tests/unit/services/jobLock.test.js
+++ b/backend/tests/unit/services/jobLock.test.js
@@ -1,0 +1,80 @@
+const {
+    withJobLock,
+    tryBecomeLeader,
+    releaseLeadership,
+    isLeader,
+    _lockKey,
+} = require('../../../services/jobLock');
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('jobLock', () => {
+    it('runs the job and returns its result', async () => {
+        const res = await withJobLock('unit:simple', async () => 42);
+        expect(res).toEqual({ ran: true, result: 42 });
+    });
+
+    it('skips a job that is already running under the same name', async () => {
+        let concurrent = 0;
+        let peak = 0;
+        const job = async () => {
+            concurrent += 1;
+            peak = Math.max(peak, concurrent);
+            await sleep(50);
+            concurrent -= 1;
+            return 'done';
+        };
+
+        const [first, second] = await Promise.all([
+            withJobLock('unit:overlap', job),
+            withJobLock('unit:overlap', job),
+        ]);
+
+        expect(peak).toBe(1);
+        expect([first.ran, second.ran].sort()).toEqual([false, true]);
+    });
+
+    it('lets different job names run at the same time', async () => {
+        let concurrent = 0;
+        let peak = 0;
+        const job = async () => {
+            concurrent += 1;
+            peak = Math.max(peak, concurrent);
+            await sleep(30);
+            concurrent -= 1;
+        };
+
+        await Promise.all([
+            withJobLock('unit:a', job),
+            withJobLock('unit:b', job),
+        ]);
+        expect(peak).toBe(2);
+    });
+
+    it('releases the lock when the job throws', async () => {
+        await expect(
+            withJobLock('unit:throws', async () => {
+                throw new Error('boom');
+            })
+        ).rejects.toThrow('boom');
+
+        const again = await withJobLock('unit:throws', async () => 'ok');
+        expect(again.ran).toBe(true);
+    });
+
+    it('hands out leadership once per process and releases it', async () => {
+        expect(await tryBecomeLeader('unit:leader')).toBe(true);
+        expect(isLeader('unit:leader')).toBe(true);
+        expect(await tryBecomeLeader('unit:leader')).toBe(true);
+
+        await releaseLeadership('unit:leader');
+        expect(isLeader('unit:leader')).toBe(false);
+    });
+
+    it('derives a stable 32-bit key from the job name', () => {
+        expect(_lockKey('telegram-poller')).toBe(_lockKey('telegram-poller'));
+        expect(_lockKey('a')).not.toBe(_lockKey('b'));
+        expect(Number.isInteger(_lockKey('x'))).toBe(true);
+        expect(Math.abs(_lockKey('x'))).toBeLessThan(2 ** 31);
+    });
+});

--- a/docs/16-postgresql.md
+++ b/docs/16-postgresql.md
@@ -113,6 +113,37 @@ Uploads live on disk (`TUDUDI_UPLOAD_PATH`) and need their own backup.
 
 ---
 
+## Running More Than One Process
+
+PostgreSQL is what makes a second app process possible. tududi coordinates
+through the database so that several containers can share it safely:
+
+- **Schema and migrations.** The entrypoint runs `db-prepare` and
+  `sequelize-cli db:migrate` under a PostgreSQL advisory lock
+  (`scripts/with-db-lock.js`), so containers booting together wait for each
+  other instead of both creating the schema.
+- **Scheduled jobs.** Every tick of the task scheduler (summaries, due and
+  deferred task notifications) and of the CalDAV sync takes a per-job
+  advisory lock; whichever process gets it runs that tick, the others skip
+  it. Duplicate notifications cannot happen.
+- **Telegram polling.** Bot update offsets live in memory, so one process
+  holds a long-lived leader lock and polls; the others retry every minute
+  and take over if it goes away. Bots are polled in parallel batches
+  (`TELEGRAM_POLL_CONCURRENCY`, default 10).
+- **Rate limits.** Hit counters are kept in the `rate_limits` table instead
+  of per-process memory, so limits are the same however many processes
+  serve requests and survive restarts. Expired rows are swept nightly.
+
+Nothing needs configuring for this; it is automatic whenever the dialect is
+PostgreSQL. You can still pin the background work to one container with
+`DISABLE_SCHEDULER=true` and `DISABLE_TELEGRAM=true` on the others, which
+keeps a scheduler crash from ever affecting HTTP traffic.
+
+With `TUDUDI_HOSTED_MODE=true` the server refuses to start unless
+`TUDUDI_SESSION_SECRET`, `TUDUDI_TRUST_PROXY`, `TUDUDI_ALLOWED_ORIGINS`,
+public `FRONTEND_URL`/`BACKEND_URL`, `ENABLE_EMAIL` with an SMTP host, and a
+PostgreSQL `DATABASE_URL` are all set, and prints exactly what is missing.
+
 ## Troubleshooting
 
 | Symptom | Cause and fix |


### PR DESCRIPTION
## Description

First half of Phase 3 of the SaaS plan (follows #1472 to #1475). Removes the single-process assumptions so that a web + worker (or web + web) deployment on one PostgreSQL database is safe. Nothing changes for SQLite installs, which are single-process by definition.

- **Schema and migrations under a lock.** `scripts/with-db-lock.js` runs a command while holding a PostgreSQL advisory lock; the entrypoint uses it for `db-prepare` and `sequelize-cli db:migrate`, so two containers starting together wait for each other instead of both creating the schema.
- **Job leadership.** `services/jobLock.js`: `withJobLock(name, fn)` takes a transaction-scoped advisory lock per tick (self-releasing if the process dies), used by every task-scheduler job and the CalDAV sync. `tryBecomeLeader(name)` holds a long-lived lock for the Telegram poller, whose update offsets live in memory; non-leaders retry every minute and take over if the leader disappears. On SQLite both degrade to an in-process mutex.
- **Shared rate-limit store.** `middleware/rateLimitStore.js` implements the express-rate-limit Store on a new `rate_limits` table (one `INSERT ... ON CONFLICT ... RETURNING` per hit, window reset inside the statement). Enabled automatically on PostgreSQL; expired rows are swept by the nightly cleanup job.
- **Telegram poller.** Bots are polled in parallel batches (`TELEGRAM_POLL_CONCURRENCY`, default 10) instead of one after another per 5-second tick.
- **Hosted-mode config validation.** `config/hostedConfig.js`: with `TUDUDI_HOSTED_MODE=true` the server exits at boot with a list of what is missing (session secret, trust proxy, allowed origins, public `FRONTEND_URL`/`BACKEND_URL`, email with SMTP host, PostgreSQL).

**Bug fixed along the way:** the nightly `cleanup_tokens` job required `./registrationService` from the tasks module (it lives in `modules/auth`), so it had been throwing every night.

Docs: new "Running More Than One Process" section in `docs/16-postgresql.md`; `backend/.env.example`.

## Type of Change

- [x] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [x] Documentation/Translation update

## Testing

- New `tests/unit/services/jobLock.test.js` (overlap skipped, different names run together, lock released on throw, leadership), `tests/unit/config/hostedConfig.test.js`, `tests/unit/middleware/rateLimitStore.test.js` (upsert counting, window reset, decrement/reset, sweep; PostgreSQL-only parts skip on SQLite).
- Lock and store tests also run against a local PostgreSQL 16: 28 passed.
- `npm test`: 1896 passed. Two failures: `uploads-static` is the known parallel flake (passes alone); `recurring-tasks` "weekly completion_based" also fails on clean `main` at this hour (local time past midnight Sunday while UTC is still Saturday), so it is a pre-existing date-boundary case, not from this branch.
- `npm run backend:test:upgrade`: 64 passed (schema parity includes the new `rate_limits` table). `npm run lint`: 0 errors.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)