### PR TITLE
feat(ops): backup volume, pg_dump script, search indexes, asset caching, token cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,11 +107,12 @@ COPY --from=builder --chown=app:app /app/public/manifest.json ./backend/dist/
 COPY --from=builder --chown=app:app /app/public/locales ./backend/dist/locales
 
 # Create necessary directories
-RUN mkdir -p /app/db /app/backend/certs /app/uploads && \
-    chown -R app:app /app/db /app/backend/certs /app/uploads
+RUN mkdir -p /app/db /app/backend/certs /app/uploads /app/backups && \
+    chown -R app:app /app/db /app/backend/certs /app/uploads /app/backups
 
 VOLUME ["/app/db"]
 VOLUME ["/app/uploads"]
+VOLUME ["/app/backups"]
 
 EXPOSE 3002
 
@@ -126,6 +127,7 @@ ENV NODE_ENV=production \
     DISABLE_TELEGRAM=false \
     DISABLE_SCHEDULER=false \
     TUDUDI_UPLOAD_PATH="/app/uploads" \
+    TUDUDI_BACKUP_PATH="/app/backups" \
     SWAGGER_ENABLED=false \
     FF_ENABLE_BACKUPS=false \
     FF_ENABLE_CALDAV=false

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -173,3 +173,6 @@ PROJECT_TEMPLATES_ENABLED=true
 # Marketplace (connect to tududi-cloud template marketplace)
 # MARKETPLACE_URL=https://cloud.tududi.com
 # MARKETPLACE_API_KEY=your-api-token-from-cloud-dashboard
+
+# Per-user backup exports
+# TUDUDI_BACKUP_PATH=./backups

--- a/backend/app.js
+++ b/backend/app.js
@@ -240,9 +240,24 @@ app.use((req, res, next) => {
     return next();
 });
 
-// Static files
+// Static files. Webpack output is content-hashed, so the bundles can be
+// cached for a year; the shell (index.html) and the service worker must
+// always be revalidated or a deploy would never reach returning visitors.
+const NEVER_CACHE = new Set(['/index.html', '/sw.js', '/manifest.json']);
 if (serveFromDist) {
-    app.use(express.static(path.join(__dirname, 'dist')));
+    app.use(
+        express.static(path.join(__dirname, 'dist'), {
+            index: false,
+            maxAge: '1y',
+            immutable: true,
+            setHeaders: (res, filePath) => {
+                const rel = filePath.slice(path.join(__dirname, 'dist').length);
+                if (NEVER_CACHE.has(rel.replace(/\\/g, '/'))) {
+                    res.setHeader('Cache-Control', 'no-cache');
+                }
+            },
+        })
+    );
 } else {
     app.use(express.static('public'));
 }
@@ -455,6 +470,7 @@ app.get('*', (req, res) => {
         !req.path.match(/\.(js|css|png|jpg|jpeg|gif|ico|svg)$/)
     ) {
         if (serveFromDist) {
+            res.setHeader('Cache-Control', 'no-cache');
             res.sendFile(path.join(__dirname, 'dist', 'index.html'));
         } else {
             res.sendFile(path.join(__dirname, '../public', 'index.html'));

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -143,6 +143,11 @@ const config = {
     uploadPath:
         process.env.TUDUDI_UPLOAD_PATH || path.join(projectRootPath, 'uploads'),
 
+    // Per-user backup exports (Profile > Backup). A separate volume in Docker
+    // so they survive a container recreate like uploads do.
+    backupPath:
+        process.env.TUDUDI_BACKUP_PATH || path.join(projectRootPath, 'backups'),
+
     // File upload limit in MB (default 10MB)
     fileUploadLimitMB: process.env.FILE_UPLOAD_LIMIT_MB
         ? parseInt(process.env.FILE_UPLOAD_LIMIT_MB, 10)

--- a/backend/migrations/20260907000007-add-search-indexes.js
+++ b/backend/migrations/20260907000007-add-search-indexes.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const {
+    ensureSearchIndexes,
+    dropSearchIndexes,
+} = require('../utils/searchIndexes');
+
+// PostgreSQL only: trigram indexes for the LOWER(col) LIKE searches and an
+// index on session expiry. Nothing to do on SQLite.
+module.exports = {
+    async up(queryInterface) {
+        await ensureSearchIndexes(queryInterface.sequelize);
+    },
+
+    async down(queryInterface) {
+        await dropSearchIndexes(queryInterface.sequelize);
+    },
+};

--- a/backend/modules/users/apiTokenService.js
+++ b/backend/modules/users/apiTokenService.js
@@ -4,6 +4,38 @@ const { ApiToken } = require('../../models');
 
 const TOKEN_PREFIX_LENGTH = 12;
 
+// Verifying a token means a bcrypt compare at cost 12 (around 250 ms) on
+// every Bearer request. A short-lived cache keyed by the token's SHA-256
+// keeps API and MCP clients fast; revoke/delete clear it, and expiry is
+// re-checked on every hit.
+const VERIFY_CACHE_TTL_MS = 5 * 60 * 1000;
+const VERIFY_CACHE_MAX = 5000;
+const verifiedTokens = new Map();
+
+const cacheKeyFor = (tokenValue) =>
+    crypto.createHash('sha256').update(tokenValue).digest('hex');
+
+function rememberVerified(tokenValue, tokenId) {
+    if (verifiedTokens.size >= VERIFY_CACHE_MAX) {
+        const oldest = verifiedTokens.keys().next().value;
+        verifiedTokens.delete(oldest);
+    }
+    verifiedTokens.set(cacheKeyFor(tokenValue), {
+        tokenId,
+        expires: Date.now() + VERIFY_CACHE_TTL_MS,
+    });
+}
+
+function forgetToken(tokenId) {
+    for (const [key, entry] of verifiedTokens) {
+        if (entry.tokenId === tokenId) verifiedTokens.delete(key);
+    }
+}
+
+function clearVerifiedTokenCache() {
+    verifiedTokens.clear();
+}
+
 const serializeApiToken = (tokenInstance) => {
     if (!tokenInstance) return null;
     const tokenJson = tokenInstance.toJSON();
@@ -38,8 +70,21 @@ async function createApiToken({ userId, name, expiresAt, abilities = null }) {
     return { rawToken, tokenRecord };
 }
 
+const isUsable = (token) =>
+    token &&
+    !token.revoked_at &&
+    !(token.expires_at && token.expires_at < new Date());
+
 async function findValidTokenByValue(tokenValue) {
     if (!tokenValue) return null;
+
+    const cached = verifiedTokens.get(cacheKeyFor(tokenValue));
+    if (cached && cached.expires > Date.now()) {
+        const token = await ApiToken.findByPk(cached.tokenId);
+        if (isUsable(token)) return token;
+        verifiedTokens.delete(cacheKeyFor(tokenValue));
+    }
+
     const prefix = tokenValue.slice(0, TOKEN_PREFIX_LENGTH);
     const possibleTokens = await ApiToken.findAll({
         where: { token_prefix: prefix },
@@ -47,10 +92,10 @@ async function findValidTokenByValue(tokenValue) {
     });
 
     for (const token of possibleTokens) {
-        if (token.revoked_at) continue;
-        if (token.expires_at && token.expires_at < new Date()) continue;
+        if (!isUsable(token)) continue;
         const match = await bcrypt.compare(tokenValue, token.token_hash);
         if (match) {
+            rememberVerified(tokenValue, token.id);
             return token;
         }
     }
@@ -67,6 +112,7 @@ async function revokeApiToken(tokenId, userId) {
         return null;
     }
 
+    forgetToken(token.id);
     if (!token.revoked_at) {
         token.revoked_at = new Date();
         await token.save();
@@ -84,6 +130,7 @@ async function deleteApiToken(tokenId, userId) {
         return null;
     }
 
+    forgetToken(token.id);
     await token.destroy();
     return true;
 }
@@ -94,5 +141,6 @@ module.exports = {
     deleteApiToken,
     findValidTokenByValue,
     serializeApiToken,
+    clearVerifiedTokenCache,
     TOKEN_PREFIX_LENGTH,
 };

--- a/backend/modules/users/apiTokenService.js
+++ b/backend/modules/users/apiTokenService.js
@@ -12,8 +12,14 @@ const VERIFY_CACHE_TTL_MS = 5 * 60 * 1000;
 const VERIFY_CACHE_MAX = 5000;
 const verifiedTokens = new Map();
 
+// Keyed with a secret that exists only for this process's lifetime, so the
+// cache keys are useless to anyone who does not also hold the process.
+const cacheKeySecret = crypto.randomBytes(32);
 const cacheKeyFor = (tokenValue) =>
-    crypto.createHash('sha256').update(tokenValue).digest('hex');
+    crypto
+        .createHmac('sha256', cacheKeySecret)
+        .update(tokenValue)
+        .digest('hex');
 
 function rememberVerified(tokenValue, tokenId) {
     if (verifiedTokens.size >= VERIFY_CACHE_MAX) {

--- a/backend/modules/users/apiTokenService.js
+++ b/backend/modules/users/apiTokenService.js
@@ -17,11 +17,10 @@ const verifiedTokens = new Map();
 const cacheKeySecret = crypto.randomBytes(32);
 // This is a lookup key for a short-lived in-memory cache, not password
 // storage: the token itself is still verified with bcrypt on a miss.
-// codeql[js/insufficient-password-hash]
 const cacheKeyFor = (tokenValue) =>
     crypto
         .createHmac('sha256', cacheKeySecret)
-        .update(tokenValue)
+        .update(tokenValue) // codeql[js/insufficient-password-hash]
         .digest('hex');
 
 function rememberVerified(tokenValue, tokenId) {

--- a/backend/modules/users/apiTokenService.js
+++ b/backend/modules/users/apiTokenService.js
@@ -15,6 +15,9 @@ const verifiedTokens = new Map();
 // Keyed with a secret that exists only for this process's lifetime, so the
 // cache keys are useless to anyone who does not also hold the process.
 const cacheKeySecret = crypto.randomBytes(32);
+// This is a lookup key for a short-lived in-memory cache, not password
+// storage: the token itself is still verified with bcrypt on a miss.
+// codeql[js/insufficient-password-hash]
 const cacheKeyFor = (tokenValue) =>
     crypto
         .createHmac('sha256', cacheKeySecret)

--- a/backend/modules/users/apiTokenService.js
+++ b/backend/modules/users/apiTokenService.js
@@ -20,7 +20,7 @@ const cacheKeySecret = crypto.randomBytes(32);
 const cacheKeyFor = (tokenValue) =>
     crypto
         .createHmac('sha256', cacheKeySecret)
-        .update(tokenValue) // codeql[js/insufficient-password-hash]
+        .update(tokenValue)
         .digest('hex');
 
 function rememberVerified(tokenValue, tokenId) {

--- a/backend/scripts/db-prepare.js
+++ b/backend/scripts/db-prepare.js
@@ -142,6 +142,8 @@ async function prepareDatabase() {
     if (dialect === 'postgres') {
         const recorded = await recordBaseline(queryInterface);
         await seedReferenceData();
+        const { ensureSearchIndexes } = require('../utils/searchIndexes');
+        await ensureSearchIndexes(sequelize);
         console.log(
             `✅ Schema created and ${recorded} migration(s) recorded as baseline`
         );

--- a/backend/services/backupService.js
+++ b/backend/services/backupService.js
@@ -127,7 +127,8 @@ function validateBackupData(backupData) {
  * @returns {Promise<string>} - Path to backups directory
  */
 async function getBackupsDirectory() {
-    const backupsDir = path.join(__dirname, '../backups');
+    const { getConfig } = require('../config/config');
+    const backupsDir = getConfig().backupPath;
     try {
         await fs.access(backupsDir);
     } catch {

--- a/backend/tests/unit/services/apiTokenCache.test.js
+++ b/backend/tests/unit/services/apiTokenCache.test.js
@@ -1,0 +1,75 @@
+const bcrypt = require('bcrypt');
+const { ApiToken } = require('../../../models');
+const {
+    createApiToken,
+    findValidTokenByValue,
+    revokeApiToken,
+    deleteApiToken,
+    clearVerifiedTokenCache,
+} = require('../../../modules/users/apiTokenService');
+const { createTestUser } = require('../../helpers/testUtils');
+
+describe('API token verification cache', () => {
+    let user;
+
+    beforeEach(async () => {
+        clearVerifiedTokenCache();
+        user = await createTestUser({
+            email: `tok_${Date.now()}@example.com`,
+        });
+    });
+
+    it('verifies with bcrypt once and answers from the cache afterwards', async () => {
+        const { rawToken, tokenRecord } = await createApiToken({
+            userId: user.id,
+            name: 'cached',
+        });
+        const compare = jest.spyOn(bcrypt, 'compare');
+
+        const first = await findValidTokenByValue(rawToken);
+        expect(first.id).toBe(tokenRecord.id);
+        expect(compare).toHaveBeenCalledTimes(1);
+
+        const second = await findValidTokenByValue(rawToken);
+        expect(second.id).toBe(tokenRecord.id);
+        expect(compare).toHaveBeenCalledTimes(1);
+        compare.mockRestore();
+    });
+
+    it('stops answering after revoke and after delete', async () => {
+        const { rawToken, tokenRecord } = await createApiToken({
+            userId: user.id,
+            name: 'revoked',
+        });
+        expect(await findValidTokenByValue(rawToken)).not.toBeNull();
+
+        await revokeApiToken(tokenRecord.id, user.id);
+        expect(await findValidTokenByValue(rawToken)).toBeNull();
+
+        const other = await createApiToken({ userId: user.id, name: 'gone' });
+        expect(await findValidTokenByValue(other.rawToken)).not.toBeNull();
+        await deleteApiToken(other.tokenRecord.id, user.id);
+        expect(await findValidTokenByValue(other.rawToken)).toBeNull();
+    });
+
+    it('re-checks expiry on cache hits', async () => {
+        const { rawToken, tokenRecord } = await createApiToken({
+            userId: user.id,
+            name: 'expiring',
+            expiresAt: new Date(Date.now() + 60_000),
+        });
+        expect(await findValidTokenByValue(rawToken)).not.toBeNull();
+
+        await ApiToken.update(
+            { expires_at: new Date(Date.now() - 1000) },
+            { where: { id: tokenRecord.id } }
+        );
+        expect(await findValidTokenByValue(rawToken)).toBeNull();
+    });
+
+    it('never caches a wrong token', async () => {
+        await createApiToken({ userId: user.id, name: 'real' });
+        expect(await findValidTokenByValue('tt_' + 'f'.repeat(64))).toBeNull();
+        expect(await findValidTokenByValue('tt_' + 'f'.repeat(64))).toBeNull();
+    });
+});

--- a/backend/tests/unit/utils/searchIndexes.test.js
+++ b/backend/tests/unit/utils/searchIndexes.test.js
@@ -1,0 +1,56 @@
+const { sequelize } = require('../../../models');
+const { isPostgres } = require('../../../utils/db-dialect');
+const {
+    ensureSearchIndexes,
+    dropSearchIndexes,
+    SEARCH_INDEXES,
+} = require('../../../utils/searchIndexes');
+
+const describePg = isPostgres() ? describe : describe.skip;
+const describeSqlite = isPostgres() ? describe.skip : describe;
+
+describeSqlite('search indexes on SQLite', () => {
+    it('is a no-op', async () => {
+        expect(await ensureSearchIndexes(sequelize)).toEqual([]);
+        await expect(dropSearchIndexes(sequelize)).resolves.toBeUndefined();
+    });
+});
+
+describePg('search indexes on PostgreSQL', () => {
+    beforeAll(async () => {
+        await sequelize.sync();
+    });
+
+    afterAll(async () => {
+        await dropSearchIndexes(sequelize);
+    });
+
+    const indexNames = async () => {
+        const [rows] = await sequelize.query(
+            "SELECT indexname FROM pg_indexes WHERE indexname LIKE '%_trgm' OR indexname = 'sessions_expires'"
+        );
+        return rows.map((r) => r.indexname).sort();
+    };
+
+    it('creates a trigram index per search column and is idempotent', async () => {
+        const created = await ensureSearchIndexes(sequelize);
+        for (const [, , name] of SEARCH_INDEXES) {
+            expect(created).toContain(name);
+        }
+        const names = await indexNames();
+        expect(names).toEqual(expect.arrayContaining(created));
+
+        const again = await ensureSearchIndexes(sequelize);
+        expect(again).toEqual(created);
+        expect(await indexNames()).toEqual(names);
+    });
+
+    it('drops them again', async () => {
+        await ensureSearchIndexes(sequelize);
+        await dropSearchIndexes(sequelize);
+        const names = await indexNames();
+        for (const [, , name] of SEARCH_INDEXES) {
+            expect(names).not.toContain(name);
+        }
+    });
+});

--- a/backend/utils/searchIndexes.js
+++ b/backend/utils/searchIndexes.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// Search runs LOWER(column) LIKE '%term%'. On PostgreSQL a trigram GIN
+// index over the same expression turns that from a sequential scan into an
+// index lookup. SQLite has no equivalent, so this is a no-op there.
+//
+// Called from the migration (existing databases) and from db-prepare
+// (fresh PostgreSQL databases, whose schema comes from sync() and never
+// replays the migrations).
+
+const SEARCH_INDEXES = [
+    ['tasks', 'name', 'tasks_name_trgm'],
+    ['tasks', 'note', 'tasks_note_trgm'],
+    ['notes', 'title', 'notes_title_trgm'],
+    ['notes', 'content', 'notes_content_trgm'],
+    ['projects', 'name', 'projects_name_trgm'],
+    ['projects', 'description', 'projects_description_trgm'],
+];
+
+async function tableExists(sequelize, table) {
+    const [rows] = await sequelize.query(
+        'SELECT 1 FROM information_schema.tables WHERE table_name = :table',
+        { replacements: { table } }
+    );
+    return rows.length > 0;
+}
+
+async function ensureSearchIndexes(sequelize) {
+    if (sequelize.getDialect() !== 'postgres') return [];
+
+    const created = [];
+    await sequelize.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+
+    for (const [table, column, name] of SEARCH_INDEXES) {
+        if (!(await tableExists(sequelize, table))) continue;
+        await sequelize.query(
+            `CREATE INDEX IF NOT EXISTS "${name}" ON "${table}" USING gin (LOWER("${column}") gin_trgm_ops)`
+        );
+        created.push(name);
+    }
+
+    // connect-session-sequelize sweeps expired rows every 15 minutes with a
+    // WHERE on expires; without an index that is a table scan.
+    if (await tableExists(sequelize, 'Sessions')) {
+        await sequelize.query(
+            'CREATE INDEX IF NOT EXISTS "sessions_expires" ON "Sessions" ("expires")'
+        );
+        created.push('sessions_expires');
+    }
+
+    return created;
+}
+
+async function dropSearchIndexes(sequelize) {
+    if (sequelize.getDialect() !== 'postgres') return;
+    for (const [, , name] of SEARCH_INDEXES) {
+        await sequelize.query(`DROP INDEX IF EXISTS "${name}"`);
+    }
+    await sequelize.query('DROP INDEX IF EXISTS "sessions_expires"');
+}
+
+module.exports = { ensureSearchIndexes, dropSearchIndexes, SEARCH_INDEXES };

--- a/docs/16-postgresql.md
+++ b/docs/16-postgresql.md
@@ -144,6 +144,14 @@ With `TUDUDI_HOSTED_MODE=true` the server refuses to start unless
 public `FRONTEND_URL`/`BACKEND_URL`, `ENABLE_EMAIL` with an SMTP host, and a
 PostgreSQL `DATABASE_URL` are all set, and prints exactly what is missing.
 
+## Search Indexes
+
+Search runs `LOWER(column) LIKE '%term%'`. On PostgreSQL, tududi creates
+trigram GIN indexes (`pg_trgm`) over those expressions on tasks, notes and
+projects, plus an index on session expiry, both for fresh databases
+(`db-prepare`) and existing ones (migration `20260907000007`). Nothing to
+configure; `pg_trgm` ships with PostgreSQL.
+
 ## Health Checks and Logs
 
 - `GET /api/health` answers 200 as soon as the process is up. The Docker

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -137,6 +137,21 @@ npm start
 
 ---
 
+## Per-User Backup Exports
+
+The in-app export (Profile > Backup, `FF_ENABLE_BACKUPS=true`) writes each
+user's `.json.gz` under `TUDUDI_BACKUP_PATH` (default `backend/backups`,
+`/app/backups` in the Docker image, declared as a volume). Mount it like
+`uploads`, or those exports disappear when the container is recreated.
+
+## PostgreSQL Dumps
+
+`scripts/pg-backup.sh <dir>` runs `pg_dump --no-owner --no-acl` against
+`DATABASE_URL`, gzips it to `<dir>/tududi-<timestamp>.sql.gz`, and prunes
+dumps older than `BACKUP_KEEP_DAYS` (default 14). Run it from cron on the
+host and copy the directory off the machine (restic, rclone, object
+storage). Restore with `gunzip -c <file> | psql "$DATABASE_URL"`.
+
 ## Per-User Export Format
 
 Exports (Profile > Backup, `FF_ENABLE_BACKUPS=true`) are JSON (`format: 2`)

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -77,9 +77,9 @@ else
 fi
 
 echo "Setting ownership of application directories to $TARGET_USER:$TARGET_GROUP"
-mkdir -p /app/db /app/backend/certs /app/uploads
+mkdir -p /app/db /app/backend/certs /app/uploads /app/backups
 chown -R "$TARGET_USER":"$TARGET_GROUP" /app/backend /app/scripts
-chown -R "$TARGET_USER":"$TARGET_GROUP" /app/db /app/uploads
+chown -R "$TARGET_USER":"$TARGET_GROUP" /app/db /app/uploads /app/backups
 chmod 770 /app/db /app/backend/certs /app/uploads
 set_db_file_permissions
 

--- a/scripts/pg-backup.sh
+++ b/scripts/pg-backup.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Dumps the tududi PostgreSQL database to a compressed file and prunes old
+# dumps. Meant for cron on the host (or a sidecar) of a PostgreSQL install;
+# the SQLite file backup in backend/cmd/start.sh does not apply there.
+#
+#   DATABASE_URL=postgres://... ./scripts/pg-backup.sh /var/backups/tududi
+#
+# Keeps BACKUP_KEEP_DAYS days of dumps (default 14). Copy the directory
+# somewhere off the machine (restic, rclone, object storage) to have a real
+# backup; this script only produces the files.
+set -euo pipefail
+
+DEST=${1:-${BACKUP_DIR:-./backups}}
+KEEP_DAYS=${BACKUP_KEEP_DAYS:-14}
+
+if [ -z "${DATABASE_URL:-}" ]; then
+  echo "DATABASE_URL is not set" >&2
+  exit 1
+fi
+if ! command -v pg_dump >/dev/null 2>&1; then
+  echo "pg_dump not found; install the PostgreSQL client tools" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST"
+STAMP=$(date -u +%Y%m%dT%H%M%SZ)
+FILE="$DEST/tududi-$STAMP.sql.gz"
+TMP="$FILE.part"
+
+# --no-owner/--no-acl: restorable into a database owned by any role.
+pg_dump --no-owner --no-acl "$DATABASE_URL" | gzip -9 > "$TMP"
+mv "$TMP" "$FILE"
+echo "Wrote $FILE ($(du -h "$FILE" | cut -f1))"
+
+find "$DEST" -name 'tududi-*.sql.gz' -mtime "+$KEEP_DAYS" -print -delete | sed 's/^/Pruned /'
+
+# Restore with:
+#   gunzip -c tududi-<stamp>.sql.gz | psql "$DATABASE_URL"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,22 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 
 const isDevelopment = process.env.NODE_ENV !== 'production';
+// Identifies one build in cache names: the git commit when available,
+// otherwise the build time.
+const buildId = (() => {
+    try {
+        return (
+            require('child_process')
+                .execSync('git rev-parse --short HEAD', {
+                    stdio: ['ignore', 'pipe', 'ignore'],
+                })
+                .toString()
+                .trim() || Date.now().toString(36)
+        );
+    } catch (_) {
+        return Date.now().toString(36);
+    }
+})();
 const frontendPort = parseInt(process.env.FRONTEND_PORT || '8080', 10);
 const frontendHost = process.env.FRONTEND_HOST || '0.0.0.0';
 const backendUrl = process.env.BACKEND_URL || 'http://localhost:3002';
@@ -104,6 +120,18 @@ module.exports = {
                     to: '',
                     globOptions: {
                         ignore: ['**/index.html'],
+                    },
+                    // The service worker's static cache name must change per
+                    // build, or returning visitors keep the old shell after
+                    // a deploy. The API cache name stays stable on purpose.
+                    transform(content, absoluteFrom) {
+                        if (!absoluteFrom.endsWith('sw.js')) return content;
+                        return content
+                            .toString()
+                            .replace(
+                                "const CACHE_VERSION = 'tududi-v1';",
+                                `const CACHE_VERSION = 'tududi-${buildId}';`
+                            );
                     },
                 },
             ],


### PR DESCRIPTION
## Description

Phase 3, second half (follows #1476, #1477). Operational improvements that help self-hosted installs as much as the hosted one; nothing is behind a flag.

- **Backup exports survive recreates.** Per-user backup exports (Profile > Backup) now go to `TUDUDI_BACKUP_PATH` (default `backend/backups`; `/app/backups` in the image, declared as a `VOLUME` and chowned by the entrypoint). Previously they were written under `/app/backend/backups`, which was not a volume.
- **`scripts/pg-backup.sh`**: `pg_dump --no-owner --no-acl` to a gzipped, timestamped file with retention (`BACKUP_KEEP_DAYS`, default 14), for cron on the host. Documented in `docs/backups.md` with the restore command.
- **Search indexes on PostgreSQL.** `backend/utils/searchIndexes.js` creates `pg_trgm` GIN indexes over exactly the `LOWER(column)` expressions the search uses (tasks name/note, notes title/content, projects name/description) plus an index on `Sessions.expires` for the sweeper. Applied by migration `20260907000007` for existing databases and by `db-prepare` for fresh PostgreSQL databases, whose schema comes from `sync()` and never replays migrations. No-op on SQLite.
- **Static asset caching.** Content-hashed webpack bundles are served with `Cache-Control: max-age=1y, immutable`; `index.html`, `sw.js` and `manifest.json` are always revalidated (`no-cache`), as is the SPA fallback. Previously everything was `max-age=0`.
- **Service worker cache per build.** The copied `sw.js` gets its static `CACHE_VERSION` rewritten to the build's git commit (build time as fallback), so returning visitors pick up a deploy instead of keeping the old shell. The API cache name stays stable on purpose.
- **API token verification cache.** Every Bearer request paid a bcrypt cost-12 compare (~250 ms). Verified tokens are now remembered for five minutes keyed by the token's SHA-256 (never the raw value), cleared on revoke and delete, with expiry re-checked on every hit. `revokeApiToken`/`deleteApiToken` drop the entry.

Not included from the original plan: SQL-level pagination on `GET /api/tasks`. That route expands recurring tasks in memory before slicing, so a naive `LIMIT` would change which occurrences appear; it needs its own change.

## Type of Change

- [x] New feature (adds functionality)
- [x] Documentation/Translation update

## Testing

- New `tests/unit/services/apiTokenCache.test.js`: bcrypt called once then served from cache, revoke and delete stop answering, expiry re-checked on hits, wrong tokens never cached.
- New `tests/unit/utils/searchIndexes.test.js`: no-op on SQLite; on PostgreSQL creates every index, is idempotent, and drops them (run locally against PostgreSQL 16: passes).
- `npm run frontend:build` produces `dist/sw.js` with `CACHE_VERSION = 'tududi-<commit>'`.
- `npm test`: 1950 passed; four failures are the known parallel flakes (project-sharing, subtasks, url; all pass alone) and the pre-existing date-boundary recurring test. `npm run lint`: 0 errors.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)