### PR TITLE
feat(billing): plan catalog, billing tables, and entitlements service for hosted mode

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -59,6 +59,15 @@ DISABLE_TELEGRAM=false
 # with TUDUDI_USER_EMAIL/TUDUDI_USER_PASSWORD instead), and SSO auto-provisioning
 # respects the registration toggle.
 TUDUDI_HOSTED_MODE=false
+# Hosted-mode plans (see docs/17-hosted-mode.md). Only read when the flag is true.
+# TUDUDI_TRIAL_DAYS=14
+# TUDUDI_PAST_DUE_GRACE_DAYS=14
+# TUDUDI_HOSTED_EXEMPT_ADMINS=true
+# TUDUDI_PLANS_JSON={"free":{"limits":{"max_tasks":200}}}
+# STRIPE_SECRET_KEY=sk_live_...
+# STRIPE_WEBHOOK_SECRET=whsec_...
+# STRIPE_PRICE_PRO_MONTHLY=price_...
+# STRIPE_PRICE_PRO_ANNUAL=price_...
 
 # Feature Flags
 FF_ENABLE_BACKUPS=false

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -86,6 +86,22 @@ const config = {
     // registration) are switched off. Off by default for self-hosters.
     hosted: {
         enabled: process.env.TUDUDI_HOSTED_MODE === 'true',
+        trialDays: process.env.TUDUDI_TRIAL_DAYS
+            ? parseInt(process.env.TUDUDI_TRIAL_DAYS, 10)
+            : 14,
+        graceDays: process.env.TUDUDI_PAST_DUE_GRACE_DAYS
+            ? parseInt(process.env.TUDUDI_PAST_DUE_GRACE_DAYS, 10)
+            : 14,
+        exemptAdmins: process.env.TUDUDI_HOSTED_EXEMPT_ADMINS !== 'false',
+        stripe: {
+            secretKey: process.env.STRIPE_SECRET_KEY,
+            webhookSecret: process.env.STRIPE_WEBHOOK_SECRET,
+            apiVersion: process.env.STRIPE_API_VERSION || undefined,
+            prices: {
+                proMonthly: process.env.STRIPE_PRICE_PRO_MONTHLY,
+                proAnnual: process.env.STRIPE_PRICE_PRO_ANNUAL,
+            },
+        },
     },
 
     email: process.env.TUDUDI_USER_EMAIL,

--- a/backend/config/plans.js
+++ b/backend/config/plans.js
@@ -1,0 +1,139 @@
+'use strict';
+
+// Plan catalog for hosted mode. Limits are per user; null means unlimited.
+// Feature keys gate whole capabilities. TUDUDI_PLANS_JSON (a JSON object
+// with the same shape) is deep-merged over these defaults, so an operator
+// can change a number without a code change.
+
+const DEFAULT_PLANS = {
+    free: {
+        name: 'Free',
+        limits: {
+            max_tasks: 200,
+            max_projects: 10,
+            max_notes: 50,
+            storage_mb: 50,
+            ai_requests_per_day: 0,
+        },
+        features: {
+            ai: false,
+            mcp: false,
+            caldav: false,
+            backups_import: false,
+            telegram: false,
+            attachments: true,
+        },
+    },
+    pro: {
+        name: 'Pro',
+        limits: {
+            max_tasks: null,
+            max_projects: null,
+            max_notes: null,
+            storage_mb: 5000,
+            ai_requests_per_day: 200,
+        },
+        features: {
+            ai: true,
+            mcp: true,
+            caldav: true,
+            backups_import: true,
+            telegram: true,
+            attachments: true,
+        },
+    },
+};
+
+const LIMIT_KEYS = Object.keys(DEFAULT_PLANS.free.limits);
+const FEATURE_KEYS = Object.keys(DEFAULT_PLANS.free.features);
+
+// What a self-hosted instance (hosted mode off) gets: no limits at all.
+const UNLIMITED = Object.freeze({
+    key: 'unlimited',
+    name: 'Unlimited',
+    limits: Object.freeze(
+        Object.fromEntries(LIMIT_KEYS.map((key) => [key, null]))
+    ),
+    features: Object.freeze(
+        Object.fromEntries(FEATURE_KEYS.map((key) => [key, true]))
+    ),
+});
+
+function deepMerge(base, override) {
+    if (!override || typeof override !== 'object' || Array.isArray(override)) {
+        return base;
+    }
+    const out = { ...base };
+    for (const [key, value] of Object.entries(override)) {
+        if (
+            value &&
+            typeof value === 'object' &&
+            !Array.isArray(value) &&
+            base[key] &&
+            typeof base[key] === 'object'
+        ) {
+            out[key] = deepMerge(base[key], value);
+        } else {
+            out[key] = value;
+        }
+    }
+    return out;
+}
+
+function parseOverrides(json) {
+    if (!json) return null;
+    try {
+        const parsed = JSON.parse(json);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            throw new Error('TUDUDI_PLANS_JSON must be a JSON object');
+        }
+        return parsed;
+    } catch (error) {
+        console.error(
+            `Ignoring TUDUDI_PLANS_JSON: ${error.message}. Using default plans.`
+        );
+        return null;
+    }
+}
+
+let cache = null;
+let cachedFrom;
+
+function getPlans(env = process.env) {
+    const json = env.TUDUDI_PLANS_JSON || '';
+    if (cache && cachedFrom === json) return cache;
+
+    const merged = deepMerge(DEFAULT_PLANS, parseOverrides(json));
+    const plans = {};
+    for (const [key, plan] of Object.entries(merged)) {
+        plans[key] = {
+            key,
+            name: plan.name || key,
+            limits: { ...UNLIMITED.limits, ...(plan.limits || {}) },
+            features: {
+                ...Object.fromEntries(FEATURE_KEYS.map((k) => [k, false])),
+                ...(plan.features || {}),
+            },
+        };
+    }
+    cache = plans;
+    cachedFrom = json;
+    return plans;
+}
+
+function getPlan(key, env = process.env) {
+    return getPlans(env)[key] || null;
+}
+
+module.exports = {
+    DEFAULT_PLANS,
+    UNLIMITED,
+    LIMIT_KEYS,
+    FEATURE_KEYS,
+    getPlans,
+    getPlan,
+    _resetCache: () => {
+        cache = null;
+        cachedFrom = undefined;
+    },
+};

--- a/backend/middleware/entitlements.js
+++ b/backend/middleware/entitlements.js
@@ -1,0 +1,43 @@
+const entitlements = require('../services/entitlementsService');
+const { getAuthenticatedUserId } = require('../utils/request-utils');
+
+// Route-level guards for hosted mode. Each one is a no-op when hosted mode
+// is off (the service returns before any query), so self-hosted installs
+// carry no cost.
+
+const requireFeature = (feature) => async (req, res, next) => {
+    try {
+        await entitlements.assertFeature(getAuthenticatedUserId(req), feature);
+        next();
+    } catch (error) {
+        next(error);
+    }
+};
+
+const requireQuota =
+    (resource, countFromReq = () => 1) =>
+    async (req, res, next) => {
+        try {
+            const n = Math.max(1, Number(countFromReq(req)) || 1);
+            await entitlements.assertCanCreate(
+                getAuthenticatedUserId(req),
+                resource,
+                n
+            );
+            next();
+        } catch (error) {
+            next(error);
+        }
+    };
+
+const requireStorage = (bytesFromReq) => async (req, res, next) => {
+    try {
+        const bytes = Number(bytesFromReq(req)) || 0;
+        await entitlements.assertStorage(getAuthenticatedUserId(req), bytes);
+        next();
+    } catch (error) {
+        next(error);
+    }
+};
+
+module.exports = { requireFeature, requireQuota, requireStorage };

--- a/backend/migrations/20260907000004-create-billing-accounts.js
+++ b/backend/migrations/20260907000004-create-billing-accounts.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const { safeCreateTable, safeAddIndex } = require('../utils/migration-utils');
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await safeCreateTable(queryInterface, 'billing_accounts', {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            user_id: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                unique: true,
+                references: { model: 'users', key: 'id' },
+                onUpdate: 'CASCADE',
+                onDelete: 'CASCADE',
+            },
+            stripe_customer_id: {
+                type: Sequelize.STRING(64),
+                allowNull: true,
+                unique: true,
+            },
+            stripe_subscription_id: {
+                type: Sequelize.STRING(64),
+                allowNull: true,
+                unique: true,
+            },
+            plan: {
+                type: Sequelize.STRING(32),
+                allowNull: false,
+                defaultValue: 'free',
+            },
+            status: {
+                type: Sequelize.STRING(32),
+                allowNull: false,
+                defaultValue: 'none',
+            },
+            price_id: { type: Sequelize.STRING(64), allowNull: true },
+            billing_interval: { type: Sequelize.STRING(16), allowNull: true },
+            current_period_start: { type: Sequelize.DATE, allowNull: true },
+            current_period_end: { type: Sequelize.DATE, allowNull: true },
+            trial_ends_at: { type: Sequelize.DATE, allowNull: true },
+            cancel_at_period_end: {
+                type: Sequelize.BOOLEAN,
+                allowNull: false,
+                defaultValue: false,
+            },
+            canceled_at: { type: Sequelize.DATE, allowNull: true },
+            last_payment_failed_at: { type: Sequelize.DATE, allowNull: true },
+            override_plan: { type: Sequelize.STRING(32), allowNull: true },
+            override_expires_at: { type: Sequelize.DATE, allowNull: true },
+            override_reason: { type: Sequelize.STRING(255), allowNull: true },
+            override_by_user_id: { type: Sequelize.INTEGER, allowNull: true },
+            last_stripe_event_created: {
+                type: Sequelize.INTEGER,
+                allowNull: true,
+            },
+            created_at: { type: Sequelize.DATE, allowNull: false },
+            updated_at: { type: Sequelize.DATE, allowNull: false },
+        });
+
+        await safeAddIndex(queryInterface, 'billing_accounts', ['status'], {
+            name: 'billing_accounts_status',
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable('billing_accounts');
+    },
+};

--- a/backend/migrations/20260907000005-create-billing-events.js
+++ b/backend/migrations/20260907000005-create-billing-events.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { safeCreateTable, safeAddIndex } = require('../utils/migration-utils');
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await safeCreateTable(queryInterface, 'billing_events', {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            stripe_event_id: {
+                type: Sequelize.STRING(64),
+                allowNull: false,
+                unique: true,
+            },
+            type: { type: Sequelize.STRING(64), allowNull: false },
+            status: {
+                type: Sequelize.STRING(16),
+                allowNull: false,
+                defaultValue: 'received',
+            },
+            user_id: { type: Sequelize.INTEGER, allowNull: true },
+            error: { type: Sequelize.TEXT, allowNull: true },
+            processed_at: { type: Sequelize.DATE, allowNull: true },
+            created_at: { type: Sequelize.DATE, allowNull: false },
+            updated_at: { type: Sequelize.DATE, allowNull: false },
+        });
+
+        await safeAddIndex(queryInterface, 'billing_events', ['type'], {
+            name: 'billing_events_type',
+        });
+        await safeAddIndex(queryInterface, 'billing_events', ['created_at'], {
+            name: 'billing_events_created_at',
+        });
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable('billing_events');
+    },
+};

--- a/backend/migrations/20260907000006-create-usage-counters.js
+++ b/backend/migrations/20260907000006-create-usage-counters.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const { safeCreateTable } = require('../utils/migration-utils');
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await safeCreateTable(queryInterface, 'usage_counters', {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            user_id: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                references: { model: 'users', key: 'id' },
+                onUpdate: 'CASCADE',
+                onDelete: 'CASCADE',
+            },
+            metric: { type: Sequelize.STRING(32), allowNull: false },
+            period_key: { type: Sequelize.STRING(16), allowNull: false },
+            count: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                defaultValue: 0,
+            },
+            created_at: { type: Sequelize.DATE, allowNull: false },
+            updated_at: { type: Sequelize.DATE, allowNull: false },
+        });
+
+        // Composite unique index: safeAddIndex skips composites when any
+        // column already has an index, so it is added directly.
+        const indexes = await queryInterface.showIndex('usage_counters');
+        if (
+            !indexes.some((i) => i.name === 'usage_counters_user_metric_period')
+        ) {
+            await queryInterface.addIndex(
+                'usage_counters',
+                ['user_id', 'metric', 'period_key'],
+                { unique: true, name: 'usage_counters_user_metric_period' }
+            );
+        }
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable('usage_counters');
+    },
+};

--- a/backend/models/billing_account.js
+++ b/backend/models/billing_account.js
@@ -1,0 +1,118 @@
+const { DataTypes } = require('sequelize');
+
+// One row per user in hosted mode, created lazily on first entitlement
+// lookup. Everything Stripe tells us about the subscription lands here;
+// override_* is the admin's way to comp or restrict an account.
+const STATUSES = [
+    'none',
+    'trialing',
+    'active',
+    'past_due',
+    'canceled',
+    'unpaid',
+    'incomplete',
+    'incomplete_expired',
+    'paused',
+];
+
+module.exports = (sequelize) => {
+    const BillingAccount = sequelize.define(
+        'BillingAccount',
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            user_id: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                unique: true,
+                references: { model: 'users', key: 'id' },
+                onDelete: 'CASCADE',
+            },
+            stripe_customer_id: {
+                type: DataTypes.STRING(64),
+                allowNull: true,
+                unique: true,
+            },
+            stripe_subscription_id: {
+                type: DataTypes.STRING(64),
+                allowNull: true,
+                unique: true,
+            },
+            plan: {
+                type: DataTypes.STRING(32),
+                allowNull: false,
+                defaultValue: 'free',
+            },
+            status: {
+                type: DataTypes.STRING(32),
+                allowNull: false,
+                defaultValue: 'none',
+                validate: { isIn: [STATUSES] },
+            },
+            price_id: {
+                type: DataTypes.STRING(64),
+                allowNull: true,
+            },
+            billing_interval: {
+                type: DataTypes.STRING(16),
+                allowNull: true,
+            },
+            current_period_start: {
+                type: DataTypes.DATE,
+                allowNull: true,
+            },
+            current_period_end: {
+                type: DataTypes.DATE,
+                allowNull: true,
+            },
+            trial_ends_at: {
+                type: DataTypes.DATE,
+                allowNull: true,
+            },
+            cancel_at_period_end: {
+                type: DataTypes.BOOLEAN,
+                allowNull: false,
+                defaultValue: false,
+            },
+            canceled_at: {
+                type: DataTypes.DATE,
+                allowNull: true,
+            },
+            last_payment_failed_at: {
+                type: DataTypes.DATE,
+                allowNull: true,
+            },
+            override_plan: {
+                type: DataTypes.STRING(32),
+                allowNull: true,
+            },
+            override_expires_at: {
+                type: DataTypes.DATE,
+                allowNull: true,
+            },
+            override_reason: {
+                type: DataTypes.STRING(255),
+                allowNull: true,
+            },
+            override_by_user_id: {
+                type: DataTypes.INTEGER,
+                allowNull: true,
+            },
+            last_stripe_event_created: {
+                type: DataTypes.INTEGER,
+                allowNull: true,
+            },
+        },
+        {
+            tableName: 'billing_accounts',
+            indexes: [{ fields: ['status'] }],
+        }
+    );
+
+    BillingAccount.STATUSES = STATUSES;
+
+    return BillingAccount;
+};

--- a/backend/models/billing_event.js
+++ b/backend/models/billing_event.js
@@ -1,0 +1,51 @@
+const { DataTypes } = require('sequelize');
+
+// Every Stripe webhook event we have seen, keyed by Stripe's event id, so
+// a redelivered event is recognised and applied once.
+module.exports = (sequelize) => {
+    const BillingEvent = sequelize.define(
+        'BillingEvent',
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            stripe_event_id: {
+                type: DataTypes.STRING(64),
+                allowNull: false,
+                unique: true,
+            },
+            type: {
+                type: DataTypes.STRING(64),
+                allowNull: false,
+            },
+            status: {
+                type: DataTypes.STRING(16),
+                allowNull: false,
+                defaultValue: 'received',
+                validate: {
+                    isIn: [['received', 'processed', 'skipped', 'failed']],
+                },
+            },
+            user_id: {
+                type: DataTypes.INTEGER,
+                allowNull: true,
+            },
+            error: {
+                type: DataTypes.TEXT,
+                allowNull: true,
+            },
+            processed_at: {
+                type: DataTypes.DATE,
+                allowNull: true,
+            },
+        },
+        {
+            tableName: 'billing_events',
+            indexes: [{ fields: ['type'] }, { fields: ['created_at'] }],
+        }
+    );
+
+    return BillingEvent;
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -85,6 +85,14 @@ const Goal = require('./goal')(sequelize);
 const Person = require('./person')(sequelize);
 const UserProjectArea = require('./user_project_area')(sequelize);
 const RateLimit = require('./rate_limit')(sequelize);
+const BillingAccount = require('./billing_account')(sequelize);
+const BillingEvent = require('./billing_event')(sequelize);
+const UsageCounter = require('./usage_counter')(sequelize);
+
+User.hasOne(BillingAccount, { foreignKey: 'user_id', as: 'BillingAccount' });
+BillingAccount.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
+User.hasMany(UsageCounter, { foreignKey: 'user_id', as: 'UsageCounters' });
+UsageCounter.belongsTo(User, { foreignKey: 'user_id', as: 'User' });
 
 User.hasMany(Area, { foreignKey: 'user_id' });
 Area.belongsTo(User, { foreignKey: 'user_id' });
@@ -477,4 +485,7 @@ module.exports = {
     Person,
     UserProjectArea,
     RateLimit,
+    BillingAccount,
+    BillingEvent,
+    UsageCounter,
 };

--- a/backend/models/usage_counter.js
+++ b/backend/models/usage_counter.js
@@ -1,0 +1,48 @@
+const { DataTypes } = require('sequelize');
+
+// Counters for rate-type limits (AI requests per day). Stock limits such
+// as task counts are counted live; only metrics with no row to count need
+// a counter.
+module.exports = (sequelize) => {
+    const UsageCounter = sequelize.define(
+        'UsageCounter',
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            user_id: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                references: { model: 'users', key: 'id' },
+                onDelete: 'CASCADE',
+            },
+            metric: {
+                type: DataTypes.STRING(32),
+                allowNull: false,
+            },
+            period_key: {
+                type: DataTypes.STRING(16),
+                allowNull: false,
+            },
+            count: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                defaultValue: 0,
+            },
+        },
+        {
+            tableName: 'usage_counters',
+            indexes: [
+                {
+                    unique: true,
+                    fields: ['user_id', 'metric', 'period_key'],
+                    name: 'usage_counters_user_metric_period',
+                },
+            ],
+        }
+    );
+
+    return UsageCounter;
+};

--- a/backend/modules/feature-flags/service.js
+++ b/backend/modules/feature-flags/service.js
@@ -11,10 +11,14 @@ class FeatureFlagsService {
      * Get all feature flags.
      */
     getAll() {
+        const { getConfig } = require('../../config/config');
+        const hosted = getConfig().hosted || {};
         return {
             backups: process.env.FF_ENABLE_BACKUPS === 'true',
             caldav: isCalDAVEnabled(),
             mcp: process.env.FF_ENABLE_MCP === 'true',
+            hosted: hosted.enabled === true,
+            billing: hosted.enabled === true && !!hosted.stripe?.secretKey,
         };
     }
 }

--- a/backend/services/accountErasureService.js
+++ b/backend/services/accountErasureService.js
@@ -30,6 +30,8 @@ const {
     CalendarToken,
     Person,
     UserProjectArea,
+    BillingAccount,
+    UsageCounter,
 } = require('../models');
 const { getConfig } = require('../config/config');
 const { getBackupsDirectory } = require('./backupService');
@@ -151,6 +153,8 @@ async function eraseUserAccount(userId) {
         await Backup.destroy(byUser);
         await OIDCIdentity.destroy(byUser);
         await AuthAuditLog.destroy(byUser);
+        await UsageCounter.destroy(byUser);
+        await BillingAccount.destroy(byUser);
 
         // Other people's contact cards that pointed at this account keep
         // their own data but lose the link.

--- a/backend/services/entitlementsService.js
+++ b/backend/services/entitlementsService.js
@@ -1,0 +1,309 @@
+const { Op } = require('sequelize');
+const { getConfig } = require('../config/config');
+const { getPlans, UNLIMITED } = require('../config/plans');
+const { isAdmin } = require('./rolesService');
+const { PlanLimitError, FeatureNotInPlanError } = require('../shared/errors');
+
+// What a user may do right now, derived from their billing account and the
+// plan catalog. With hosted mode off every function answers "unlimited"
+// before touching the database, so self-hosted installs pay nothing for
+// these checks.
+
+const CACHE_TTL_MS = 30 * 1000;
+const cache = new Map();
+
+const ACTIVE_TASK_STATUSES_EXCLUDED = [2, 3, 5]; // done, archived, cancelled
+
+const RESOURCE_LIMIT = {
+    task: 'max_tasks',
+    project: 'max_projects',
+    note: 'max_notes',
+};
+
+function isHostedMode() {
+    return getConfig().hosted?.enabled === true;
+}
+
+function models() {
+    return require('../models');
+}
+
+// Pure: which plan applies, and why. `account` may be null (no row yet).
+function resolvePlan(
+    account,
+    user,
+    { isAdmin: admin = false, now = new Date() } = {}
+) {
+    const config = getConfig();
+    if (!config.hosted?.enabled) {
+        return { plan: UNLIMITED, reason: 'hosted_off', status: 'none' };
+    }
+
+    const plans = getPlans();
+    const pro = plans.pro;
+    const free = plans.free;
+    const status = account?.status || 'none';
+    const graceMs = (config.hosted.graceDays || 0) * 24 * 60 * 60 * 1000;
+
+    if (admin && config.hosted.exemptAdmins !== false) {
+        return { plan: pro, reason: 'admin', status };
+    }
+
+    if (account?.override_plan) {
+        const expires = account.override_expires_at
+            ? new Date(account.override_expires_at)
+            : null;
+        if (!expires || expires > now) {
+            const overridden = plans[account.override_plan] || pro;
+            return { plan: overridden, reason: 'override', status };
+        }
+    }
+
+    if (status === 'active' || status === 'trialing') {
+        return {
+            plan: plans[account.plan] || pro,
+            reason: 'subscription',
+            status,
+        };
+    }
+
+    if (status === 'past_due' && account?.current_period_end) {
+        const graceUntil = new Date(
+            new Date(account.current_period_end).getTime() + graceMs
+        );
+        if (graceUntil > now) {
+            return {
+                plan: plans[account.plan] || pro,
+                reason: 'grace',
+                status,
+                graceUntil,
+            };
+        }
+    }
+
+    const trialEnd = account?.trial_ends_at
+        ? new Date(account.trial_ends_at)
+        : null;
+    if (trialEnd && trialEnd > now) {
+        return { plan: pro, reason: 'trial', status, trialEndsAt: trialEnd };
+    }
+
+    return { plan: free, reason: 'free', status };
+}
+
+async function ensureAccount(userId) {
+    const { BillingAccount, User } = models();
+    const existing = await BillingAccount.findOne({
+        where: { user_id: userId },
+    });
+    if (existing) return existing;
+
+    const user = await User.findByPk(userId, {
+        attributes: ['id', 'created_at'],
+    });
+    if (!user) return null;
+
+    const trialDays = getConfig().hosted.trialDays || 0;
+    const createdAt = user.created_at ? new Date(user.created_at) : new Date();
+    const trialEndsAt =
+        trialDays > 0
+            ? new Date(createdAt.getTime() + trialDays * 24 * 60 * 60 * 1000)
+            : null;
+
+    const [account] = await BillingAccount.findOrCreate({
+        where: { user_id: userId },
+        defaults: { user_id: userId, trial_ends_at: trialEndsAt },
+    });
+    return account;
+}
+
+async function getEntitlements(userId, { includeUsage = false } = {}) {
+    if (!isHostedMode()) {
+        return {
+            hosted: false,
+            plan: UNLIMITED.key,
+            planName: UNLIMITED.name,
+            status: 'none',
+            reason: 'hosted_off',
+            limits: UNLIMITED.limits,
+            features: UNLIMITED.features,
+            usage: includeUsage ? await getUsage(userId) : undefined,
+        };
+    }
+
+    const cached = cache.get(userId);
+    let resolved = cached && cached.expires > Date.now() ? cached.value : null;
+
+    if (!resolved) {
+        const account = await ensureAccount(userId);
+        const admin = await isAdmin(userId);
+        const r = resolvePlan(account, null, { isAdmin: admin });
+        resolved = {
+            hosted: true,
+            plan: r.plan.key,
+            planName: r.plan.name,
+            status: r.status,
+            reason: r.reason,
+            limits: r.plan.limits,
+            features: r.plan.features,
+            trial_ends_at: account?.trial_ends_at || null,
+            current_period_end: account?.current_period_end || null,
+            cancel_at_period_end: account?.cancel_at_period_end || false,
+            grace_until: r.graceUntil || null,
+            override: account?.override_plan
+                ? {
+                      plan: account.override_plan,
+                      expires_at: account.override_expires_at,
+                      reason: account.override_reason,
+                  }
+                : null,
+        };
+        cache.set(userId, {
+            value: resolved,
+            expires: Date.now() + CACHE_TTL_MS,
+        });
+    }
+
+    return includeUsage
+        ? { ...resolved, usage: await getUsage(userId) }
+        : resolved;
+}
+
+function invalidate(userId) {
+    if (userId === undefined) cache.clear();
+    else cache.delete(userId);
+}
+
+async function hasFeature(userId, feature) {
+    if (!isHostedMode()) return true;
+    const ent = await getEntitlements(userId);
+    return ent.features[feature] !== false;
+}
+
+async function assertFeature(userId, feature) {
+    if (!isHostedMode()) return;
+    const ent = await getEntitlements(userId);
+    if (ent.features[feature] === false) {
+        throw new FeatureNotInPlanError(feature, ent.plan);
+    }
+}
+
+async function countResource(userId, resource) {
+    const { Task, Project, Note } = models();
+    if (resource === 'task') {
+        return Task.count({
+            where: {
+                user_id: userId,
+                status: { [Op.notIn]: ACTIVE_TASK_STATUSES_EXCLUDED },
+            },
+        });
+    }
+    if (resource === 'project') {
+        return Project.count({ where: { user_id: userId } });
+    }
+    if (resource === 'note') {
+        return Note.count({ where: { user_id: userId } });
+    }
+    throw new Error(`Unknown resource: ${resource}`);
+}
+
+// Throws when creating `n` more of `resource` would exceed the plan.
+async function assertCanCreate(userId, resource, n = 1) {
+    if (!isHostedMode()) return;
+    const ent = await getEntitlements(userId);
+    const limit = ent.limits[RESOURCE_LIMIT[resource]];
+    if (limit === null || limit === undefined) return;
+
+    const current = await countResource(userId, resource);
+    if (current + n > limit) {
+        throw new PlanLimitError(resource, limit, current, ent.plan);
+    }
+}
+
+async function storageBytesUsed(userId) {
+    const { TaskAttachment } = models();
+    const total = await TaskAttachment.sum('file_size', {
+        where: { user_id: userId },
+    });
+    return Number(total) || 0;
+}
+
+async function assertStorage(userId, additionalBytes) {
+    if (!isHostedMode()) return;
+    const ent = await getEntitlements(userId);
+    const limitMb = ent.limits.storage_mb;
+    if (limitMb === null || limitMb === undefined) return;
+
+    const used = await storageBytesUsed(userId);
+    const limitBytes = limitMb * 1024 * 1024;
+    if (used + additionalBytes > limitBytes) {
+        throw new PlanLimitError('storage', limitBytes, used, ent.plan);
+    }
+}
+
+function todayKey(now = new Date()) {
+    return now.toISOString().slice(0, 10);
+}
+
+// Atomically records one use of a per-day metric and throws when the
+// day's budget is exhausted. Returns the new count.
+async function consumeUsage(userId, metric, n = 1) {
+    if (!isHostedMode()) return 0;
+    const ent = await getEntitlements(userId);
+    const limitKey = `${metric}_per_day`;
+    const limit = ent.limits[limitKey];
+
+    const { UsageCounter } = models();
+    const period = todayKey();
+    const [row] = await UsageCounter.findOrCreate({
+        where: { user_id: userId, metric, period_key: period },
+        defaults: { user_id: userId, metric, period_key: period, count: 0 },
+    });
+
+    if (limit !== null && limit !== undefined && row.count + n > limit) {
+        throw new PlanLimitError(metric, limit, row.count, ent.plan);
+    }
+
+    await row.increment('count', { by: n });
+    return row.count + n;
+}
+
+async function getUsage(userId) {
+    const { UsageCounter } = models();
+    const [tasks, projects, notes, storage_bytes, ai] = await Promise.all([
+        countResource(userId, 'task'),
+        countResource(userId, 'project'),
+        countResource(userId, 'note'),
+        storageBytesUsed(userId),
+        UsageCounter.findOne({
+            where: {
+                user_id: userId,
+                metric: 'ai_requests',
+                period_key: todayKey(),
+            },
+            attributes: ['count'],
+            raw: true,
+        }),
+    ]);
+    return {
+        tasks,
+        projects,
+        notes,
+        storage_bytes,
+        ai_requests_today: ai ? ai.count : 0,
+    };
+}
+
+module.exports = {
+    isHostedMode,
+    resolvePlan,
+    ensureAccount,
+    getEntitlements,
+    invalidate,
+    hasFeature,
+    assertFeature,
+    assertCanCreate,
+    assertStorage,
+    consumeUsage,
+    getUsage,
+};

--- a/backend/shared/errors/index.js
+++ b/backend/shared/errors/index.js
@@ -32,6 +32,44 @@ class ForbiddenError extends AppError {
     }
 }
 
+// 402: the action is fine, the plan is not. `details` lets the client show
+// which limit was hit and what the current plan is.
+class PlanLimitError extends AppError {
+    constructor(resource, limit, current, plan) {
+        super(
+            `Your ${plan} plan allows ${limit} ${resource === 'storage' ? 'bytes of storage' : resource + 's'}`,
+            402,
+            'PLAN_LIMIT_REACHED'
+        );
+        this.details = { resource, limit, current, plan };
+    }
+
+    toJSON() {
+        return { ...super.toJSON(), details: this.details };
+    }
+}
+
+class FeatureNotInPlanError extends AppError {
+    constructor(feature, plan) {
+        super(
+            `The ${feature} feature is not included in your ${plan} plan`,
+            402,
+            'FEATURE_NOT_IN_PLAN'
+        );
+        this.details = { feature, plan };
+    }
+
+    toJSON() {
+        return { ...super.toJSON(), details: this.details };
+    }
+}
+
+class BillingNotConfiguredError extends AppError {
+    constructor(message = 'Billing is not configured on this instance') {
+        super(message, 503, 'BILLING_NOT_CONFIGURED');
+    }
+}
+
 class ServiceUnavailableError extends AppError {
     constructor(message = 'Service temporarily unavailable') {
         super(message, 503, 'SERVICE_UNAVAILABLE');
@@ -46,4 +84,7 @@ module.exports = {
     UnauthorizedError,
     ForbiddenError,
     ServiceUnavailableError,
+    PlanLimitError,
+    FeatureNotInPlanError,
+    BillingNotConfiguredError,
 };

--- a/backend/tests/helpers/setup.js
+++ b/backend/tests/helpers/setup.js
@@ -45,6 +45,9 @@ const CLEANUP_TABLES = [
     'caldav_calendars',
     'calendar_tokens',
     'rate_limits',
+    'usage_counters',
+    'billing_events',
+    'billing_accounts',
     'notifications',
     'permissions',
     // actions and the audit/identity tables reference users; on PostgreSQL

--- a/backend/tests/integration/entitlements.test.js
+++ b/backend/tests/integration/entitlements.test.js
@@ -1,0 +1,205 @@
+const { getConfig } = require('../../config/config');
+const plans = require('../../config/plans');
+const {
+    Task,
+    Project,
+    Note,
+    Role,
+    BillingAccount,
+    UsageCounter,
+} = require('../../models');
+const entitlements = require('../../services/entitlementsService');
+const { createTestUser } = require('../helpers/testUtils');
+
+const config = getConfig();
+
+describe('entitlementsService with hosted mode off', () => {
+    it('answers unlimited without creating a billing row', async () => {
+        const user = await createTestUser({
+            email: `off_${Date.now()}@example.com`,
+        });
+
+        const ent = await entitlements.getEntitlements(user.id);
+        expect(ent.hosted).toBe(false);
+        expect(ent.limits.max_tasks).toBeNull();
+        expect(ent.features.mcp).toBe(true);
+        expect(await BillingAccount.count()).toBe(0);
+
+        await expect(
+            entitlements.assertCanCreate(user.id, 'task', 10000)
+        ).resolves.toBeUndefined();
+        await expect(
+            entitlements.assertFeature(user.id, 'ai')
+        ).resolves.toBeUndefined();
+        expect(await entitlements.consumeUsage(user.id, 'ai_requests')).toBe(0);
+        expect(await UsageCounter.count()).toBe(0);
+    });
+});
+
+describe('entitlementsService with hosted mode on', () => {
+    let user;
+
+    beforeEach(async () => {
+        config.hosted.enabled = true;
+        config.hosted.trialDays = 0;
+        process.env.TUDUDI_PLANS_JSON = JSON.stringify({
+            free: {
+                limits: {
+                    max_tasks: 2,
+                    max_projects: 1,
+                    max_notes: 1,
+                    storage_mb: 1,
+                    ai_requests_per_day: 2,
+                },
+            },
+        });
+        plans._resetCache();
+        entitlements.invalidate();
+
+        // The first user on an empty instance would be admin (and exempt)
+        // on a self-hosted install; hosted mode never promotes implicitly.
+        user = await createTestUser({
+            email: `on_${Date.now()}@example.com`,
+        });
+        const role = await Role.findOne({ where: { user_id: user.id } });
+        if (role.is_admin) {
+            throw new Error('hosted mode must not promote the first user');
+        }
+    });
+
+    afterEach(() => {
+        config.hosted.enabled = false;
+        config.hosted.trialDays = 14;
+        delete process.env.TUDUDI_PLANS_JSON;
+        plans._resetCache();
+        entitlements.invalidate();
+    });
+
+    it('creates the billing row lazily and reports the free plan', async () => {
+        const ent = await entitlements.getEntitlements(user.id, {
+            includeUsage: true,
+        });
+        expect(ent.hosted).toBe(true);
+        expect(ent.plan).toBe('free');
+        expect(ent.limits.max_tasks).toBe(2);
+        expect(ent.usage).toEqual({
+            tasks: 0,
+            projects: 0,
+            notes: 0,
+            storage_bytes: 0,
+            ai_requests_today: 0,
+        });
+        expect(
+            await BillingAccount.count({ where: { user_id: user.id } })
+        ).toBe(1);
+    });
+
+    it('starts a trial from the account creation date when configured', async () => {
+        config.hosted.trialDays = 14;
+        const ent = await entitlements.getEntitlements(user.id);
+        expect(ent.plan).toBe('pro');
+        expect(ent.reason).toBe('trial');
+        expect(new Date(ent.trial_ends_at).getTime()).toBeGreaterThan(
+            Date.now()
+        );
+    });
+
+    it('stops task creation at the limit, counting only active tasks', async () => {
+        await Task.create({ name: 'a', user_id: user.id });
+        await Task.create({
+            name: 'b',
+            user_id: user.id,
+            status: Task.STATUS.DONE,
+        });
+        await expect(
+            entitlements.assertCanCreate(user.id, 'task')
+        ).resolves.toBeUndefined();
+
+        await Task.create({ name: 'c', user_id: user.id });
+        await expect(
+            entitlements.assertCanCreate(user.id, 'task')
+        ).rejects.toMatchObject({
+            statusCode: 402,
+            code: 'PLAN_LIMIT_REACHED',
+            details: { resource: 'task', limit: 2, current: 2, plan: 'free' },
+        });
+        await expect(
+            entitlements.assertCanCreate(user.id, 'task', 3)
+        ).rejects.toThrow();
+    });
+
+    it('limits projects and notes the same way', async () => {
+        await Project.create({ name: 'p', user_id: user.id });
+        await expect(
+            entitlements.assertCanCreate(user.id, 'project')
+        ).rejects.toMatchObject({ code: 'PLAN_LIMIT_REACHED' });
+
+        await Note.create({ title: 'n', content: 'c', user_id: user.id });
+        await expect(
+            entitlements.assertCanCreate(user.id, 'note')
+        ).rejects.toMatchObject({ code: 'PLAN_LIMIT_REACHED' });
+    });
+
+    it('enforces the storage quota', async () => {
+        await expect(
+            entitlements.assertStorage(user.id, 512 * 1024)
+        ).resolves.toBeUndefined();
+        await expect(
+            entitlements.assertStorage(user.id, 2 * 1024 * 1024)
+        ).rejects.toMatchObject({
+            code: 'PLAN_LIMIT_REACHED',
+            details: { resource: 'storage', plan: 'free' },
+        });
+    });
+
+    it('gates features and counts daily AI usage', async () => {
+        await expect(
+            entitlements.assertFeature(user.id, 'mcp')
+        ).rejects.toMatchObject({
+            statusCode: 402,
+            code: 'FEATURE_NOT_IN_PLAN',
+            details: { feature: 'mcp', plan: 'free' },
+        });
+        expect(await entitlements.hasFeature(user.id, 'attachments')).toBe(
+            true
+        );
+
+        expect(await entitlements.consumeUsage(user.id, 'ai_requests')).toBe(1);
+        expect(await entitlements.consumeUsage(user.id, 'ai_requests')).toBe(2);
+        await expect(
+            entitlements.consumeUsage(user.id, 'ai_requests')
+        ).rejects.toMatchObject({ code: 'PLAN_LIMIT_REACHED' });
+
+        const usage = await entitlements.getUsage(user.id);
+        expect(usage.ai_requests_today).toBe(2);
+    });
+
+    it('lifts limits through an admin override and drops the cache', async () => {
+        await Task.create({ name: 'a', user_id: user.id });
+        await Task.create({ name: 'b', user_id: user.id });
+        await expect(
+            entitlements.assertCanCreate(user.id, 'task')
+        ).rejects.toThrow();
+
+        await BillingAccount.update(
+            { override_plan: 'pro', override_reason: 'friend' },
+            { where: { user_id: user.id } }
+        );
+        entitlements.invalidate(user.id);
+
+        await expect(
+            entitlements.assertCanCreate(user.id, 'task')
+        ).resolves.toBeUndefined();
+        const ent = await entitlements.getEntitlements(user.id);
+        expect(ent.reason).toBe('override');
+        expect(ent.override.reason).toBe('friend');
+    });
+
+    it('exempts admins', async () => {
+        await Role.update({ is_admin: true }, { where: { user_id: user.id } });
+        entitlements.invalidate(user.id);
+        const ent = await entitlements.getEntitlements(user.id);
+        expect(ent.plan).toBe('pro');
+        expect(ent.reason).toBe('admin');
+    });
+});

--- a/backend/tests/unit/services/entitlementsService.test.js
+++ b/backend/tests/unit/services/entitlementsService.test.js
@@ -1,0 +1,161 @@
+const { getConfig } = require('../../../config/config');
+const plans = require('../../../config/plans');
+const { resolvePlan } = require('../../../services/entitlementsService');
+
+const config = getConfig();
+const DAY = 24 * 60 * 60 * 1000;
+const now = new Date('2026-09-06T12:00:00Z');
+const inDays = (d) => new Date(now.getTime() + d * DAY);
+
+describe('plans catalog', () => {
+    afterEach(() => {
+        delete process.env.TUDUDI_PLANS_JSON;
+        plans._resetCache();
+    });
+
+    it('ships a free and a pro plan with every limit and feature key', () => {
+        const all = plans.getPlans();
+        expect(Object.keys(all)).toEqual(['free', 'pro']);
+        for (const key of plans.LIMIT_KEYS) {
+            expect(all.free.limits).toHaveProperty(key);
+            expect(all.pro.limits).toHaveProperty(key);
+        }
+        for (const key of plans.FEATURE_KEYS) {
+            expect(typeof all.free.features[key]).toBe('boolean');
+        }
+        expect(all.pro.limits.max_tasks).toBeNull();
+    });
+
+    it('deep-merges TUDUDI_PLANS_JSON over the defaults', () => {
+        process.env.TUDUDI_PLANS_JSON = JSON.stringify({
+            free: { limits: { max_tasks: 5 }, features: { ai: true } },
+            team: { name: 'Team', limits: { max_tasks: 9000 } },
+        });
+        plans._resetCache();
+
+        const all = plans.getPlans();
+        expect(all.free.limits.max_tasks).toBe(5);
+        expect(all.free.limits.max_projects).toBe(10);
+        expect(all.free.features.ai).toBe(true);
+        expect(all.free.features.mcp).toBe(false);
+        expect(all.team.name).toBe('Team');
+        expect(all.team.limits.max_projects).toBeNull();
+    });
+
+    it('falls back to the defaults on invalid JSON', () => {
+        process.env.TUDUDI_PLANS_JSON = '{not json';
+        plans._resetCache();
+        expect(plans.getPlans().free.limits.max_tasks).toBe(200);
+    });
+});
+
+describe('resolvePlan', () => {
+    beforeEach(() => {
+        config.hosted.enabled = true;
+        config.hosted.graceDays = 14;
+        config.hosted.exemptAdmins = true;
+        plans._resetCache();
+    });
+
+    afterEach(() => {
+        config.hosted.enabled = false;
+    });
+
+    const resolve = (account, opts = {}) =>
+        resolvePlan(account, null, { now, ...opts });
+
+    it('is unlimited when hosted mode is off, whatever the account says', () => {
+        config.hosted.enabled = false;
+        const r = resolve({ status: 'canceled' });
+        expect(r.plan.key).toBe('unlimited');
+        expect(r.reason).toBe('hosted_off');
+    });
+
+    it('gives a user with no account row the free plan', () => {
+        const r = resolve(null);
+        expect(r.plan.key).toBe('free');
+        expect(r.reason).toBe('free');
+    });
+
+    it('treats a running local trial as pro and an expired one as free', () => {
+        expect(
+            resolve({ status: 'none', trial_ends_at: inDays(3) })
+        ).toMatchObject({
+            reason: 'trial',
+        });
+        expect(
+            resolve({ status: 'none', trial_ends_at: inDays(-1) })
+        ).toMatchObject({
+            reason: 'free',
+        });
+    });
+
+    it('honours active and trialing subscriptions', () => {
+        expect(resolve({ status: 'active', plan: 'pro' }).plan.key).toBe('pro');
+        expect(resolve({ status: 'trialing', plan: 'pro' }).reason).toBe(
+            'subscription'
+        );
+    });
+
+    it('keeps pro during the past_due grace window, then drops to free', () => {
+        const inside = resolve({
+            status: 'past_due',
+            plan: 'pro',
+            current_period_end: inDays(-3),
+        });
+        expect(inside.reason).toBe('grace');
+        expect(inside.plan.key).toBe('pro');
+
+        const outside = resolve({
+            status: 'past_due',
+            plan: 'pro',
+            current_period_end: inDays(-20),
+        });
+        expect(outside.reason).toBe('free');
+    });
+
+    it('drops canceled, unpaid and expired subscriptions to free', () => {
+        for (const status of [
+            'canceled',
+            'unpaid',
+            'incomplete_expired',
+            'paused',
+        ]) {
+            expect(resolve({ status, plan: 'pro' }).plan.key).toBe('free');
+        }
+    });
+
+    it('applies a valid admin override and ignores an expired one', () => {
+        expect(
+            resolve({ status: 'canceled', override_plan: 'pro' }).reason
+        ).toBe('override');
+        expect(
+            resolve({
+                status: 'canceled',
+                override_plan: 'pro',
+                override_expires_at: inDays(30),
+            }).plan.key
+        ).toBe('pro');
+        expect(
+            resolve({
+                status: 'canceled',
+                override_plan: 'pro',
+                override_expires_at: inDays(-1),
+            }).plan.key
+        ).toBe('free');
+        expect(
+            resolve({ status: 'active', plan: 'pro', override_plan: 'free' })
+                .plan.key
+        ).toBe('free');
+    });
+
+    it('exempts admins unless told otherwise', () => {
+        expect(resolve({ status: 'canceled' }, { isAdmin: true }).reason).toBe(
+            'admin'
+        );
+        config.hosted.exemptAdmins = false;
+        expect(
+            resolve({ status: 'canceled' }, { isAdmin: true }).plan.key
+        ).toBe('free');
+    });
+});

--- a/docs/17-hosted-mode.md
+++ b/docs/17-hosted-mode.md
@@ -1,0 +1,73 @@
+# Hosted Mode
+
+Hosted mode is how tududi runs as a public, multi-user service (a single
+shared instance where unrelated people sign up). It is off by default and a
+self-hosted install never needs it. Everything in this document is a no-op
+until `TUDUDI_HOSTED_MODE=true`.
+
+## What the flag changes
+
+| Area | Self-hosted (default) | Hosted mode |
+|---|---|---|
+| First registered user | becomes admin | regular user; admin comes from `TUDUDI_USER_EMAIL` |
+| `POST /api/admin/set-admin-role` with no roles | any user may bootstrap | refused |
+| OIDC auto-provisioning | always creates accounts | only while registration is enabled |
+| Boot | starts with whatever is set | refuses to start until session secret, trust proxy, allowed origins, public URLs, email and PostgreSQL are configured (`config/hostedConfig.js`) |
+| `GET /api/health` | includes environment and proxy setting | omits them |
+| Plans and limits | none, everything unlimited | the plan catalog below applies |
+
+## Plans and limits
+
+The catalog lives in `backend/config/plans.js`:
+
+| | Free | Pro |
+|---|---|---|
+| Active tasks (not done, archived or cancelled) | 200 | unlimited |
+| Projects | 10 | unlimited |
+| Notes | 50 | unlimited |
+| Attachment storage | 50 MB | 5 GB |
+| AI requests per day | 0 | 200 |
+| AI assistant, MCP, CalDAV, Telegram, backup import | no | yes |
+
+`null` means unlimited. Override any number with `TUDUDI_PLANS_JSON`, a JSON
+object deep-merged over the defaults:
+
+```bash
+TUDUDI_PLANS_JSON='{"free":{"limits":{"max_tasks":100}},"pro":{"limits":{"storage_mb":10000}}}'
+```
+
+Other knobs:
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `TUDUDI_TRIAL_DAYS` | `14` | new accounts get Pro for this long, counted from the account creation date |
+| `TUDUDI_PAST_DUE_GRACE_DAYS` | `14` | after a failed payment, Pro continues this long past the period end |
+| `TUDUDI_HOSTED_EXEMPT_ADMINS` | `true` | admins are treated as Pro |
+
+## How limits are enforced
+
+`backend/services/entitlementsService.js` answers "what may this user do"
+from their `billing_accounts` row and the catalog. Resolution order: hosted
+off, admin exemption, admin override, active or trialing subscription,
+past-due grace, local trial, free.
+
+Only creation is ever limited. Reads, edits, completing, deleting,
+exporting and downloading always work, so a downgraded account above the
+free limits loses nothing; it just cannot add more until it is back under
+the limit or upgrades. Limits answer `402` with `code: PLAN_LIMIT_REACHED`
+and `details: { resource, limit, current, plan }`; plan-only features answer
+`402` with `code: FEATURE_NOT_IN_PLAN`.
+
+Stock limits (tasks, projects, notes, storage) are counted live, so
+completing tasks or deleting attachments frees quota immediately. Per-day
+budgets (AI requests) use the `usage_counters` table.
+
+## Tables
+
+- `billing_accounts`: one row per user, created on first use. Subscription
+  state as reported by Stripe, the local trial end, and the admin override.
+- `billing_events`: every Stripe webhook event id, so redeliveries are
+  applied once.
+- `usage_counters`: `(user, metric, day)` counters.
+
+All three are removed with the account by `services/accountErasureService.js`.

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -52,6 +52,8 @@ const Navbar: React.FC<NavbarProps> = ({
         backups: false,
         caldav: false,
         mcp: false,
+        hosted: false,
+        billing: false,
     });
     const dropdownRef = useRef<HTMLDivElement>(null);
     const navigate = useNavigate();

--- a/frontend/components/Profile/ProfileSettings.tsx
+++ b/frontend/components/Profile/ProfileSettings.tsx
@@ -164,6 +164,8 @@ const ProfileSettings: React.FC<ProfileSettingsProps> = ({
         backups: false,
         caldav: false,
         mcp: false,
+        hosted: false,
+        billing: false,
     });
     const [isChangingLanguage, setIsChangingLanguage] = useState(false);
     const [isPolling, setIsPolling] = useState(false);

--- a/frontend/utils/featureFlags.ts
+++ b/frontend/utils/featureFlags.ts
@@ -4,6 +4,8 @@ export interface FeatureFlags {
     backups: boolean;
     caldav: boolean;
     mcp: boolean;
+    hosted: boolean;
+    billing: boolean;
 }
 
 let cachedFeatureFlags: FeatureFlags | null = null;
@@ -24,6 +26,8 @@ export const getFeatureFlags = async (): Promise<FeatureFlags> => {
                 backups: false,
                 caldav: false,
                 mcp: false,
+                hosted: false,
+                billing: false,
             };
         }
 
@@ -32,6 +36,8 @@ export const getFeatureFlags = async (): Promise<FeatureFlags> => {
             backups: false,
             caldav: false,
             mcp: false,
+            hosted: false,
+            billing: false,
         };
         cachedFeatureFlags = {
             ...defaultFlags,
@@ -44,6 +50,8 @@ export const getFeatureFlags = async (): Promise<FeatureFlags> => {
             backups: false,
             caldav: false,
             mcp: false,
+            hosted: false,
+            billing: false,
         };
     }
 };


### PR DESCRIPTION
## Description

Phase 2 foundation (follows #1476, #1477). Everything here is inert unless `TUDUDI_HOSTED_MODE=true`; no route enforces anything yet, that is the next PR. Self-hosted installs pay nothing: every entitlement function returns "unlimited" before touching the database.

- **Plan catalog** `backend/config/plans.js`: Free (200 active tasks, 10 projects, 50 notes, 50 MB, no AI/MCP/CalDAV/Telegram/backup import) and Pro (unlimited items, 5 GB, 200 AI requests/day, all features). `TUDUDI_PLANS_JSON` is deep-merged over the defaults so any number can change without a release. `null` means unlimited.
- **Tables** with migrations, models, and erasure on account deletion:
  - `billing_accounts`: one row per user, created lazily; subscription state as Stripe reports it, the local trial end, and an admin override.
  - `billing_events`: Stripe event ids, for idempotent webhooks.
  - `usage_counters`: `(user, metric, day)` for per-day budgets.
- **Entitlements** `backend/services/entitlementsService.js`: `resolvePlan` (pure) picks hosted-off, admin exemption, override, active/trialing, past-due grace (`TUDUDI_PAST_DUE_GRACE_DAYS`), local trial (`TUDUDI_TRIAL_DAYS` from the account creation date), then free. `assertCanCreate` counts live rows (active tasks only, so completing frees quota), `assertStorage` sums attachment sizes, `consumeUsage` increments the daily counter, all throwing 402 with `code` and `details`. 30-second cache with explicit invalidation.
- **Middleware** `backend/middleware/entitlements.js`: `requireFeature`, `requireQuota`, `requireStorage`.
- **Errors**: `PlanLimitError` and `FeatureNotInPlanError` (402, with `details`), `BillingNotConfiguredError` (503).
- **Feature flags** report `hosted` and `billing`; the frontend `FeatureFlags` type follows.
- **Config**: `TUDUDI_TRIAL_DAYS` (14), `TUDUDI_PAST_DUE_GRACE_DAYS` (14), `TUDUDI_HOSTED_EXEMPT_ADMINS` (true), `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_PRO_MONTHLY`, `STRIPE_PRICE_PRO_ANNUAL`.
- Docs: new `docs/17-hosted-mode.md`.

## Type of Change

- [x] New feature (adds functionality)
- [x] Documentation/Translation update

## Testing

- `tests/unit/services/entitlementsService.test.js`: catalog defaults, JSON override merge, invalid JSON fallback, and the full `resolvePlan` matrix (hosted off, no row, trial running/expired, active/trialing, grace inside/outside, canceled/unpaid/expired/paused, override valid/expired/downgrade, admin exemption on/off).
- `tests/integration/entitlements.test.js`: hosted off creates no rows and never throws; hosted on with tiny limits: lazy row creation, trial start, task limit counting only active tasks, project/note limits, storage quota, feature gating, daily AI budget, admin override with cache invalidation, admin exemption.
- Schema parity test passes with the three new tables. `npm test`: 1925 passed (only the pre-existing date-boundary recurring test fails). `tsc --noEmit` clean. `npm run lint`: 0 errors.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)