### PR TITLE
feat(billing): Stripe checkout, portal, webhooks, and admin overrides

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -139,6 +139,13 @@ app.use(
     })
 );
 
+// Stripe webhook: raw body, before JSON parsing, sessions, CSRF and rate
+// limiting. The signature is the authentication.
+const billingModule = require('./modules/billing');
+['/api', API_BASE_PATH].forEach((base) => {
+    app.post(`${base}/billing/webhook`, billingModule.webhookHandler());
+});
+
 // Body parsing (skip for CalDAV routes which need raw body access)
 app.use((req, res, next) => {
     const isCalDAVPath =
@@ -422,6 +429,7 @@ const registerApiRoutes = (basePath) => {
     app.use(basePath, telegramModule.routes);
     app.use(basePath, quotesModule.routes);
     app.use(basePath, backupModule.routes);
+    app.use(basePath, billingModule.routes);
     app.use(basePath, searchModule.routes);
     app.use(basePath, viewsModule.routes);
     app.use(basePath, notificationsModule.routes);
@@ -488,6 +496,7 @@ async function startServer() {
         // A hosted instance must not come up half-configured
         const { assertHostedConfig } = require('./config/hostedConfig');
         assertHostedConfig();
+        billingModule.billingService.validateConfig();
 
         const server = app.listen(config.port, config.host, () => {
             console.log(`Server running on port ${config.port}`);

--- a/backend/modules/billing/controller.js
+++ b/backend/modules/billing/controller.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const billingService = require('./service');
+const { logError } = require('../../services/logService');
+const { getAuthenticatedUserId } = require('../../utils/request-utils');
+const { UnauthorizedError, ValidationError } = require('../../shared/errors');
+
+function requireUserId(req) {
+    const userId = getAuthenticatedUserId(req);
+    if (!userId) throw new UnauthorizedError('Authentication required');
+    return userId;
+}
+
+const billingController = {
+    async status(req, res, next) {
+        try {
+            res.json(await billingService.getStatus(requireUserId(req)));
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    catalog(req, res, next) {
+        try {
+            res.json(billingService.getCatalog());
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    async checkout(req, res, next) {
+        try {
+            const interval = req.body?.interval === 'year' ? 'year' : 'month';
+            res.json(
+                await billingService.createCheckoutSession(
+                    requireUserId(req),
+                    interval
+                )
+            );
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    async portal(req, res, next) {
+        try {
+            res.json(
+                await billingService.createPortalSession(requireUserId(req))
+            );
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    async sync(req, res, next) {
+        try {
+            const sessionId = req.body?.session_id;
+            if (sessionId !== undefined && typeof sessionId !== 'string') {
+                throw new ValidationError('session_id must be a string');
+            }
+            res.json(
+                await billingService.syncFromStripe(requireUserId(req), {
+                    sessionId,
+                })
+            );
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    // Raw body, no session, no CSRF: Stripe signs the payload instead.
+    async webhook(req, res) {
+        const signature = req.headers['stripe-signature'];
+        if (!signature) {
+            return res.status(400).json({ error: 'Missing Stripe signature' });
+        }
+        try {
+            const result = await billingService.handleWebhook(
+                req.body,
+                signature
+            );
+            res.json({ received: true, ...result });
+        } catch (error) {
+            if (error.type === 'StripeSignatureVerificationError') {
+                return res
+                    .status(400)
+                    .json({ error: 'Invalid Stripe signature' });
+            }
+            if (error.statusCode === 503) {
+                return res.status(503).json({ error: error.message });
+            }
+            logError('Stripe webhook failed:', error);
+            // 500 makes Stripe retry, which is what we want for our own faults
+            res.status(500).json({ error: 'Webhook processing failed' });
+        }
+    },
+
+    async adminList(req, res, next) {
+        try {
+            res.json(
+                await billingService.adminListAccounts(
+                    requireUserId(req),
+                    req.query
+                )
+            );
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    async adminGet(req, res, next) {
+        try {
+            res.json(
+                await billingService.adminGetAccount(
+                    requireUserId(req),
+                    Number(req.params.userId)
+                )
+            );
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    async adminSetOverride(req, res, next) {
+        try {
+            res.json(
+                await billingService.adminSetOverride(
+                    requireUserId(req),
+                    Number(req.params.userId),
+                    req.body || {}
+                )
+            );
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    async adminClearOverride(req, res, next) {
+        try {
+            res.json(
+                await billingService.adminClearOverride(
+                    requireUserId(req),
+                    Number(req.params.userId)
+                )
+            );
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    async adminSync(req, res, next) {
+        try {
+            res.json(
+                await billingService.adminSync(
+                    requireUserId(req),
+                    Number(req.params.userId)
+                )
+            );
+        } catch (error) {
+            next(error);
+        }
+    },
+};
+
+module.exports = billingController;

--- a/backend/modules/billing/index.js
+++ b/backend/modules/billing/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+const routes = require('./routes');
+const { webhookHandler } = require('./webhookRoutes');
+const billingService = require('./service');
+
+module.exports = { routes, webhookHandler, billingService };

--- a/backend/modules/billing/repository.js
+++ b/backend/modules/billing/repository.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const { Op } = require('sequelize');
+const {
+    BillingAccount,
+    BillingEvent,
+    User,
+    sequelize,
+} = require('../../models');
+
+class BillingRepository {
+    findAccountByUserId(userId) {
+        return BillingAccount.findOne({ where: { user_id: userId } });
+    }
+
+    findAccountByCustomerId(customerId) {
+        return BillingAccount.findOne({
+            where: { stripe_customer_id: customerId },
+        });
+    }
+
+    findAccountBySubscriptionId(subscriptionId) {
+        return BillingAccount.findOne({
+            where: { stripe_subscription_id: subscriptionId },
+        });
+    }
+
+    findUserByUid(uid) {
+        return User.findOne({ where: { uid }, attributes: ['id', 'email'] });
+    }
+
+    findUserById(id) {
+        return User.findByPk(id, {
+            attributes: ['id', 'uid', 'email', 'name'],
+        });
+    }
+
+    // Returns null when the event was seen before (unique violation).
+    async recordEvent(stripeEventId, type) {
+        try {
+            return await BillingEvent.create({
+                stripe_event_id: stripeEventId,
+                type,
+                status: 'received',
+            });
+        } catch (error) {
+            if (error.name === 'SequelizeUniqueConstraintError') return null;
+            throw error;
+        }
+    }
+
+    async listAccounts({ q, page = 1, limit = 50 }) {
+        const offset = (Math.max(1, page) - 1) * limit;
+        const userWhere = q ? { email: { [Op.like]: `%${q}%` } } : undefined;
+        const { rows, count } = await BillingAccount.findAndCountAll({
+            include: [
+                {
+                    model: User,
+                    as: 'User',
+                    attributes: ['id', 'uid', 'email', 'name'],
+                    where: userWhere,
+                    required: true,
+                },
+            ],
+            order: [['updated_at', 'DESC']],
+            limit,
+            offset,
+        });
+        return { rows, count };
+    }
+
+    async summary() {
+        const rows = await BillingAccount.findAll({
+            attributes: [
+                'plan',
+                'status',
+                [sequelize.fn('COUNT', sequelize.col('id')), 'count'],
+            ],
+            group: ['plan', 'status'],
+            raw: true,
+        });
+        return rows.map((r) => ({
+            plan: r.plan,
+            status: r.status,
+            count: Number(r.count),
+        }));
+    }
+}
+
+module.exports = new BillingRepository();

--- a/backend/modules/billing/routes.js
+++ b/backend/modules/billing/routes.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const express = require('express');
+const router = express.Router();
+const controller = require('./controller');
+const entitlements = require('../../services/entitlementsService');
+
+// Every billing route disappears on a self-hosted instance.
+const requireHosted = (req, res, next) => {
+    if (!entitlements.isHostedMode()) {
+        return res.status(404).json({ error: 'Not found' });
+    }
+    next();
+};
+
+router.use(['/billing', '/admin/billing'], requireHosted);
+
+router.get('/billing', controller.status);
+router.get('/billing/plans', controller.catalog);
+router.post('/billing/checkout', controller.checkout);
+router.post('/billing/portal', controller.portal);
+router.post('/billing/sync', controller.sync);
+
+router.get('/admin/billing', controller.adminList);
+router.get('/admin/billing/:userId', controller.adminGet);
+router.put('/admin/billing/:userId/override', controller.adminSetOverride);
+router.delete('/admin/billing/:userId/override', controller.adminClearOverride);
+router.post('/admin/billing/:userId/sync', controller.adminSync);
+
+module.exports = router;

--- a/backend/modules/billing/service.js
+++ b/backend/modules/billing/service.js
@@ -1,0 +1,523 @@
+'use strict';
+
+const { getConfig } = require('../../config/config');
+const { getPlans } = require('../../config/plans');
+const entitlements = require('../../services/entitlementsService');
+const { logError, logInfo } = require('../../services/logService');
+const { isAdmin } = require('../../services/rolesService');
+const repository = require('./repository');
+const {
+    getStripe,
+    isBillingConfigured,
+    configuredPrices,
+} = require('./stripeClient');
+const {
+    subscriptionToAccountFields,
+    deletedSubscriptionFields,
+} = require('./subscriptionMapper');
+const {
+    ValidationError,
+    NotFoundError,
+    ForbiddenError,
+    ConflictError,
+    BillingNotConfiguredError,
+} = require('../../shared/errors');
+
+const ACTIVE_STATUSES = new Set(['active', 'trialing', 'past_due']);
+
+function billingTabUrl(extra = '') {
+    return `${getConfig().frontendUrl}/profile?section=billing${extra}`;
+}
+
+class BillingService {
+    isHosted() {
+        return entitlements.isHostedMode();
+    }
+
+    // What the billing tab shows.
+    async getStatus(userId) {
+        const ent = await entitlements.getEntitlements(userId, {
+            includeUsage: true,
+        });
+        const account = await repository.findAccountByUserId(userId);
+        const prices = configuredPrices();
+        return {
+            ...ent,
+            billing_configured: isBillingConfigured(),
+            checkout_available:
+                isBillingConfigured() &&
+                !!(prices.month || prices.year) &&
+                !ACTIVE_STATUSES.has(account?.status),
+            portal_available:
+                isBillingConfigured() && !!account?.stripe_customer_id,
+            intervals: {
+                month: !!prices.month,
+                year: !!prices.year,
+            },
+            subscription: account
+                ? {
+                      status: account.status,
+                      interval: account.billing_interval,
+                      current_period_end: account.current_period_end,
+                      cancel_at_period_end: account.cancel_at_period_end,
+                      last_payment_failed_at: account.last_payment_failed_at,
+                  }
+                : null,
+        };
+    }
+
+    // Public catalog: names, limits and features, never price ids.
+    getCatalog() {
+        const prices = configuredPrices();
+        return {
+            plans: Object.values(getPlans()).map((plan) => ({
+                key: plan.key,
+                name: plan.name,
+                limits: plan.limits,
+                features: plan.features,
+            })),
+            intervals: { month: !!prices.month, year: !!prices.year },
+            trial_days: getConfig().hosted.trialDays,
+        };
+    }
+
+    async ensureCustomer(user, account) {
+        if (account.stripe_customer_id) return account.stripe_customer_id;
+        const stripe = getStripe();
+        const customer = await stripe.customers.create({
+            email: user.email,
+            name: user.name || undefined,
+            metadata: { user_id: String(user.id), user_uid: user.uid },
+        });
+        await account.update({ stripe_customer_id: customer.id });
+        return customer.id;
+    }
+
+    async createCheckoutSession(userId, interval) {
+        if (!isBillingConfigured()) throw new BillingNotConfiguredError();
+        const prices = configuredPrices();
+        const priceId = prices[interval];
+        if (!priceId) {
+            throw new ValidationError(
+                `No ${interval === 'year' ? 'annual' : 'monthly'} price is configured`
+            );
+        }
+
+        const user = await repository.findUserById(userId);
+        if (!user) throw new NotFoundError('User not found');
+        const account = await entitlements.ensureAccount(userId);
+        if (ACTIVE_STATUSES.has(account.status)) {
+            throw new ConflictError(
+                'You already have a subscription. Use "Manage subscription" to change it.'
+            );
+        }
+
+        const customerId = await this.ensureCustomer(user, account);
+        const stripe = getStripe();
+        const session = await stripe.checkout.sessions.create({
+            mode: 'subscription',
+            customer: customerId,
+            client_reference_id: user.uid,
+            line_items: [{ price: priceId, quantity: 1 }],
+            allow_promotion_codes: true,
+            subscription_data: {
+                metadata: { user_id: String(user.id), user_uid: user.uid },
+            },
+            success_url: billingTabUrl(
+                '&checkout=success&session_id={CHECKOUT_SESSION_ID}'
+            ),
+            cancel_url: billingTabUrl('&checkout=cancel'),
+        });
+
+        return { url: session.url, id: session.id };
+    }
+
+    async createPortalSession(userId) {
+        if (!isBillingConfigured()) throw new BillingNotConfiguredError();
+        const account = await repository.findAccountByUserId(userId);
+        if (!account?.stripe_customer_id) {
+            throw new ValidationError('No billing account to manage yet');
+        }
+        const stripe = getStripe();
+        const session = await stripe.billingPortal.sessions.create({
+            customer: account.stripe_customer_id,
+            return_url: billingTabUrl(),
+        });
+        return { url: session.url };
+    }
+
+    // Re-reads the subscription from Stripe. Used right after checkout (the
+    // redirect can beat the webhook) and by admins.
+    async syncFromStripe(userId, { sessionId } = {}) {
+        if (!isBillingConfigured()) throw new BillingNotConfiguredError();
+        const stripe = getStripe();
+        const account = await entitlements.ensureAccount(userId);
+        if (!account) throw new NotFoundError('User not found');
+
+        let subscriptionId = account.stripe_subscription_id;
+        if (sessionId) {
+            const session = await stripe.checkout.sessions.retrieve(sessionId);
+            const sessionUserUid = session.client_reference_id;
+            const user = await repository.findUserById(userId);
+            if (!user || sessionUserUid !== user.uid) {
+                throw new ForbiddenError(
+                    'That checkout belongs to someone else'
+                );
+            }
+            if (session.subscription) {
+                subscriptionId =
+                    typeof session.subscription === 'string'
+                        ? session.subscription
+                        : session.subscription.id;
+            }
+            if (session.customer && !account.stripe_customer_id) {
+                await account.update({
+                    stripe_customer_id:
+                        typeof session.customer === 'string'
+                            ? session.customer
+                            : session.customer.id,
+                });
+            }
+        }
+
+        if (subscriptionId) {
+            const sub = await stripe.subscriptions.retrieve(subscriptionId);
+            await account.update(subscriptionToAccountFields(sub));
+        }
+        entitlements.invalidate(userId);
+        return this.getStatus(userId);
+    }
+
+    async resolveAccountForEvent(object) {
+        const uid =
+            object.client_reference_id ||
+            object.metadata?.user_uid ||
+            object.subscription_details?.metadata?.user_uid;
+        if (uid) {
+            const user = await repository.findUserByUid(uid);
+            if (user) return entitlements.ensureAccount(user.id);
+        }
+        const userIdMeta =
+            object.metadata?.user_id ||
+            object.subscription_details?.metadata?.user_id;
+        if (userIdMeta && /^\d+$/.test(String(userIdMeta))) {
+            const user = await repository.findUserById(Number(userIdMeta));
+            if (user) return entitlements.ensureAccount(user.id);
+        }
+        const customerId =
+            typeof object.customer === 'string'
+                ? object.customer
+                : object.customer?.id;
+        if (customerId) {
+            const byCustomer =
+                await repository.findAccountByCustomerId(customerId);
+            if (byCustomer) return byCustomer;
+        }
+        if (object.object === 'subscription' && object.id) {
+            return repository.findAccountBySubscriptionId(object.id);
+        }
+        const subId =
+            typeof object.subscription === 'string'
+                ? object.subscription
+                : object.subscription?.id;
+        if (subId) return repository.findAccountBySubscriptionId(subId);
+        return null;
+    }
+
+    async handleWebhook(rawBody, signature) {
+        if (!isBillingConfigured()) throw new BillingNotConfiguredError();
+        const { webhookSecret } = getConfig().hosted.stripe;
+        if (!webhookSecret) throw new BillingNotConfiguredError();
+
+        const stripe = getStripe();
+        const event = stripe.webhooks.constructEvent(
+            rawBody,
+            signature,
+            webhookSecret
+        );
+
+        const record = await repository.recordEvent(event.id, event.type);
+        if (!record) {
+            return { duplicate: true, type: event.type };
+        }
+
+        try {
+            const outcome = await this.applyEvent(event);
+            await record.update({
+                status: outcome.handled ? 'processed' : 'skipped',
+                user_id: outcome.userId || null,
+                processed_at: new Date(),
+            });
+            return { ...outcome, type: event.type };
+        } catch (error) {
+            await record.update({
+                status: 'failed',
+                error: String(error.message || error).slice(0, 2000),
+                processed_at: new Date(),
+            });
+            throw error;
+        }
+    }
+
+    async applyEvent(event) {
+        const object = event.data.object;
+        const stripe = getStripe();
+
+        switch (event.type) {
+            case 'checkout.session.completed': {
+                const account = await this.resolveAccountForEvent(object);
+                if (!account) return { handled: false, reason: 'unknown_user' };
+                const fields = {};
+                if (object.customer) {
+                    fields.stripe_customer_id =
+                        typeof object.customer === 'string'
+                            ? object.customer
+                            : object.customer.id;
+                }
+                if (object.subscription) {
+                    const subId =
+                        typeof object.subscription === 'string'
+                            ? object.subscription
+                            : object.subscription.id;
+                    const sub = await stripe.subscriptions.retrieve(subId);
+                    Object.assign(fields, subscriptionToAccountFields(sub));
+                }
+                await account.update({
+                    ...fields,
+                    last_stripe_event_created: event.created,
+                });
+                entitlements.invalidate(account.user_id);
+                return { handled: true, userId: account.user_id };
+            }
+
+            case 'customer.subscription.created':
+            case 'customer.subscription.updated': {
+                const account = await this.resolveAccountForEvent(object);
+                if (!account) return { handled: false, reason: 'unknown_user' };
+                if (
+                    account.last_stripe_event_created &&
+                    event.created < account.last_stripe_event_created
+                ) {
+                    return { handled: false, reason: 'stale_event' };
+                }
+                await account.update({
+                    ...subscriptionToAccountFields(object),
+                    last_stripe_event_created: event.created,
+                });
+                entitlements.invalidate(account.user_id);
+                return { handled: true, userId: account.user_id };
+            }
+
+            case 'customer.subscription.deleted': {
+                const account = await this.resolveAccountForEvent(object);
+                if (!account) return { handled: false, reason: 'unknown_user' };
+                await account.update({
+                    ...deletedSubscriptionFields(object),
+                    last_stripe_event_created: event.created,
+                });
+                entitlements.invalidate(account.user_id);
+                return { handled: true, userId: account.user_id };
+            }
+
+            case 'invoice.payment_failed': {
+                const account = await this.resolveAccountForEvent(object);
+                if (!account) return { handled: false, reason: 'unknown_user' };
+                await account.update({
+                    status: 'past_due',
+                    last_payment_failed_at: new Date(),
+                });
+                entitlements.invalidate(account.user_id);
+                await this.notifyPaymentFailed(account.user_id);
+                return { handled: true, userId: account.user_id };
+            }
+
+            case 'invoice.paid':
+            case 'invoice.payment_succeeded': {
+                const account = await this.resolveAccountForEvent(object);
+                if (!account) return { handled: false, reason: 'unknown_user' };
+                const fields = { last_payment_failed_at: null };
+                if (account.status === 'past_due') fields.status = 'active';
+                const subId =
+                    typeof object.subscription === 'string'
+                        ? object.subscription
+                        : object.subscription?.id;
+                if (subId) {
+                    try {
+                        const sub = await stripe.subscriptions.retrieve(subId);
+                        Object.assign(fields, subscriptionToAccountFields(sub));
+                    } catch (error) {
+                        logError(
+                            'Could not refresh subscription after payment:',
+                            error
+                        );
+                    }
+                }
+                await account.update(fields);
+                entitlements.invalidate(account.user_id);
+                return { handled: true, userId: account.user_id };
+            }
+
+            default:
+                return { handled: false, reason: 'ignored_type' };
+        }
+    }
+
+    async notifyPaymentFailed(userId) {
+        try {
+            const { Notification } = require('../../models');
+            await Notification.createNotification({
+                userId,
+                type: 'system',
+                level: 'warning',
+                title: 'Payment failed',
+                message:
+                    'Your last payment did not go through. Update your card under Profile > Billing to keep your plan.',
+                data: { section: 'billing' },
+            });
+        } catch (error) {
+            logError('Failed to create payment-failed notification:', error);
+        }
+    }
+
+    // Admin
+
+    async adminListAccounts(requesterId, query) {
+        await this.assertAdmin(requesterId);
+        const [summary, list] = await Promise.all([
+            repository.summary(),
+            repository.listAccounts({
+                q: query.q,
+                page: Number(query.page) || 1,
+                limit: Math.min(Number(query.limit) || 50, 200),
+            }),
+        ]);
+        return {
+            summary,
+            total: list.count,
+            accounts: list.rows.map((a) => ({
+                user_id: a.user_id,
+                email: a.User?.email,
+                name: a.User?.name,
+                plan: a.plan,
+                status: a.status,
+                trial_ends_at: a.trial_ends_at,
+                current_period_end: a.current_period_end,
+                cancel_at_period_end: a.cancel_at_period_end,
+                override_plan: a.override_plan,
+                override_expires_at: a.override_expires_at,
+                stripe_customer_id: a.stripe_customer_id,
+            })),
+        };
+    }
+
+    async adminGetAccount(requesterId, userId) {
+        await this.assertAdmin(requesterId);
+        const user = await repository.findUserById(userId);
+        if (!user) throw new NotFoundError('User not found');
+        const status = await this.getStatus(userId);
+        const account = await repository.findAccountByUserId(userId);
+        return {
+            user: { id: user.id, email: user.email, name: user.name },
+            status,
+            account,
+        };
+    }
+
+    async adminSetOverride(requesterId, userId, { plan, expires_at, reason }) {
+        await this.assertAdmin(requesterId);
+        if (!getPlans()[plan]) {
+            throw new ValidationError(`Unknown plan: ${plan}`);
+        }
+        const account = await entitlements.ensureAccount(userId);
+        if (!account) throw new NotFoundError('User not found');
+        const expires = expires_at ? new Date(expires_at) : null;
+        if (expires_at && Number.isNaN(expires.getTime())) {
+            throw new ValidationError('expires_at must be a valid date');
+        }
+        await account.update({
+            override_plan: plan,
+            override_expires_at: expires,
+            override_reason: reason ? String(reason).slice(0, 255) : null,
+            override_by_user_id: requesterId,
+        });
+        entitlements.invalidate(userId);
+        logInfo(
+            `Admin ${requesterId} set plan override ${plan} for user ${userId}`
+        );
+        return this.adminGetAccount(requesterId, userId);
+    }
+
+    async adminClearOverride(requesterId, userId) {
+        await this.assertAdmin(requesterId);
+        const account = await repository.findAccountByUserId(userId);
+        if (account) {
+            await account.update({
+                override_plan: null,
+                override_expires_at: null,
+                override_reason: null,
+                override_by_user_id: null,
+            });
+        }
+        entitlements.invalidate(userId);
+        return this.adminGetAccount(requesterId, userId);
+    }
+
+    async adminSync(requesterId, userId) {
+        await this.assertAdmin(requesterId);
+        await this.syncFromStripe(userId);
+        return this.adminGetAccount(requesterId, userId);
+    }
+
+    async assertAdmin(requesterId) {
+        if (!(await isAdmin(requesterId))) {
+            throw new ForbiddenError('Forbidden');
+        }
+    }
+
+    // Best effort: a deleted account must not keep being charged.
+    async cancelForDeletedUser(userId) {
+        if (!isBillingConfigured()) return;
+        try {
+            const account = await repository.findAccountByUserId(userId);
+            if (
+                account?.stripe_subscription_id &&
+                ACTIVE_STATUSES.has(account.status)
+            ) {
+                await getStripe().subscriptions.cancel(
+                    account.stripe_subscription_id
+                );
+            }
+            if (account?.stripe_customer_id) {
+                await getStripe().customers.del(account.stripe_customer_id);
+            }
+        } catch (error) {
+            logError(
+                `Failed to cancel Stripe subscription for user ${userId}:`,
+                error
+            );
+        }
+    }
+
+    validateConfig() {
+        if (!this.isHosted()) return [];
+        const problems = [];
+        const { secretKey, webhookSecret } = getConfig().hosted.stripe || {};
+        const prices = configuredPrices();
+        if (!secretKey)
+            problems.push(
+                'STRIPE_SECRET_KEY is not set: checkout is unavailable'
+            );
+        if (secretKey && !webhookSecret)
+            problems.push(
+                'STRIPE_WEBHOOK_SECRET is not set: subscription changes will not be applied'
+            );
+        if (secretKey && !prices.month && !prices.year)
+            problems.push(
+                'No STRIPE_PRICE_PRO_MONTHLY or STRIPE_PRICE_PRO_ANNUAL configured: nothing to sell'
+            );
+        for (const p of problems) logError(`Billing: ${p}`);
+        return problems;
+    }
+}
+
+module.exports = new BillingService();

--- a/backend/modules/billing/stripeClient.js
+++ b/backend/modules/billing/stripeClient.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const { getConfig } = require('../../config/config');
+const { BillingNotConfiguredError } = require('../../shared/errors');
+
+// The Stripe SDK is only loaded when a hosted instance has a key. Self-hosted
+// installs never require it.
+let client = null;
+let clientKey = null;
+
+function stripeConfig() {
+    return getConfig().hosted?.stripe || {};
+}
+
+function isBillingConfigured() {
+    const config = getConfig();
+    return config.hosted?.enabled === true && !!stripeConfig().secretKey;
+}
+
+function getStripe() {
+    const { secretKey, apiVersion } = stripeConfig();
+    if (!isBillingConfigured()) {
+        throw new BillingNotConfiguredError();
+    }
+    if (!client || clientKey !== secretKey) {
+        const Stripe = require('stripe');
+        client = new Stripe(secretKey, apiVersion ? { apiVersion } : {});
+        clientKey = secretKey;
+    }
+    return client;
+}
+
+function configuredPrices() {
+    const prices = stripeConfig().prices || {};
+    return {
+        month: prices.proMonthly || null,
+        year: prices.proAnnual || null,
+    };
+}
+
+// Which plan a Stripe price id belongs to. One paid tier for now.
+function planForPrice(priceId) {
+    const prices = configuredPrices();
+    if (priceId && (priceId === prices.month || priceId === prices.year)) {
+        return 'pro';
+    }
+    return null;
+}
+
+module.exports = {
+    getStripe,
+    isBillingConfigured,
+    configuredPrices,
+    planForPrice,
+    _reset: () => {
+        client = null;
+        clientKey = null;
+    },
+};

--- a/backend/modules/billing/subscriptionMapper.js
+++ b/backend/modules/billing/subscriptionMapper.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { planForPrice } = require('./stripeClient');
+
+const toDate = (epochSeconds) =>
+    epochSeconds ? new Date(epochSeconds * 1000) : null;
+
+// Older Stripe API versions put the period on the subscription; newer ones
+// put it on each item. Read whichever is present.
+function periodOf(sub) {
+    const item = sub.items?.data?.[0];
+    return {
+        start: toDate(item?.current_period_start ?? sub.current_period_start),
+        end: toDate(item?.current_period_end ?? sub.current_period_end),
+    };
+}
+
+// Fields to write on billing_accounts for a Stripe subscription object.
+function subscriptionToAccountFields(sub) {
+    const item = sub.items?.data?.[0];
+    const priceId = item?.price?.id || null;
+    const interval = item?.price?.recurring?.interval || null;
+    const period = periodOf(sub);
+    const plan = planForPrice(priceId);
+
+    return {
+        stripe_subscription_id: sub.id,
+        stripe_customer_id:
+            typeof sub.customer === 'string' ? sub.customer : sub.customer?.id,
+        status: sub.status,
+        plan: plan || 'pro',
+        price_id: priceId,
+        billing_interval: interval,
+        current_period_start: period.start,
+        current_period_end: period.end,
+        trial_ends_at: toDate(sub.trial_end),
+        cancel_at_period_end: !!sub.cancel_at_period_end,
+        canceled_at: toDate(sub.canceled_at),
+    };
+}
+
+function deletedSubscriptionFields(sub) {
+    return {
+        status: 'canceled',
+        plan: 'free',
+        cancel_at_period_end: false,
+        canceled_at: toDate(sub.canceled_at) || new Date(),
+        current_period_end: periodOf(sub).end || undefined,
+    };
+}
+
+module.exports = {
+    subscriptionToAccountFields,
+    deletedSubscriptionFields,
+    periodOf,
+};

--- a/backend/modules/billing/webhookRoutes.js
+++ b/backend/modules/billing/webhookRoutes.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const express = require('express');
+const controller = require('./controller');
+const entitlements = require('../../services/entitlementsService');
+
+// Mounted in app.js before the JSON body parser, sessions, CSRF and the
+// rate limiters: Stripe needs the raw bytes to verify its signature and has
+// no session. 404 on self-hosted instances.
+function webhookHandler() {
+    const raw = express.raw({ type: '*/*', limit: '1mb' });
+    return (req, res, next) => {
+        if (!entitlements.isHostedMode()) {
+            return res.status(404).json({ error: 'Not found' });
+        }
+        raw(req, res, (err) => {
+            if (err) return next(err);
+            controller.webhook(req, res);
+        });
+    };
+}
+
+module.exports = { webhookHandler };

--- a/backend/services/accountErasureService.js
+++ b/backend/services/accountErasureService.js
@@ -59,6 +59,10 @@ async function unlinkWithin(baseDir, relativeOrAbsolute) {
 // Rows go inside one transaction; files are removed only after it commits,
 // so a rollback never leaves rows pointing at missing files.
 async function eraseUserAccount(userId) {
+    // Stop charging before removing the rows that point at Stripe
+    const { billingService } = require('../modules/billing');
+    await billingService.cancelForDeletedUser(userId);
+
     const filesToDelete = [];
     const transaction = await sequelize.transaction();
 

--- a/backend/tests/integration/billing.test.js
+++ b/backend/tests/integration/billing.test.js
@@ -1,0 +1,588 @@
+const request = require('supertest');
+
+// A stand-in for the Stripe SDK. Tests set mockStripe.* to shape answers.
+const mockStripe = {
+    event: null,
+    signatureError: false,
+    subscriptions: {},
+    sessions: {},
+    created: [],
+    cancelled: [],
+};
+jest.mock('stripe', () => {
+    class StripeSignatureVerificationError extends Error {
+        constructor() {
+            super('bad signature');
+            this.type = 'StripeSignatureVerificationError';
+        }
+    }
+    // A plain function, not jest.fn(): the Jest config resets mock
+    // implementations between tests, which would leave `new Stripe()`
+    // returning undefined from the second test on.
+    return function Stripe() {
+        return {
+            webhooks: {
+                constructEvent: (body, sig) => {
+                    if (mockStripe.signatureError || sig !== 'valid') {
+                        throw new StripeSignatureVerificationError();
+                    }
+                    return JSON.parse(body.toString());
+                },
+            },
+            customers: {
+                create: async (params) => {
+                    const customer = {
+                        id: `cus_${mockStripe.created.length + 1}`,
+                        ...params,
+                    };
+                    mockStripe.created.push(customer);
+                    return customer;
+                },
+                del: async (id) => ({ id, deleted: true }),
+            },
+            subscriptions: {
+                retrieve: async (id) => {
+                    if (!mockStripe.subscriptions[id])
+                        throw new Error(`no sub ${id}`);
+                    return mockStripe.subscriptions[id];
+                },
+                cancel: async (id) => {
+                    mockStripe.cancelled.push(id);
+                    return { id, status: 'canceled' };
+                },
+            },
+            checkout: {
+                sessions: {
+                    create: async (params) => ({
+                        id: 'cs_test_1',
+                        url: 'https://checkout.stripe.test/cs_test_1',
+                        ...params,
+                    }),
+                    retrieve: async (id) => mockStripe.sessions[id],
+                },
+            },
+            billingPortal: {
+                sessions: {
+                    create: async () => ({
+                        url: 'https://portal.stripe.test/x',
+                    }),
+                },
+            },
+        };
+    };
+});
+
+const app = require('../../app');
+const { getConfig } = require('../../config/config');
+const { BillingAccount, BillingEvent, Role, User } = require('../../models');
+const entitlements = require('../../services/entitlementsService');
+const stripeClient = require('../../modules/billing/stripeClient');
+const { createTestUser } = require('../helpers/testUtils');
+
+const config = getConfig();
+const PRICE_MONTH = 'price_month';
+const PRICE_YEAR = 'price_year';
+
+const login = async (user) => {
+    const agent = request.agent(app);
+    await agent
+        .post('/api/login')
+        .send({ email: user.email, password: 'password123' });
+    return agent;
+};
+
+const subscriptionFixture = (overrides = {}) => ({
+    id: 'sub_1',
+    object: 'subscription',
+    customer: 'cus_1',
+    status: 'active',
+    cancel_at_period_end: false,
+    canceled_at: null,
+    trial_end: null,
+    items: {
+        data: [
+            {
+                price: { id: PRICE_MONTH, recurring: { interval: 'month' } },
+                current_period_start: 1_800_000_000,
+                current_period_end: 1_802_592_000,
+            },
+        ],
+    },
+    metadata: {},
+    ...overrides,
+});
+
+const postEvent = (event, sig = 'valid') =>
+    request(app)
+        .post('/api/billing/webhook')
+        .set('stripe-signature', sig)
+        .set('content-type', 'application/json')
+        .send(JSON.stringify(event));
+
+function enableHostedBilling() {
+    config.hosted.enabled = true;
+    config.hosted.trialDays = 0;
+    config.hosted.stripe.secretKey = 'sk_test_x';
+    config.hosted.stripe.webhookSecret = 'whsec_x';
+    config.hosted.stripe.prices.proMonthly = PRICE_MONTH;
+    config.hosted.stripe.prices.proAnnual = PRICE_YEAR;
+    stripeClient._reset();
+    entitlements.invalidate();
+}
+
+function disableHostedBilling() {
+    config.hosted.enabled = false;
+    config.hosted.trialDays = 14;
+    config.hosted.stripe.secretKey = undefined;
+    config.hosted.stripe.webhookSecret = undefined;
+    config.hosted.stripe.prices.proMonthly = undefined;
+    config.hosted.stripe.prices.proAnnual = undefined;
+    stripeClient._reset();
+    entitlements.invalidate();
+}
+
+describe('Billing with hosted mode off', () => {
+    it('hides every billing route, webhook included', async () => {
+        const user = await createTestUser({
+            email: `off_${Date.now()}@example.com`,
+        });
+        const agent = await login(user);
+        expect((await agent.get('/api/billing')).status).toBe(404);
+        expect(
+            (await agent.post('/api/billing/checkout').send({})).status
+        ).toBe(404);
+        expect(
+            (
+                await postEvent({
+                    id: 'evt_off',
+                    type: 'x',
+                    data: { object: {} },
+                })
+            ).status
+        ).toBe(404);
+        expect((await agent.get('/api/admin/billing')).status).toBe(404);
+    });
+});
+
+describe('Billing with hosted mode on', () => {
+    let user, agent;
+
+    beforeEach(async () => {
+        enableHostedBilling();
+        mockStripe.signatureError = false;
+        mockStripe.subscriptions = {};
+        mockStripe.sessions = {};
+        mockStripe.created = [];
+        mockStripe.cancelled = [];
+        user = await createTestUser({
+            email: `bill_${Date.now()}@example.com`,
+        });
+        agent = await login(user);
+    });
+
+    afterEach(disableHostedBilling);
+
+    describe('status and catalog', () => {
+        it('reports the free plan, usage, and what the UI may offer', async () => {
+            const res = await agent.get('/api/billing');
+            expect(res.status).toBe(200);
+            expect(res.body.plan).toBe('free');
+            expect(res.body.billing_configured).toBe(true);
+            expect(res.body.checkout_available).toBe(true);
+            expect(res.body.portal_available).toBe(false);
+            expect(res.body.intervals).toEqual({ month: true, year: true });
+            expect(res.body.usage.tasks).toBe(0);
+        });
+
+        it('publishes the catalog without price ids', async () => {
+            const res = await agent.get('/api/billing/plans');
+            expect(res.status).toBe(200);
+            expect(res.body.plans.map((p) => p.key)).toEqual(['free', 'pro']);
+            expect(JSON.stringify(res.body)).not.toContain(PRICE_MONTH);
+        });
+    });
+
+    describe('checkout and portal', () => {
+        it('creates a customer and a checkout session for the chosen interval', async () => {
+            const res = await agent
+                .post('/api/billing/checkout')
+                .send({ interval: 'year' });
+            expect(res.status).toBe(200);
+            expect(res.body.url).toMatch(/^https:\/\/checkout/);
+            expect(mockStripe.created).toHaveLength(1);
+            expect(mockStripe.created[0].email).toBe(user.email);
+
+            const account = await BillingAccount.findOne({
+                where: { user_id: user.id },
+            });
+            expect(account.stripe_customer_id).toBe('cus_1');
+        });
+
+        it('refuses checkout while a subscription is active', async () => {
+            await BillingAccount.create({
+                user_id: user.id,
+                status: 'active',
+                plan: 'pro',
+                stripe_customer_id: 'cus_9',
+            });
+            const res = await agent
+                .post('/api/billing/checkout')
+                .send({ interval: 'month' });
+            expect(res.status).toBe(409);
+        });
+
+        it('opens the portal only once a customer exists', async () => {
+            const before = await agent.post('/api/billing/portal');
+            expect(before.status).toBe(400);
+
+            await BillingAccount.create({
+                user_id: user.id,
+                stripe_customer_id: 'cus_2',
+            });
+            const after = await agent.post('/api/billing/portal');
+            expect(after.status).toBe(200);
+            expect(after.body.url).toMatch(/^https:\/\/portal/);
+        });
+
+        it('answers 503 when Stripe is not configured', async () => {
+            config.hosted.stripe.secretKey = undefined;
+            stripeClient._reset();
+            const res = await agent
+                .post('/api/billing/checkout')
+                .send({ interval: 'month' });
+            expect(res.status).toBe(503);
+            expect(res.body.code).toBe('BILLING_NOT_CONFIGURED');
+        });
+    });
+
+    describe('sync after checkout', () => {
+        it('reads the subscription from the checkout session and refuses other users sessions', async () => {
+            await BillingAccount.create({
+                user_id: user.id,
+                stripe_customer_id: 'cus_1',
+            });
+            mockStripe.sessions.cs_1 = {
+                id: 'cs_1',
+                client_reference_id: user.uid,
+                customer: 'cus_1',
+                subscription: 'sub_1',
+            };
+            mockStripe.subscriptions.sub_1 = subscriptionFixture();
+
+            const res = await agent
+                .post('/api/billing/sync')
+                .send({ session_id: 'cs_1' });
+            expect(res.status).toBe(200);
+            expect(res.body.plan).toBe('pro');
+            expect(res.body.subscription.status).toBe('active');
+
+            const other = await createTestUser({
+                email: `other_${Date.now()}@example.com`,
+            });
+            const otherAgent = await login(other);
+            const stolen = await otherAgent
+                .post('/api/billing/sync')
+                .send({ session_id: 'cs_1' });
+            expect(stolen.status).toBe(403);
+        });
+    });
+
+    describe('webhooks', () => {
+        it('rejects a bad signature', async () => {
+            const res = await postEvent(
+                {
+                    id: 'evt_sig',
+                    type: 'customer.subscription.updated',
+                    data: { object: {} },
+                },
+                'wrong'
+            );
+            expect(res.status).toBe(400);
+            expect(await BillingEvent.count()).toBe(0);
+        });
+
+        it('applies checkout.session.completed once, even when redelivered', async () => {
+            mockStripe.subscriptions.sub_1 = subscriptionFixture();
+            const event = {
+                id: 'evt_1',
+                type: 'checkout.session.completed',
+                created: 1_800_000_100,
+                data: {
+                    object: {
+                        object: 'checkout.session',
+                        client_reference_id: user.uid,
+                        customer: 'cus_1',
+                        subscription: 'sub_1',
+                    },
+                },
+            };
+
+            const first = await postEvent(event);
+            expect(first.status).toBe(200);
+            expect(first.body.handled).toBe(true);
+
+            const again = await postEvent(event);
+            expect(again.status).toBe(200);
+            expect(again.body.duplicate).toBe(true);
+
+            expect(
+                await BillingEvent.count({
+                    where: { stripe_event_id: 'evt_1' },
+                })
+            ).toBe(1);
+            const account = await BillingAccount.findOne({
+                where: { user_id: user.id },
+            });
+            expect(account.status).toBe('active');
+            expect(account.plan).toBe('pro');
+            expect(account.billing_interval).toBe('month');
+            expect(account.stripe_subscription_id).toBe('sub_1');
+            expect(new Date(account.current_period_end).getTime()).toBe(
+                1_802_592_000 * 1000
+            );
+
+            const status = await agent.get('/api/billing');
+            expect(status.body.plan).toBe('pro');
+            expect(status.body.reason).toBe('subscription');
+        });
+
+        it('maps subscription updates, ignores stale ones, and handles deletion', async () => {
+            await BillingAccount.create({
+                user_id: user.id,
+                stripe_customer_id: 'cus_1',
+                stripe_subscription_id: 'sub_1',
+                status: 'active',
+                plan: 'pro',
+            });
+
+            const updated = await postEvent({
+                id: 'evt_u1',
+                type: 'customer.subscription.updated',
+                created: 2000,
+                data: {
+                    object: subscriptionFixture({
+                        cancel_at_period_end: true,
+                        status: 'active',
+                    }),
+                },
+            });
+            expect(updated.body.handled).toBe(true);
+            let account = await BillingAccount.findOne({
+                where: { user_id: user.id },
+            });
+            expect(account.cancel_at_period_end).toBe(true);
+
+            const stale = await postEvent({
+                id: 'evt_u0',
+                type: 'customer.subscription.updated',
+                created: 1000,
+                data: {
+                    object: subscriptionFixture({
+                        cancel_at_period_end: false,
+                    }),
+                },
+            });
+            expect(stale.body.handled).toBe(false);
+            expect(stale.body.reason).toBe('stale_event');
+            account = await BillingAccount.findOne({
+                where: { user_id: user.id },
+            });
+            expect(account.cancel_at_period_end).toBe(true);
+
+            const deleted = await postEvent({
+                id: 'evt_d1',
+                type: 'customer.subscription.deleted',
+                created: 3000,
+                data: {
+                    object: subscriptionFixture({
+                        status: 'canceled',
+                        canceled_at: 3000,
+                    }),
+                },
+            });
+            expect(deleted.body.handled).toBe(true);
+            account = await BillingAccount.findOne({
+                where: { user_id: user.id },
+            });
+            expect(account.status).toBe('canceled');
+            expect(account.plan).toBe('free');
+
+            const status = await agent.get('/api/billing');
+            expect(status.body.plan).toBe('free');
+        });
+
+        it('marks payment failures past_due, notifies, and recovers on payment', async () => {
+            await BillingAccount.create({
+                user_id: user.id,
+                stripe_customer_id: 'cus_1',
+                stripe_subscription_id: 'sub_1',
+                status: 'active',
+                plan: 'pro',
+                current_period_end: new Date(Date.now() + 86_400_000),
+            });
+            mockStripe.subscriptions.sub_1 = subscriptionFixture();
+
+            const failed = await postEvent({
+                id: 'evt_f1',
+                type: 'invoice.payment_failed',
+                created: 4000,
+                data: {
+                    object: {
+                        object: 'invoice',
+                        customer: 'cus_1',
+                        subscription: 'sub_1',
+                    },
+                },
+            });
+            expect(failed.body.handled).toBe(true);
+            let account = await BillingAccount.findOne({
+                where: { user_id: user.id },
+            });
+            expect(account.status).toBe('past_due');
+            expect(account.last_payment_failed_at).not.toBeNull();
+
+            const { Notification } = require('../../models');
+            const note = await Notification.findOne({
+                where: { user_id: user.id, level: 'warning' },
+            });
+            expect(note).not.toBeNull();
+
+            // still pro inside the grace window
+            const during = await agent.get('/api/billing');
+            expect(during.body.plan).toBe('pro');
+            expect(during.body.reason).toBe('grace');
+
+            const paid = await postEvent({
+                id: 'evt_p1',
+                type: 'invoice.paid',
+                created: 5000,
+                data: {
+                    object: {
+                        object: 'invoice',
+                        customer: 'cus_1',
+                        subscription: 'sub_1',
+                    },
+                },
+            });
+            expect(paid.body.handled).toBe(true);
+            account = await BillingAccount.findOne({
+                where: { user_id: user.id },
+            });
+            expect(account.status).toBe('active');
+            expect(account.last_payment_failed_at).toBeNull();
+        });
+
+        it('skips events for unknown customers and unknown types without failing', async () => {
+            const unknown = await postEvent({
+                id: 'evt_x1',
+                type: 'customer.subscription.updated',
+                created: 1,
+                data: {
+                    object: subscriptionFixture({
+                        customer: 'cus_nobody',
+                        id: 'sub_nobody',
+                    }),
+                },
+            });
+            expect(unknown.status).toBe(200);
+            expect(unknown.body.handled).toBe(false);
+            expect(unknown.body.reason).toBe('unknown_user');
+
+            const ignored = await postEvent({
+                id: 'evt_x2',
+                type: 'charge.refunded',
+                created: 1,
+                data: { object: {} },
+            });
+            expect(ignored.status).toBe(200);
+            expect(ignored.body.reason).toBe('ignored_type');
+            const row = await BillingEvent.findOne({
+                where: { stripe_event_id: 'evt_x2' },
+            });
+            expect(row.status).toBe('skipped');
+        });
+    });
+
+    describe('admin', () => {
+        let admin, adminAgent;
+
+        beforeEach(async () => {
+            admin = await createTestUser({
+                email: `admin_${Date.now()}@example.com`,
+            });
+            await Role.update(
+                { is_admin: true },
+                { where: { user_id: admin.id } }
+            );
+            adminAgent = await login(admin);
+        });
+
+        it('is refused for regular users', async () => {
+            expect((await agent.get('/api/admin/billing')).status).toBe(403);
+            expect(
+                (
+                    await agent
+                        .put(`/api/admin/billing/${user.id}/override`)
+                        .send({ plan: 'pro' })
+                ).status
+            ).toBe(403);
+        });
+
+        it('lists accounts, comps a user, and clears the override', async () => {
+            await agent.get('/api/billing'); // creates the row
+
+            const list = await adminAgent.get('/api/admin/billing');
+            expect(list.status).toBe(200);
+            expect(
+                list.body.accounts.find((a) => a.user_id === user.id)
+            ).toBeDefined();
+            expect(Array.isArray(list.body.summary)).toBe(true);
+
+            const comp = await adminAgent
+                .put(`/api/admin/billing/${user.id}/override`)
+                .send({
+                    plan: 'pro',
+                    reason: 'beta tester',
+                    expires_at: '2099-01-01',
+                });
+            expect(comp.status).toBe(200);
+            expect(comp.body.status.plan).toBe('pro');
+            expect(comp.body.status.reason).toBe('override');
+
+            const mine = await agent.get('/api/billing');
+            expect(mine.body.plan).toBe('pro');
+
+            const bad = await adminAgent
+                .put(`/api/admin/billing/${user.id}/override`)
+                .send({ plan: 'platinum' });
+            expect(bad.status).toBe(400);
+
+            const clear = await adminAgent.delete(
+                `/api/admin/billing/${user.id}/override`
+            );
+            expect(clear.status).toBe(200);
+            expect(clear.body.status.plan).toBe('free');
+        });
+    });
+
+    describe('account deletion', () => {
+        it('cancels the Stripe subscription before erasing the account', async () => {
+            await BillingAccount.create({
+                user_id: user.id,
+                stripe_customer_id: 'cus_1',
+                stripe_subscription_id: 'sub_1',
+                status: 'active',
+                plan: 'pro',
+            });
+            const res = await agent
+                .delete('/api/profile')
+                .send({ password: 'password123' });
+            expect(res.status).toBe(204);
+            expect(mockStripe.cancelled).toEqual(['sub_1']);
+            expect(await User.findByPk(user.id)).toBeNull();
+            expect(
+                await BillingAccount.count({ where: { user_id: user.id } })
+            ).toBe(0);
+        });
+    });
+});

--- a/docs/17-hosted-mode.md
+++ b/docs/17-hosted-mode.md
@@ -71,3 +71,46 @@ budgets (AI requests) use the `usage_counters` table.
 - `usage_counters`: `(user, metric, day)` counters.
 
 All three are removed with the account by `services/accountErasureService.js`.
+
+## Stripe
+
+Billing is Stripe Checkout plus the Customer Portal; tududi never sees card
+details. Set:
+
+| Variable | Meaning |
+|---|---|
+| `STRIPE_SECRET_KEY` | secret API key (`sk_live_...`) |
+| `STRIPE_WEBHOOK_SECRET` | signing secret of the webhook endpoint below |
+| `STRIPE_PRICE_PRO_MONTHLY` | price id of the monthly Pro price |
+| `STRIPE_PRICE_PRO_ANNUAL` | price id of the annual Pro price |
+
+Point a Stripe webhook at `https://your-host/api/billing/webhook` with the
+events `checkout.session.completed`, `customer.subscription.created`,
+`customer.subscription.updated`, `customer.subscription.deleted`,
+`invoice.paid` and `invoice.payment_failed`. The endpoint reads the raw
+body, verifies the signature, records every event id in `billing_events`
+(a redelivered event is acknowledged and not applied twice), and answers
+500 on an internal fault so Stripe retries.
+
+Endpoints (all 404 on a self-hosted instance):
+
+| Route | Purpose |
+|---|---|
+| `GET /api/billing` | plan, status, usage, and what the UI may offer |
+| `GET /api/billing/plans` | the catalog, without price ids |
+| `POST /api/billing/checkout` `{ interval: "month" \| "year" }` | Checkout session URL |
+| `POST /api/billing/portal` | Customer Portal URL |
+| `POST /api/billing/sync` `{ session_id? }` | re-read the subscription from Stripe (the checkout redirect can beat the webhook) |
+| `GET /api/admin/billing` | overview and account list (admin) |
+| `PUT /api/admin/billing/:userId/override` `{ plan, expires_at?, reason? }` | comp or restrict an account (admin) |
+| `DELETE /api/admin/billing/:userId/override` | remove the override (admin) |
+| `POST /api/admin/billing/:userId/sync` | force a re-read from Stripe (admin) |
+
+After a failed payment the account is `past_due`: Pro continues for
+`TUDUDI_PAST_DUE_GRACE_DAYS` past the period end while Stripe retries, and
+the user gets an in-app warning. A cancelled subscription drops to Free at
+once but nothing is deleted or hidden. Deleting an account cancels its
+subscription and removes the Stripe customer.
+
+Local testing: `stripe listen --forward-to localhost:3002/api/billing/webhook`
+and `stripe trigger checkout.session.completed`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "sequelize-cli": "~6.6.2",
         "slugify": "^1.6.6",
         "sqlite3": "^6.0.1",
+        "stripe": "^18.5.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
         "umzug": "^2.3.0",
@@ -20421,6 +20422,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/stripe": {
+      "version": "18.5.0",
+      "resolved": "https://registry.npmjs.org/stripe/-/stripe-18.5.0.tgz",
+      "integrity": "sha512-Hp+wFiEQtCB0LlNgcFh5uVyKznpDjzyUZ+CNVEf+I3fhlYvh7rZruIg+jOwzJRCpy0ZTPMjlzm7J2/M2N6d+DA==",
+      "license": "MIT",
+      "dependencies": {
+        "qs": "^6.11.0"
+      },
+      "engines": {
+        "node": ">=12.*"
+      },
+      "peerDependencies": {
+        "@types/node": ">=12.x.x"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/style-loader": {

--- a/package.json
+++ b/package.json
@@ -187,6 +187,7 @@
     "sequelize-cli": "~6.6.2",
     "slugify": "^1.6.6",
     "sqlite3": "^6.0.1",
+    "stripe": "^18.5.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1",
     "umzug": "^2.3.0",


### PR DESCRIPTION
## Description

Phase 2 Stripe integration (follows #1479; reopened as #1480 was auto-closed when its base branch was deleted). `backend/modules/billing` wires hosted mode to Stripe Checkout and the Customer Portal, so tududi never handles card details. Every route answers 404 on a self-hosted instance and the `stripe` SDK is only loaded when a key is configured.

**User-facing endpoints**
- `GET /api/billing`: plan, status, reason, usage, subscription summary, and what the UI may offer (`checkout_available`, `portal_available`, configured intervals).
- `GET /api/billing/plans`: the catalog without price ids.
- `POST /api/billing/checkout { interval }`: creates the Stripe customer on first use (tagged with the user id and uid) and a subscription Checkout session with promotion codes allowed; 409 while a subscription is active.
- `POST /api/billing/portal`: Customer Portal session.
- `POST /api/billing/sync { session_id? }`: re-reads the subscription from Stripe, because the checkout redirect can beat the webhook; a session belonging to another user is refused.

**Webhook** `POST /api/billing/webhook`: mounted in `app.js` before the JSON parser, sessions, CSRF and rate limiters; the Stripe signature is the authentication. Every event id goes into `billing_events` first, so a redelivered event is acknowledged once. Handled: `checkout.session.completed`, `customer.subscription.created/updated` (stale events ignored by `event.created`), `customer.subscription.deleted` (drops to Free), `invoice.payment_failed` (`past_due` plus an in-app warning), `invoice.paid` (back to `active`). Unknown customers and unhandled types are recorded as skipped with 200; our own faults answer 500 so Stripe retries. `subscriptionMapper.js` reads the billing period from either the subscription or its item, covering both Stripe API generations.

**Admin**: `GET /api/admin/billing` (summary by plan/status plus a searchable list), `GET/PUT/DELETE /api/admin/billing/:userId/override` (comp or restrict with an optional expiry and reason), `POST .../sync`.

**Erasure**: deleting an account cancels its subscription and removes the Stripe customer before the rows go.

Boot logs a warning when hosted mode is on but a Stripe key, webhook secret, or price is missing. Docs: Stripe section in `docs/17-hosted-mode.md`.

## Type of Change

- [x] New feature (adds functionality)
- [x] Documentation/Translation update

## Testing

- New `tests/integration/billing.test.js` with a mocked Stripe SDK (16 tests): hosted off hides every route including the webhook; status and catalog; checkout creates the customer and session, 409 when active, 503 when unconfigured; portal only with a customer; sync from a checkout session and 403 for someone else's session; bad signature 400; `checkout.session.completed` applied once on redelivery with the mapped fields; subscription updates, stale-event guard, deletion; payment failure to `past_due` with notification and grace, recovery on `invoice.paid`; unknown customer and ignored type recorded as skipped; admin list/override/clear with 403 for non-admins; account deletion cancels the subscription.
- `npm test`: 1944 passed; the five failures are the known parallel flakes (all pass alone) and the pre-existing date-boundary recurring tests. `tsc --noEmit` clean. `npm run lint`: 0 errors.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
