### PR TITLE
feat(billing): enforce plan limits at every create path, surface 402 in the UI

### DIFF
--- a/backend/modules/ai-assistant/routes.js
+++ b/backend/modules/ai-assistant/routes.js
@@ -3,10 +3,15 @@
 const express = require('express');
 const router = express.Router();
 const controller = require('./controller');
+const { requireFeature } = require('../../middleware/entitlements');
 
 router.get('/ai-assistant/config', controller.getConfig);
 router.get('/ai-assistant/daily-brief', controller.getCachedBrief);
-router.post('/ai-assistant/daily-brief', controller.getDailyBrief);
+router.post(
+    '/ai-assistant/daily-brief',
+    requireFeature('ai'),
+    controller.getDailyBrief
+);
 router.get(
     '/ai-assistant/task-insights/:taskUid',
     controller.getCachedTaskInsights
@@ -15,7 +20,11 @@ router.patch(
     '/ai-assistant/task-insights/:taskUid/dismissed',
     controller.updateTaskInsightsDismissed
 );
-router.post('/ai-assistant/task-insights', controller.getTaskInsights);
+router.post(
+    '/ai-assistant/task-insights',
+    requireFeature('ai'),
+    controller.getTaskInsights
+);
 router.get(
     '/ai-assistant/project-insights/:projectUid',
     controller.getCachedProjectInsights
@@ -24,6 +33,10 @@ router.patch(
     '/ai-assistant/project-insights/:projectUid/dismissed',
     controller.updateProjectInsightsDismissed
 );
-router.post('/ai-assistant/project-insights', controller.getProjectInsights);
+router.post(
+    '/ai-assistant/project-insights',
+    requireFeature('ai'),
+    controller.getProjectInsights
+);
 
 module.exports = router;

--- a/backend/modules/ai-assistant/service.js
+++ b/backend/modules/ai-assistant/service.js
@@ -1,4 +1,5 @@
 'use strict';
+const entitlements = require('../../services/entitlementsService');
 
 const OpenAI = require('openai');
 const moment = require('moment-timezone');
@@ -335,6 +336,7 @@ function buildEntityMaps({ metrics, projects }) {
 
 async function generateDailyBrief(userId) {
     const client = getOpenAIClient();
+    await entitlements.consumeUsage(userId, 'ai_requests');
 
     const context = await fetchUserContext(userId);
     const contextSummary = buildContextSummary(context);
@@ -502,6 +504,7 @@ async function updateTaskInsightsDismissed(taskUid, userId, dismissed) {
 
 async function generateTaskInsights(taskContext, userId) {
     const client = getOpenAIClient();
+    await entitlements.consumeUsage(userId, 'ai_requests');
 
     const {
         taskUid,
@@ -708,6 +711,7 @@ async function updateProjectInsightsDismissed(projectUid, userId, dismissed) {
 
 async function generateProjectInsights(projectContext, userId) {
     const client = getOpenAIClient();
+    await entitlements.consumeUsage(userId, 'ai_requests');
 
     const {
         projectUid,

--- a/backend/modules/backup/routes.js
+++ b/backend/modules/backup/routes.js
@@ -3,6 +3,7 @@
 const express = require('express');
 const multer = require('multer');
 const router = express.Router();
+const { requireFeature } = require('../../middleware/entitlements');
 const backupController = require('./controller');
 
 const checkBackupsEnabled = (req, res, next) => {
@@ -45,15 +46,25 @@ const upload = multer({
 router.use('/backup', checkBackupsEnabled);
 
 router.post('/backup/export', backupController.export);
-router.post('/backup/import', upload.single('backup'), backupController.import);
+router.post(
+    '/backup/import',
+    requireFeature('backups_import'),
+    upload.single('backup'),
+    backupController.import
+);
 router.post(
     '/backup/validate',
+    requireFeature('backups_import'),
     upload.single('backup'),
     backupController.validate
 );
 router.get('/backup/list', backupController.list);
 router.get('/backup/:uid/download', backupController.download);
-router.post('/backup/:uid/restore', backupController.restore);
+router.post(
+    '/backup/:uid/restore',
+    requireFeature('backups_import'),
+    backupController.restore
+);
 router.delete('/backup/:uid', backupController.delete);
 
 module.exports = router;

--- a/backend/modules/caldav/middleware/caldav-auth.js
+++ b/backend/modules/caldav/middleware/caldav-auth.js
@@ -2,12 +2,22 @@ const bcrypt = require('bcrypt');
 const { User } = require('../../../models');
 const { findValidTokenByValue } = require('../../users/apiTokenService');
 const { caldavAuthLimiter } = require('../../../middleware/rateLimiter');
+const { hasFeature } = require('../../../services/entitlementsService');
+
+// CalDAV is a plan feature on hosted instances. Checked once the account
+// is known, whichever way it authenticated.
+async function planAllows(user, res) {
+    if (await hasFeature(user.id, 'caldav')) return true;
+    res.status(403).json({ error: 'CalDAV is not included in your plan' });
+    return false;
+}
 
 async function caldavAuth(req, res, next) {
     try {
         if (req.session?.userId) {
             const user = await User.findByPk(req.session.userId);
             if (user) {
+                if (!(await planAllows(user, res))) return;
                 req.currentUser = user;
                 return next();
             }
@@ -19,6 +29,7 @@ async function caldavAuth(req, res, next) {
             if (tokenRecord) {
                 const user = await User.findByPk(tokenRecord.user_id);
                 if (user) {
+                    if (!(await planAllows(user, res))) return;
                     req.currentUser = user;
                     return next();
                 }
@@ -77,6 +88,7 @@ async function caldavAuth(req, res, next) {
                 .json({ error: 'Invalid credentials' });
         }
 
+        if (!(await planAllows(user, res))) return;
         req.currentUser = user;
 
         if (req.params.username && req.params.username !== user.email) {

--- a/backend/modules/caldav/routes.js
+++ b/backend/modules/caldav/routes.js
@@ -22,6 +22,7 @@ const {
 } = require('./webdav/projects');
 const apiRoutes = require('./api/routes');
 const { requireAuth } = require('../../middleware/auth');
+const { requireFeature } = require('../../middleware/entitlements');
 const taskRepository = require('../tasks/repository');
 const vtodoSerializer = require('./icalendar/vtodo-serializer');
 const { generateCTag } = require('./utils/ctag-generator');
@@ -286,6 +287,6 @@ router.delete(
     handleDeleteTask
 );
 
-router.use('/api/caldav', requireAuth, apiRoutes);
+router.use('/api/caldav', requireAuth, requireFeature('caldav'), apiRoutes);
 
 module.exports = router;

--- a/backend/modules/caldav/services/sync-scheduler.js
+++ b/backend/modules/caldav/services/sync-scheduler.js
@@ -77,6 +77,12 @@ class SyncScheduler {
 
     async _syncCalendar(calendar) {
         try {
+            const {
+                hasFeature,
+            } = require('../../../services/entitlementsService');
+            if (!(await hasFeature(calendar.user_id, 'caldav'))) {
+                return;
+            }
             logger.logInfo(
                 `Syncing calendar ${calendar.id} for user ${calendar.user_id}`
             );

--- a/backend/modules/caldav/webdav/task-handlers.js
+++ b/backend/modules/caldav/webdav/task-handlers.js
@@ -1,4 +1,5 @@
 const { generateETag } = require('../utils/etag-generator');
+const entitlements = require('../../../services/entitlementsService');
 const { matchesETag } = require('../utils/etag-generator');
 const taskRepository = require('../../tasks/repository');
 const { CALDAV_TASK_INCLUDES } = require('../task-includes');
@@ -120,6 +121,7 @@ async function handlePutTask(req, res) {
             await existingTask.update(taskData);
             task = existingTask;
         } else {
+            await entitlements.assertCanCreate(userId, 'task');
             task = await taskRepository.create(taskData);
         }
 

--- a/backend/modules/habits/routes.js
+++ b/backend/modules/habits/routes.js
@@ -2,11 +2,17 @@
 
 const express = require('express');
 const router = express.Router();
+const { requireQuota } = require('../../middleware/entitlements');
 const habitsController = require('./controller');
 const { requireAuth } = require('../../middleware/auth');
 
 router.get('/habits', requireAuth, habitsController.getAll);
-router.post('/habits', requireAuth, habitsController.create);
+router.post(
+    '/habits',
+    requireAuth,
+    requireQuota('task'),
+    habitsController.create
+);
 router.post(
     '/habits/:uid/complete',
     requireAuth,

--- a/backend/modules/mcp/routes.js
+++ b/backend/modules/mcp/routes.js
@@ -4,6 +4,7 @@ const express = require('express');
 const router = express.Router();
 const controller = require('./controller');
 const { authenticateMcpRequest } = require('./middleware');
+const { requireFeature } = require('../../middleware/entitlements');
 
 /**
  * Middleware to check if MCP feature is enabled
@@ -25,10 +26,20 @@ const checkMcpEnabled = (req, res, next) => {
 router.get('/mcp/status', controller.getMcpStatus);
 
 // Get MCP configuration for Claude Desktop (requires feature flag)
-router.get('/mcp/config', checkMcpEnabled, controller.getMcpConfig);
+router.get(
+    '/mcp/config',
+    checkMcpEnabled,
+    requireFeature('mcp'),
+    controller.getMcpConfig
+);
 
 // List available MCP tools (requires feature flag)
-router.get('/mcp/tools', checkMcpEnabled, controller.listMcpTools);
+router.get(
+    '/mcp/tools',
+    checkMcpEnabled,
+    requireFeature('mcp'),
+    controller.listMcpTools
+);
 
 // MCP protocol endpoint - uses Bearer token auth, not session auth
 // This endpoint handles actual MCP protocol messages from remote clients
@@ -36,6 +47,7 @@ router.post(
     '/mcp',
     checkMcpEnabled,
     authenticateMcpRequest,
+    requireFeature('mcp'),
     controller.handleMcpMessage
 );
 

--- a/backend/modules/mcp/tools/projectTools.js
+++ b/backend/modules/mcp/tools/projectTools.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const entitlements = require('../../../services/entitlementsService');
 const { Project, Area, Tag } = require('../../../models');
 const { Op } = require('sequelize');
 const projectsRepository = require('../../projects/repository');
@@ -225,6 +226,7 @@ function registerProjectTools(server, context, tools) {
                 image_url: params.image_url || null,
             };
 
+            await entitlements.assertCanCreate(context.userId, 'project');
             const project = await Project.create(projectData);
 
             if (params.tags && params.tags.length > 0) {

--- a/backend/modules/mcp/tools/taskTools.js
+++ b/backend/modules/mcp/tools/taskTools.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const entitlements = require('../../../services/entitlementsService');
 const taskRepository = require('../../tasks/repository');
 const {
     serializeTask,
@@ -381,6 +382,7 @@ function registerTaskTools(server, context, tools) {
                 completion_based: params.completion_based || false,
             };
 
+            await entitlements.assertCanCreate(context.userId, 'task');
             const task = await taskRepository.create(taskData);
 
             if (params.tags && params.tags.length > 0) {
@@ -873,6 +875,7 @@ function registerTaskTools(server, context, tools) {
                 project_id: parentTask.project_id,
             };
 
+            await entitlements.assertCanCreate(context.userId, 'task');
             const subtask = await taskRepository.create(subtaskData);
 
             const reloadedSubtask = await taskRepository.findByIdAndUser(

--- a/backend/modules/notes/service.js
+++ b/backend/modules/notes/service.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const entitlements = require('../../services/entitlementsService');
 const _ = require('lodash');
 const notesRepository = require('./repository');
 const { validateUid } = require('./validation');
@@ -173,6 +174,7 @@ class NotesService {
         userId,
         { title, content, project_uid, project_id, tags, color }
     ) {
+        await entitlements.assertCanCreate(userId, 'note');
         const noteAttributes = { title, content };
 
         if (color !== undefined) {

--- a/backend/modules/projects/service.js
+++ b/backend/modules/projects/service.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const entitlements = require('../../services/entitlementsService');
 const { Op } = require('sequelize');
 const projectsRepository = require('./repository');
 const { validateUid, validateName, formatDate } = require('./validation');
@@ -293,6 +294,7 @@ class ProjectsService {
      * Create a new project.
      */
     async create(userId, data) {
+        await entitlements.assertCanCreate(userId, 'project');
         const {
             name,
             description,

--- a/backend/modules/tasks/attachments.js
+++ b/backend/modules/tasks/attachments.js
@@ -21,6 +21,8 @@ const {
 } = require('../../middleware/rateLimiter');
 
 const router = express.Router();
+const { requireFeature } = require('../../middleware/entitlements');
+const entitlements = require('../../services/entitlementsService');
 
 // Ensure authenticated
 router.use((req, res, next) => {
@@ -70,6 +72,7 @@ const upload = multer({
 router.post(
     '/upload/task-attachment',
     createResourceLimiter,
+    requireFeature('attachments'),
     upload.single('file'),
     async (req, res) => {
         try {
@@ -128,6 +131,16 @@ router.post(
 
             if (!req.file) {
                 return res.status(400).json({ error: 'No file uploaded' });
+            }
+
+            try {
+                await entitlements.assertStorage(userId, req.file.size);
+            } catch (limitError) {
+                await deleteFileFromDisk(req.file.path);
+                if (limitError.statusCode === 402) {
+                    return res.status(402).json(limitError.toJSON());
+                }
+                throw limitError;
             }
 
             // Create attachment record

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -54,6 +54,7 @@ const {
     buildUpdateAttributes,
 } = require('./core/builders');
 const { createSubtasks, updateSubtasks } = require('./operations/subtasks');
+const { requireQuota } = require('../../middleware/entitlements');
 const { handleCompletionStatus } = require('./operations/completion');
 const { captureOldValues, logTaskChanges } = require('./utils/logging');
 const {
@@ -346,146 +347,163 @@ router.get('/tasks/metrics', async (req, res) => {
     }
 });
 
-router.post('/task', async (req, res) => {
-    try {
-        const {
-            name,
-            project_id,
-            project_uid,
-            area_id,
-            area_uid,
-            goal_id,
-            parent_task_id,
-            tags,
-            Tags,
-            subtasks,
-        } = req.body;
-        const tagsData = tags || Tags;
-
-        if (!name || name.trim() === '') {
-            return res.status(400).json({ error: 'Task name is required.' });
-        }
-
-        const timezone = getSafeTimezone(req.currentUser.timezone);
-        const taskAttributes = buildTaskAttributes(
-            req.body,
-            req.currentUser.id,
-            timezone
-        );
-
+router.post(
+    '/task',
+    requireQuota(
+        'task',
+        (req) =>
+            1 +
+            (Array.isArray(req.body?.subtasks) ? req.body.subtasks.length : 0)
+    ),
+    async (req, res) => {
         try {
-            // Fetch parent end date if this is a recurring instance
-            const recurringParentEndDate = await getRecurringParentEndDate(
-                req.body.recurring_parent_id,
-                req.currentUser.id
-            );
-
-            validateDeferUntilAndDueDate(
-                taskAttributes.defer_until,
-                taskAttributes.due_date,
-                recurringParentEndDate
-            );
-        } catch (error) {
-            return res.status(400).json({ error: error.message });
-        }
-
-        try {
-            const validProjectId = await validateProjectAccess(
-                project_uid || project_id,
-                req.currentUser.id
-            );
-            if (validProjectId) taskAttributes.project_id = validProjectId;
-        } catch (error) {
-            return res
-                .status(error.message === 'Forbidden' ? 403 : 400)
-                .json({ error: error.message });
-        }
-
-        try {
-            const validAreaId = await validateAreaAccess(
-                area_uid || area_id,
-                req.currentUser.id
-            );
-            if (validAreaId) taskAttributes.area_id = validAreaId;
-        } catch (error) {
-            return res.status(400).json({ error: error.message });
-        }
-
-        try {
-            const validParentId = await validateParentTaskAccess(
-                parent_task_id,
-                req.currentUser.id
-            );
-            if (validParentId) taskAttributes.parent_task_id = validParentId;
-        } catch (error) {
-            return res.status(400).json({ error: error.message });
-        }
-
-        try {
-            const validGoalId = await validateGoalAccess(
+            const {
+                name,
+                project_id,
+                project_uid,
+                area_id,
+                area_uid,
                 goal_id,
-                req.currentUser.id
+                parent_task_id,
+                tags,
+                Tags,
+                subtasks,
+            } = req.body;
+            const tagsData = tags || Tags;
+
+            if (!name || name.trim() === '') {
+                return res
+                    .status(400)
+                    .json({ error: 'Task name is required.' });
+            }
+
+            const timezone = getSafeTimezone(req.currentUser.timezone);
+            const taskAttributes = buildTaskAttributes(
+                req.body,
+                req.currentUser.id,
+                timezone
             );
-            if (validGoalId) taskAttributes.goal_id = validGoalId;
+
+            try {
+                // Fetch parent end date if this is a recurring instance
+                const recurringParentEndDate = await getRecurringParentEndDate(
+                    req.body.recurring_parent_id,
+                    req.currentUser.id
+                );
+
+                validateDeferUntilAndDueDate(
+                    taskAttributes.defer_until,
+                    taskAttributes.due_date,
+                    recurringParentEndDate
+                );
+            } catch (error) {
+                return res.status(400).json({ error: error.message });
+            }
+
+            try {
+                const validProjectId = await validateProjectAccess(
+                    project_uid || project_id,
+                    req.currentUser.id
+                );
+                if (validProjectId) taskAttributes.project_id = validProjectId;
+            } catch (error) {
+                return res
+                    .status(error.message === 'Forbidden' ? 403 : 400)
+                    .json({ error: error.message });
+            }
+
+            try {
+                const validAreaId = await validateAreaAccess(
+                    area_uid || area_id,
+                    req.currentUser.id
+                );
+                if (validAreaId) taskAttributes.area_id = validAreaId;
+            } catch (error) {
+                return res.status(400).json({ error: error.message });
+            }
+
+            try {
+                const validParentId = await validateParentTaskAccess(
+                    parent_task_id,
+                    req.currentUser.id
+                );
+                if (validParentId)
+                    taskAttributes.parent_task_id = validParentId;
+            } catch (error) {
+                return res.status(400).json({ error: error.message });
+            }
+
+            try {
+                const validGoalId = await validateGoalAccess(
+                    goal_id,
+                    req.currentUser.id
+                );
+                if (validGoalId) taskAttributes.goal_id = validGoalId;
+            } catch (error) {
+                return res.status(400).json({ error: error.message });
+            }
+
+            const task = await taskRepository.create(taskAttributes);
+            await updateTaskTags(task, tagsData, req.currentUser.id);
+            await createSubtasks(task.id, subtasks, req.currentUser.id);
+
+            const taskWithAssociations = await taskRepository.findById(
+                task.id,
+                {
+                    include: TASK_INCLUDES_WITH_SUBTASKS,
+                }
+            );
+
+            if (!taskWithAssociations) {
+                logError('Failed to reload created task:', task.id);
+                const fallbackTask = {
+                    ...task.toJSON(),
+                    tags: [],
+                    Project: null,
+                    subtasks: [],
+                    today_move_count: 0,
+                    due_date: task.due_date
+                        ? task.due_date instanceof Date
+                            ? task.due_date.toISOString().split('T')[0]
+                            : new Date(task.due_date)
+                                  .toISOString()
+                                  .split('T')[0]
+                        : null,
+                    completed_at: task.completed_at
+                        ? task.completed_at instanceof Date
+                            ? task.completed_at.toISOString()
+                            : new Date(task.completed_at).toISOString()
+                        : null,
+                };
+                return res.status(201).json(fallbackTask);
+            }
+
+            const serializedTask = await serializeTask(
+                taskWithAssociations,
+                req.currentUser.timezone,
+                { skipDisplayNameTransform: true }
+            );
+
+            res.set({
+                'Cache-Control': 'no-cache, no-store, must-revalidate',
+                Pragma: 'no-cache',
+                Expires: '0',
+            });
+
+            res.status(201).json(serializedTask);
         } catch (error) {
-            return res.status(400).json({ error: error.message });
+            logError('Error creating task:', error);
+            logError('Error stack:', error.stack);
+            logError('Error name:', error.name);
+            res.status(400).json({
+                error: 'There was a problem creating the task.',
+                details: error.errors
+                    ? error.errors.map((e) => e.message)
+                    : [error.message],
+            });
         }
-
-        const task = await taskRepository.create(taskAttributes);
-        await updateTaskTags(task, tagsData, req.currentUser.id);
-        await createSubtasks(task.id, subtasks, req.currentUser.id);
-
-        const taskWithAssociations = await taskRepository.findById(task.id, {
-            include: TASK_INCLUDES_WITH_SUBTASKS,
-        });
-
-        if (!taskWithAssociations) {
-            logError('Failed to reload created task:', task.id);
-            const fallbackTask = {
-                ...task.toJSON(),
-                tags: [],
-                Project: null,
-                subtasks: [],
-                today_move_count: 0,
-                due_date: task.due_date
-                    ? task.due_date instanceof Date
-                        ? task.due_date.toISOString().split('T')[0]
-                        : new Date(task.due_date).toISOString().split('T')[0]
-                    : null,
-                completed_at: task.completed_at
-                    ? task.completed_at instanceof Date
-                        ? task.completed_at.toISOString()
-                        : new Date(task.completed_at).toISOString()
-                    : null,
-            };
-            return res.status(201).json(fallbackTask);
-        }
-
-        const serializedTask = await serializeTask(
-            taskWithAssociations,
-            req.currentUser.timezone,
-            { skipDisplayNameTransform: true }
-        );
-
-        res.set({
-            'Cache-Control': 'no-cache, no-store, must-revalidate',
-            Pragma: 'no-cache',
-            Expires: '0',
-        });
-
-        res.status(201).json(serializedTask);
-    } catch (error) {
-        logError('Error creating task:', error);
-        logError('Error stack:', error.stack);
-        logError('Error name:', error.name);
-        res.status(400).json({
-            error: 'There was a problem creating the task.',
-            details: error.errors
-                ? error.errors.map((e) => e.message)
-                : [error.message],
-        });
     }
-});
+);
 
 router.get('/task/:uid', requireTaskReadAccess, async (req, res) => {
     try {

--- a/backend/modules/telegram/routes.js
+++ b/backend/modules/telegram/routes.js
@@ -2,12 +2,21 @@
 
 const express = require('express');
 const router = express.Router();
+const { requireFeature } = require('../../middleware/entitlements');
 const telegramController = require('./controller');
 
-router.post('/telegram/start-polling', telegramController.startPolling);
+router.post(
+    '/telegram/start-polling',
+    requireFeature('telegram'),
+    telegramController.startPolling
+);
 router.post('/telegram/stop-polling', telegramController.stopPolling);
 router.get('/telegram/polling-status', telegramController.getPollingStatus);
-router.post('/telegram/setup', telegramController.setup);
+router.post(
+    '/telegram/setup',
+    requireFeature('telegram'),
+    telegramController.setup
+);
 router.post('/telegram/send-welcome', telegramController.sendWelcome);
 
 module.exports = router;

--- a/backend/modules/telegram/telegramInitializer.js
+++ b/backend/modules/telegram/telegramInitializer.js
@@ -38,7 +38,11 @@ async function initializeTelegramPolling() {
                     `Initializing Telegram polling for ${usersWithTelegram.length} user(s)...`
                 );
                 // Add each user to the polling list
+                const {
+                    hasFeature,
+                } = require('../../services/entitlementsService');
                 for (const user of usersWithTelegram) {
+                    if (!(await hasFeature(user.id, 'telegram'))) continue;
                     await telegramPoller.addUser(user);
                 }
             }

--- a/backend/modules/templates/service.js
+++ b/backend/modules/templates/service.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const entitlements = require('../../services/entitlementsService');
 const https = require('https');
 const http = require('http');
 const { URL } = require('url');
@@ -242,6 +243,15 @@ class TemplatesService {
         }
 
         const templateJson = template.toJSON();
+        await entitlements.assertCanCreate(userId, 'project');
+        const templateTaskCount = (templateJson.Tasks || []).length;
+        if (templateTaskCount > 0) {
+            await entitlements.assertCanCreate(
+                userId,
+                'task',
+                templateTaskCount
+            );
+        }
         const newName = options.name || `${template.name} (Copy)`;
         const projectUid = generateUid();
 

--- a/backend/modules/users/service.js
+++ b/backend/modules/users/service.js
@@ -44,6 +44,7 @@ const {
 } = require('../../shared/errors');
 const { User, Role } = require('../../models');
 const { isAdmin } = require('../../services/rolesService');
+const entitlements = require('../../services/entitlementsService');
 const { eraseUserAccount } = require('../../services/accountErasureService');
 const {
     createApiToken,
@@ -178,8 +179,12 @@ class UsersService {
         }
         if (avatar_image !== undefined)
             allowedUpdates.avatar_image = avatar_image;
-        if (telegram_bot_token !== undefined)
+        if (telegram_bot_token !== undefined) {
+            if (telegram_bot_token) {
+                await entitlements.assertFeature(userId, 'telegram');
+            }
             allowedUpdates.telegram_bot_token = telegram_bot_token;
+        }
         if (telegram_allowed_users !== undefined)
             allowedUpdates.telegram_allowed_users = telegram_allowed_users;
         if (features !== undefined) {

--- a/backend/services/entitlementsService.js
+++ b/backend/services/entitlementsService.js
@@ -264,8 +264,11 @@ async function consumeUsage(userId, metric, n = 1) {
         throw new PlanLimitError(metric, limit, row.count, ent.plan);
     }
 
+    // increment() mutates the instance on PostgreSQL but not on SQLite, so
+    // re-read rather than add locally.
     await row.increment('count', { by: n });
-    return row.count + n;
+    await row.reload();
+    return row.count;
 }
 
 async function getUsage(userId) {

--- a/backend/tests/integration/plan-enforcement.test.js
+++ b/backend/tests/integration/plan-enforcement.test.js
@@ -1,0 +1,194 @@
+const request = require('supertest');
+const path = require('path');
+const fs = require('fs').promises;
+
+process.env.FF_ENABLE_MCP = 'true';
+process.env.FF_ENABLE_BACKUPS = 'true';
+
+const app = require('../../app');
+const { getConfig } = require('../../config/config');
+const plans = require('../../config/plans');
+const { Task, Project, Role } = require('../../models');
+const entitlements = require('../../services/entitlementsService');
+const { createTestUser } = require('../helpers/testUtils');
+
+const config = getConfig();
+
+const login = async (user) => {
+    const agent = request.agent(app);
+    await agent
+        .post('/api/login')
+        .send({ email: user.email, password: 'password123' });
+    return agent;
+};
+
+const tinyPlans = (extra = {}) =>
+    JSON.stringify({
+        free: {
+            limits: {
+                max_tasks: 2,
+                max_projects: 1,
+                max_notes: 1,
+                storage_mb: 1,
+                ai_requests_per_day: 0,
+            },
+            ...extra,
+        },
+    });
+
+describe('Plan enforcement over HTTP (hosted mode on)', () => {
+    let user, agent;
+
+    beforeEach(async () => {
+        config.hosted.enabled = true;
+        config.hosted.trialDays = 0;
+        process.env.TUDUDI_PLANS_JSON = tinyPlans();
+        plans._resetCache();
+        entitlements.invalidate();
+        user = await createTestUser({
+            email: `enf_${Date.now()}@example.com`,
+        });
+        agent = await login(user);
+    });
+
+    afterEach(() => {
+        config.hosted.enabled = false;
+        config.hosted.trialDays = 14;
+        delete process.env.TUDUDI_PLANS_JSON;
+        plans._resetCache();
+        entitlements.invalidate();
+    });
+
+    it('stops task creation with 402 and details, but never reads or edits', async () => {
+        const first = await agent.post('/api/task').send({ name: 'one' });
+        expect(first.status).toBe(201);
+        const second = await agent.post('/api/task').send({ name: 'two' });
+        expect(second.status).toBe(201);
+
+        const third = await agent.post('/api/task').send({ name: 'three' });
+        expect(third.status).toBe(402);
+        expect(third.body.code).toBe('PLAN_LIMIT_REACHED');
+        expect(third.body.details).toMatchObject({
+            resource: 'task',
+            limit: 2,
+            current: 2,
+            plan: 'free',
+        });
+
+        const list = await agent.get('/api/tasks?type=all');
+        expect(list.status).toBe(200);
+        const patch = await agent
+            .patch(`/api/task/${first.body.uid}`)
+            .send({ name: 'renamed' });
+        expect(patch.status).toBe(200);
+
+        // Completing one frees a slot
+        await agent
+            .patch(`/api/task/${second.body.uid}`)
+            .send({ status: Task.STATUS.DONE });
+        const fourth = await agent.post('/api/task').send({ name: 'four' });
+        expect(fourth.status).toBe(201);
+
+        const del = await agent.delete(`/api/task/${first.body.uid}`);
+        expect([200, 204]).toContain(del.status);
+    });
+
+    it('counts subtasks sent with a new task against the limit', async () => {
+        const res = await agent
+            .post('/api/task')
+            .send({ name: 'parent', subtasks: [{ name: 'a' }, { name: 'b' }] });
+        expect(res.status).toBe(402);
+    });
+
+    it('limits projects and notes', async () => {
+        const p1 = await agent.post('/api/project').send({ name: 'p1' });
+        expect(p1.status).toBe(201);
+        const p2 = await agent.post('/api/project').send({ name: 'p2' });
+        expect(p2.status).toBe(402);
+        expect(p2.body.code).toBe('PLAN_LIMIT_REACHED');
+
+        const n1 = await agent
+            .post('/api/note')
+            .send({ title: 'n1', content: 'c' });
+        expect(n1.status).toBe(201);
+        const n2 = await agent
+            .post('/api/note')
+            .send({ title: 'n2', content: 'c' });
+        expect(n2.status).toBe(402);
+    });
+
+    it('refuses plan-only features with FEATURE_NOT_IN_PLAN', async () => {
+        const mcp = await agent.get('/api/mcp/config');
+        expect(mcp.status).toBe(402);
+        expect(mcp.body.code).toBe('FEATURE_NOT_IN_PLAN');
+        expect(mcp.body.details.feature).toBe('mcp');
+
+        const tg = await agent
+            .post('/api/telegram/setup')
+            .send({ token: '123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi' });
+        expect(tg.status).toBe(402);
+
+        const profile = await agent.patch('/api/profile').send({
+            telegram_bot_token: '123456:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi',
+        });
+        expect(profile.status).toBe(402);
+
+        const ai = await agent.post('/api/ai-assistant/daily-brief').send({});
+        expect(ai.status).toBe(402);
+
+        const restore = await agent.post('/api/backup/nope/restore');
+        expect(restore.status).toBe(402);
+        const exportRes = await agent.post('/api/backup/export');
+        expect(exportRes.status).toBe(200);
+    });
+
+    it('enforces the storage quota on upload and cleans the file up', async () => {
+        const task = await Task.create({ name: 't', user_id: user.id });
+        const big = Buffer.alloc(1200 * 1024, 'x');
+
+        const res = await agent
+            .post('/api/upload/task-attachment')
+            .field('taskUid', task.uid)
+            .attach('file', big, {
+                filename: 'big.txt',
+                contentType: 'text/plain',
+            });
+        expect(res.status).toBe(402);
+        expect(res.body.details.resource).toBe('storage');
+
+        const uploadsDir = path.join(config.uploadPath, 'tasks');
+        const files = await fs.readdir(uploadsDir).catch(() => []);
+        expect(files.filter((f) => f.includes('big'))).toEqual([]);
+    });
+
+    it('lets an admin through everything', async () => {
+        await Role.update({ is_admin: true }, { where: { user_id: user.id } });
+        entitlements.invalidate(user.id);
+
+        for (const name of ['a', 'b', 'c']) {
+            const res = await agent.post('/api/task').send({ name });
+            expect(res.status).toBe(201);
+        }
+        const mcp = await agent.get('/api/mcp/config');
+        expect(mcp.status).toBe(200);
+    });
+});
+
+describe('Plan enforcement with hosted mode off', () => {
+    it('never answers 402', async () => {
+        const user = await createTestUser({
+            email: `off_${Date.now()}@example.com`,
+        });
+        const agent = await login(user);
+
+        for (let i = 0; i < 3; i++) {
+            const res = await agent.post('/api/task').send({ name: `t${i}` });
+            expect(res.status).toBe(201);
+        }
+        await Project.create({ name: 'x', user_id: user.id });
+        const project = await agent.post('/api/project').send({ name: 'y' });
+        expect(project.status).toBe(201);
+        const mcp = await agent.get('/api/mcp/config');
+        expect(mcp.status).toBe(200);
+    });
+});

--- a/frontend/Layout.tsx
+++ b/frontend/Layout.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useToast } from './components/Shared/ToastContext';
+import UpgradeModal from './components/Billing/UpgradeModal';
 import { SidebarProvider } from './contexts/SidebarContext';
 import Navbar from './components/Navbar';
 import Sidebar from './components/Sidebar';
@@ -65,7 +66,8 @@ const Layout: React.FC<LayoutProps> = ({
     const [selectedArea, setSelectedArea] = useState<Area | null>(null);
     const [selectedTag, setSelectedTag] = useState<Tag | null>(null);
     const [selectedPerson, setSelectedPerson] = useState<Person | null>(null);
-    const [keyboardShortcuts, setKeyboardShortcuts] = useState<KeyboardShortcutsConfig | null>(null);
+    const [keyboardShortcuts, setKeyboardShortcuts] =
+        useState<KeyboardShortcutsConfig | null>(null);
 
     // Fetch keyboard shortcuts from profile
     useEffect(() => {
@@ -131,7 +133,12 @@ const Layout: React.FC<LayoutProps> = ({
                 if (window.innerWidth < 1024) {
                     setIsSidebarOpen(false);
                 }
-                navigate(`/task/${newTask.uid}`, { state: { isNew: true, from: location.pathname + location.search } });
+                navigate(`/task/${newTask.uid}`, {
+                    state: {
+                        isNew: true,
+                        from: location.pathname + location.search,
+                    },
+                });
             } else {
                 throw new Error('New task missing UID');
             }
@@ -520,6 +527,7 @@ const Layout: React.FC<LayoutProps> = ({
     return (
         <SidebarProvider isSidebarOpen={isSidebarOpen}>
             <div className={`min-h-screen ${isDarkMode ? 'dark' : ''}`}>
+                <UpgradeModal />
                 <Navbar
                     isDarkMode={isDarkMode}
                     toggleDarkMode={toggleDarkMode}
@@ -645,7 +653,6 @@ const Layout: React.FC<LayoutProps> = ({
                         onClose={closePersonModal}
                     />
                 )}
-
             </div>
         </SidebarProvider>
     );

--- a/frontend/components/Billing/UpgradeModal.tsx
+++ b/frontend/components/Billing/UpgradeModal.tsx
@@ -1,0 +1,133 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
+import { SparklesIcon } from '@heroicons/react/24/outline';
+import { PLAN_LIMIT_EVENT, PlanLimitDetail } from '../../utils/planLimits';
+
+// Listens for 402 responses surfaced by the API wrappers and explains which
+// plan limit was hit. Mounted once in the layout; invisible until needed.
+const UpgradeModal: React.FC = () => {
+    const { t } = useTranslation();
+    const navigate = useNavigate();
+    const [detail, setDetail] = useState<PlanLimitDetail | null>(null);
+
+    useEffect(() => {
+        const handler = (event: Event) => {
+            setDetail((event as CustomEvent<PlanLimitDetail>).detail);
+        };
+        window.addEventListener(PLAN_LIMIT_EVENT, handler);
+        return () => window.removeEventListener(PLAN_LIMIT_EVENT, handler);
+    }, []);
+
+    if (!detail) return null;
+
+    const { code, details } = detail;
+    const resourceLabel = (resource?: string) => {
+        switch (resource) {
+            case 'task':
+                return t('billing.resource.task', 'active tasks');
+            case 'project':
+                return t('billing.resource.project', 'projects');
+            case 'note':
+                return t('billing.resource.note', 'notes');
+            case 'storage':
+                return t('billing.resource.storage', 'attachment storage');
+            case 'ai_requests':
+                return t('billing.resource.ai', 'AI requests today');
+            default:
+                return resource || '';
+        }
+    };
+    const featureLabel = (feature?: string) => {
+        switch (feature) {
+            case 'ai':
+                return t('billing.feature.ai', 'the AI assistant');
+            case 'mcp':
+                return t('billing.feature.mcp', 'MCP integration');
+            case 'caldav':
+                return t('billing.feature.caldav', 'CalDAV sync');
+            case 'telegram':
+                return t('billing.feature.telegram', 'the Telegram bot');
+            case 'backups_import':
+                return t('billing.feature.backups_import', 'backup import');
+            case 'attachments':
+                return t('billing.feature.attachments', 'attachments');
+            default:
+                return feature || '';
+        }
+    };
+
+    const message =
+        code === 'FEATURE_NOT_IN_PLAN'
+            ? t('billing.featureNotInPlan', {
+                  defaultValue:
+                      'Your {{plan}} plan does not include {{feature}}.',
+                  plan: details?.plan,
+                  feature: featureLabel(details?.feature),
+              })
+            : t('billing.limitReached', {
+                  defaultValue:
+                      'Your {{plan}} plan allows {{limit}} {{resource}}. You are at {{current}}.',
+                  plan: details?.plan,
+                  limit:
+                      details?.resource === 'storage'
+                          ? `${Math.round((details.limit || 0) / (1024 * 1024))} MB`
+                          : details?.limit,
+                  resource: resourceLabel(details?.resource),
+                  current:
+                      details?.resource === 'storage'
+                          ? `${Math.round((details.current || 0) / (1024 * 1024))} MB`
+                          : details?.current,
+              });
+
+    return (
+        <div
+            className="fixed inset-0 z-[60] flex items-center justify-center bg-gray-900 bg-opacity-70"
+            onClick={() => setDetail(null)}
+            data-testid="upgrade-modal"
+        >
+            <div
+                className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md mx-4"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="px-6 py-5 border-b border-gray-200 dark:border-gray-700 flex items-center">
+                    <SparklesIcon className="w-6 h-6 mr-3 text-blue-500" />
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                        {t('billing.upgradeTitle', 'Upgrade to keep going')}
+                    </h3>
+                </div>
+                <div className="px-6 py-4 space-y-3 text-sm text-gray-700 dark:text-gray-300">
+                    <p>{message}</p>
+                    <p>
+                        {t(
+                            'billing.upgradeHint',
+                            'Everything you already have stays exactly as it is. Upgrading lifts the limit right away.'
+                        )}
+                    </p>
+                </div>
+                <div className="px-6 py-4 flex justify-end space-x-2">
+                    <button
+                        type="button"
+                        onClick={() => setDetail(null)}
+                        className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200"
+                    >
+                        {t('common.close', 'Close')}
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => {
+                            setDetail(null);
+                            navigate('/profile?section=billing');
+                        }}
+                        className="px-4 py-2 rounded bg-blue-600 text-white hover:bg-blue-700"
+                        data-testid="upgrade-modal-cta"
+                    >
+                        {t('billing.seePlans', 'See plans')}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default UpgradeModal;

--- a/frontend/utils/authUtils.ts
+++ b/frontend/utils/authUtils.ts
@@ -1,3 +1,8 @@
+import {
+    PlanLimitDetail,
+    PlanLimitError,
+    broadcastPlanLimit,
+} from './planLimits';
 import { getCsrfToken } from './csrfService';
 
 export const getDefaultHeaders = (): Record<string, string> => {
@@ -60,6 +65,19 @@ export const handleAuthResponse = async (
                 }, 100);
             }
             throw new Error('Authentication required');
+        }
+        if (response.status === 402) {
+            let detail: PlanLimitDetail = {
+                code: 'PLAN_LIMIT_REACHED',
+                error: errorMessage,
+            };
+            try {
+                detail = await response.json();
+            } catch {
+                // keep the generic detail
+            }
+            broadcastPlanLimit(detail);
+            throw new PlanLimitError(detail);
         }
         let details: string[] | undefined;
         try {

--- a/frontend/utils/planLimits.ts
+++ b/frontend/utils/planLimits.ts
@@ -1,0 +1,47 @@
+// A 402 from the API means the plan, not the request, said no. The API
+// wrappers turn it into a PlanLimitError and broadcast it so the upgrade
+// modal can explain it wherever the user happened to be.
+
+export const PLAN_LIMIT_EVENT = 'tududi:plan-limit';
+
+export interface PlanLimitDetail {
+    code: 'PLAN_LIMIT_REACHED' | 'FEATURE_NOT_IN_PLAN' | string;
+    error: string;
+    details?: {
+        resource?: string;
+        limit?: number;
+        current?: number;
+        feature?: string;
+        plan?: string;
+    };
+}
+
+export class PlanLimitError extends Error {
+    code: string;
+    details?: PlanLimitDetail['details'];
+
+    constructor(detail: PlanLimitDetail) {
+        super(detail.error || 'Plan limit reached');
+        this.name = 'PlanLimitError';
+        this.code = detail.code;
+        this.details = detail.details;
+    }
+}
+
+export const broadcastPlanLimit = (detail: PlanLimitDetail): void => {
+    window.dispatchEvent(new CustomEvent(PLAN_LIMIT_EVENT, { detail }));
+};
+
+// For the few components that call fetch directly instead of a service
+// wrapper. Returns true when the response was a plan limit (and handled).
+export const handlePlanLimit = async (response: Response): Promise<boolean> => {
+    if (response.status !== 402) return false;
+    let detail: PlanLimitDetail = { code: 'PLAN_LIMIT_REACHED', error: '' };
+    try {
+        detail = await response.clone().json();
+    } catch {
+        // keep the generic detail
+    }
+    broadcastPlanLimit(detail);
+    return true;
+};

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1483,6 +1483,28 @@
     "deleteUser": "Delete User",
     "confirmDeleteUser": "Are you sure you want to delete {{email}}? This action cannot be undone."
   },
+  "billing": {
+    "upgradeTitle": "Upgrade to keep going",
+    "upgradeHint": "Everything you already have stays exactly as it is. Upgrading lifts the limit right away.",
+    "seePlans": "See plans",
+    "limitReached": "Your {{plan}} plan allows {{limit}} {{resource}}. You are at {{current}}.",
+    "featureNotInPlan": "Your {{plan}} plan does not include {{feature}}.",
+    "resource": {
+      "task": "active tasks",
+      "project": "projects",
+      "note": "notes",
+      "storage": "attachment storage",
+      "ai": "AI requests today"
+    },
+    "feature": {
+      "ai": "the AI assistant",
+      "mcp": "MCP integration",
+      "caldav": "CalDAV sync",
+      "telegram": "the Telegram bot",
+      "backups_import": "backup import",
+      "attachments": "attachments"
+    }
+  },
   "shares": {
     "shareProject": "Share project",
     "targetUser": "Invite by email",


### PR DESCRIPTION
## Description

Phase 2 enforcement (follows #1478). With `TUDUDI_HOSTED_MODE=true` the plan catalog now actually applies; with it off every check returns before touching the database, so self-hosted behaviour is unchanged (covered by a dedicated test).

**Creation limits** (402 `PLAN_LIMIT_REACHED` with `details: { resource, limit, current, plan }`):
- Tasks: `POST /api/task` (route middleware, counting subtasks sent along), habits, MCP `create_task`/`create_subtask`, CalDAV PUT of a new task, template cloning (project plus the template's task count).
- Projects and notes: in their services, so MCP goes through the same gate.
- Attachments: `requireFeature('attachments')` before multer, then the storage quota after the access check; an over-quota file is unlinked and answered with 402.

**Feature gates** (402 `FEATURE_NOT_IN_PLAN`): AI generation routes (plus the daily AI budget counted inside the three generate functions), MCP config/tools/protocol, CalDAV (Basic auth on all three auth branches, the `/api/caldav` mount, and the sync scheduler skipping users without the feature), Telegram setup, start-polling, saving a bot token through the profile, and the poller's startup list, backup import/validate/restore.

**Never gated**: reads, edits, completing, deleting, backup export, attachment download.

**Frontend**: `handleAuthResponse` turns a 402 into a `PlanLimitError` and broadcasts `tududi:plan-limit`; `UpgradeModal` (mounted once in `Layout.tsx`) explains the limit or missing feature and links to the billing tab. `utils/planLimits.ts` also offers `handlePlanLimit(response)` for components that call `fetch` directly. New `billing.*` translation keys (en).

## Type of Change

- [x] New feature (adds functionality)
- [x] Documentation/Translation update

## Testing

- New `tests/integration/plan-enforcement.test.js` (hosted on with tiny limits): task limit with 402 details while list/patch/delete keep working and completing frees a slot; subtasks counted; project and note limits; MCP, Telegram setup, profile token, AI, backup restore refused while backup export stays 200; storage quota on upload with the file cleaned up; admin exempt. Hosted off: never 402.
- Suites around every hooked route (tasks, projects, notes, CalDAV protocol and hardening, Telegram, users) pass: 167 tests.
- `npm test`: 1931 passed; the two failures are the known uploads parallel flake (passes alone) and the pre-existing date-boundary recurring test. `npm run frontend:test`: 117 passed. `tsc --noEmit` clean. `npm run lint`: 0 errors.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)