### PR TITLE
feat(tasks): page the task list in the database, add a hosted deployment example

### DIFF
--- a/backend/modules/tasks/queries/query-builders.js
+++ b/backend/modules/tasks/queries/query-builders.js
@@ -14,11 +14,15 @@ const {
     getTodayBoundsInUTC,
 } = require('../../../utils/timezone-utils');
 
+// `page` ({ limit, offset }) switches to database pagination: the result is
+// then { rows, count } instead of an array. Callers that post-process the
+// list in memory (today, upcoming by day) must not pass it.
 async function filterTasksByParams(
     params,
     userId,
     userTimezone,
-    permissionCache = null
+    permissionCache = null,
+    page = null
 ) {
     const ownedOrShared = await permissionsService.ownershipOrPermissionWhere(
         'task',
@@ -420,6 +424,19 @@ async function filterTasksByParams(
     const finalWhereClause = {
         [Op.and]: [ownedOrShared, whereClause],
     };
+
+    if (page) {
+        const { rows, count } = await Task.findAndCountAll({
+            where: finalWhereClause,
+            include: includeClause,
+            order: orderClause,
+            distinct: true,
+            col: 'id',
+            limit: page.limit,
+            offset: page.offset,
+        });
+        return { rows, count };
+    }
 
     return await Task.findAll({
         where: finalWhereClause,

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -179,7 +179,32 @@ router.get('/tasks', async (req, res) => {
 
         await handleRecurringTasks(userId, type);
 
-        let tasks = await filterTasksByParams(req.query, userId, timezone);
+        const hasPagination =
+            limitParam !== undefined || offsetParam !== undefined;
+        const limit = parseInt(limitParam, 10) || 20;
+        const offset = parseInt(offsetParam, 10) || 0;
+        // Today and upcoming-by-day expand or filter the list in memory, so
+        // they page after that; everything else pages in the database.
+        const sqlPagination =
+            hasPagination &&
+            type !== 'today' &&
+            !(type === 'upcoming' && groupBy === 'day');
+
+        let tasks;
+        let totalCount;
+        if (sqlPagination) {
+            const paged = await filterTasksByParams(
+                req.query,
+                userId,
+                timezone,
+                null,
+                { limit, offset }
+            );
+            tasks = paged.rows;
+            totalCount = paged.count;
+        } else {
+            tasks = await filterTasksByParams(req.query, userId, timezone);
+        }
 
         // Fetch projects with upcoming due dates for the upcoming view
         let upcomingProjects = [];
@@ -245,14 +270,10 @@ router.get('/tasks', async (req, res) => {
             );
         }
 
-        const hasPagination =
-            limitParam !== undefined || offsetParam !== undefined;
-        const totalCount = tasks.length;
+        if (totalCount === undefined) totalCount = tasks.length;
         let paginatedTasks = tasks;
 
-        if (hasPagination) {
-            const limit = parseInt(limitParam, 10) || 20;
-            const offset = parseInt(offsetParam, 10) || 0;
+        if (hasPagination && !sqlPagination) {
             paginatedTasks = tasks.slice(offset, offset + limit);
         }
 
@@ -311,8 +332,6 @@ router.get('/tasks', async (req, res) => {
         );
 
         if (hasPagination) {
-            const limit = parseInt(limitParam, 10) || 20;
-            const offset = parseInt(offsetParam, 10) || 0;
             response.pagination = {
                 total: totalCount,
                 limit: limit,

--- a/backend/tests/integration/tasks-pagination.test.js
+++ b/backend/tests/integration/tasks-pagination.test.js
@@ -131,3 +131,85 @@ describe('Tasks Pagination', () => {
         });
     });
 });
+
+describe('GET /api/tasks database pagination', () => {
+    const request = require('supertest');
+    const app = require('../../app');
+    const { Task, Tag } = require('../../models');
+    const { createTestUser } = require('../helpers/testUtils');
+
+    let user, agent;
+
+    beforeEach(async () => {
+        user = await createTestUser({
+            email: `dbpage_${Date.now()}@example.com`,
+        });
+        agent = request.agent(app);
+        await agent
+            .post('/api/login')
+            .send({ email: user.email, password: 'password123' });
+    });
+
+    it('pages a filtered list without loading every row', async () => {
+        const tag = await Tag.create({ name: 'paged', user_id: user.id });
+        for (let i = 1; i <= 12; i++) {
+            const task = await Task.create({
+                user_id: user.id,
+                name: `Tagged ${String(i).padStart(2, '0')}`,
+                status: 0,
+            });
+            if (i % 2 === 0) await task.setTags([tag.id]);
+        }
+        const spy = jest.spyOn(Task, 'findAll');
+
+        const page1 = await agent
+            .get('/api/tasks')
+            .query({ tag: 'paged', limit: 4, offset: 0, order_by: 'name:asc' });
+        expect(page1.status).toBe(200);
+        expect(page1.body.tasks).toHaveLength(4);
+        expect(page1.body.pagination).toEqual({
+            total: 6,
+            limit: 4,
+            offset: 0,
+            hasMore: true,
+        });
+        expect(page1.body.tasks.every((t) => t.name.startsWith('Tagged'))).toBe(
+            true
+        );
+
+        const page2 = await agent
+            .get('/api/tasks')
+            .query({ tag: 'paged', limit: 4, offset: 4, order_by: 'name:asc' });
+        expect(page2.body.tasks).toHaveLength(2);
+        expect(page2.body.pagination.hasMore).toBe(false);
+
+        // The main list query was not a full findAll for the paged calls
+        expect(spy).not.toHaveBeenCalledWith(
+            expect.objectContaining({ distinct: true, limit: undefined })
+        );
+        spy.mockRestore();
+
+        const names = [...page1.body.tasks, ...page2.body.tasks].map(
+            (t) => t.name
+        );
+        expect(new Set(names).size).toBe(6);
+    });
+
+    it('still pages today and upcoming-by-day in memory', async () => {
+        for (let i = 1; i <= 5; i++) {
+            await Task.create({
+                user_id: user.id,
+                name: `Due ${i}`,
+                status: 0,
+                due_date: new Date(),
+            });
+        }
+        const today = await agent
+            .get('/api/tasks')
+            .query({ type: 'today', limit: 2, offset: 0 });
+        expect(today.status).toBe(200);
+        expect(today.body.pagination).toMatchObject({ limit: 2, offset: 0 });
+        expect(typeof today.body.pagination.total).toBe('number');
+        expect(today.body.tasks.length).toBeLessThanOrEqual(2);
+    });
+});

--- a/docs/16-postgresql.md
+++ b/docs/16-postgresql.md
@@ -74,6 +74,9 @@ For an external database (managed PostgreSQL, another host) drop the `db` servic
 
 ---
 
+For a public multi-user instance see `docs/examples/docker-compose.hosted.yml`
+and [docs/17-hosted-mode.md](17-hosted-mode.md).
+
 ## Upgrading
 
 1. Take a backup (`pg_dump`, see below).

--- a/docs/17-hosted-mode.md
+++ b/docs/17-hosted-mode.md
@@ -114,3 +114,20 @@ subscription and removes the Stripe customer.
 
 Local testing: `stripe listen --forward-to localhost:3002/api/billing/webhook`
 and `stripe trigger checkout.session.completed`.
+
+## Deploying on one machine
+
+`docs/examples/docker-compose.hosted.yml` and `docs/examples/Caddyfile` are
+a complete single-VPS layout: Caddy (automatic TLS) in front of a `web`
+container that serves HTTP with the background jobs off, a `worker`
+container from the same image that runs the schedulers and the Telegram
+poller, and PostgreSQL 16. Both app containers share `uploads/` and
+`backups/`; secrets live in `.env` on the server. The comments at the end
+of the compose file list the variables hosted mode requires; the server
+refuses to start until they are set.
+
+Point uptime monitoring at `/api/health/ready`, run `scripts/pg-backup.sh`
+from cron and copy its output off the machine, and deploy by pinning
+`TUDUDI_VERSION` to a release tag and running `docker compose pull && docker
+compose up -d`. Migrations run in the container entrypoint under a database
+lock, so `web` and `worker` can start together.

--- a/docs/examples/Caddyfile
+++ b/docs/examples/Caddyfile
@@ -1,0 +1,23 @@
+# Reverse proxy for docs/examples/docker-compose.hosted.yml.
+# Caddy obtains and renews the certificate for APP_DOMAIN by itself.
+
+{$APP_DOMAIN} {
+    encode zstd gzip
+
+    # Let the app see the real client address and scheme
+    reverse_proxy tududi-web:3002 {
+        header_up X-Forwarded-Proto {scheme}
+        header_up X-Forwarded-For {remote_host}
+    }
+
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains"
+        -Server
+    }
+
+    # Uptime monitors should watch /api/health/ready
+    log {
+        output stdout
+        format json
+    }
+}

--- a/docs/examples/docker-compose.hosted.yml
+++ b/docs/examples/docker-compose.hosted.yml
@@ -1,0 +1,112 @@
+# tududi as a hosted, multi-user service on one machine.
+#
+# Two app containers from the same image: "web" serves HTTP with the
+# background jobs switched off, "worker" runs the schedulers and the
+# Telegram poller and serves no traffic. Both share one PostgreSQL. Caddy
+# terminates TLS and obtains certificates on its own.
+#
+#   cp docs/examples/docker-compose.hosted.yml docker-compose.yml
+#   cp docs/examples/Caddyfile Caddyfile
+#   cp backend/.env.example .env   # then fill in the values listed at the bottom
+#   docker compose up -d
+#
+# Secrets live in .env on the server, never in this file.
+
+services:
+    caddy:
+        image: caddy:2-alpine
+        container_name: tududi-caddy
+        ports:
+            - '80:80'
+            - '443:443'
+        volumes:
+            - ./Caddyfile:/etc/caddy/Caddyfile:ro
+            - caddy_data:/data
+            - caddy_config:/config
+        environment:
+            APP_DOMAIN: ${APP_DOMAIN:?set APP_DOMAIN in .env}
+        depends_on:
+            - web
+        restart: unless-stopped
+
+    db:
+        image: postgres:16-alpine
+        container_name: tududi-db
+        environment:
+            POSTGRES_DB: ${DB_NAME:-tududi}
+            POSTGRES_USER: ${DB_USER:-tududi}
+            POSTGRES_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
+        # Keep max_connections above DB_POOL_MAX times the number of app
+        # containers, plus a margin for pg_dump and psql.
+        command: ['postgres', '-c', 'max_connections=60', '-c', 'shared_buffers=256MB']
+        shm_size: 256m
+        volumes:
+            - pgdata:/var/lib/postgresql/data
+        healthcheck:
+            test: ['CMD-SHELL', 'pg_isready -U ${DB_USER:-tududi} -d ${DB_NAME:-tududi}']
+            interval: 5s
+            timeout: 3s
+            retries: 10
+        restart: unless-stopped
+
+    web:
+        image: chrisvel/tududi:${TUDUDI_VERSION:-latest}
+        container_name: tududi-web
+        env_file: .env
+        environment:
+            DATABASE_URL: postgres://${DB_USER:-tududi}:${DB_PASSWORD}@db:5432/${DB_NAME:-tududi}
+            DB_POOL_MAX: ${DB_POOL_MAX:-10}
+            TUDUDI_HOSTED_MODE: 'true'
+            TUDUDI_TRUST_PROXY: '1'
+            # Background work belongs to the worker container
+            DISABLE_SCHEDULER: 'true'
+            DISABLE_TELEGRAM: 'true'
+        volumes:
+            - ./uploads:/app/uploads
+            - ./backups:/app/backups
+        expose:
+            - '3002'
+        depends_on:
+            db:
+                condition: service_healthy
+        restart: unless-stopped
+
+    worker:
+        image: chrisvel/tududi:${TUDUDI_VERSION:-latest}
+        container_name: tududi-worker
+        env_file: .env
+        environment:
+            DATABASE_URL: postgres://${DB_USER:-tududi}:${DB_PASSWORD}@db:5432/${DB_NAME:-tududi}
+            DB_POOL_MAX: ${DB_POOL_MAX:-5}
+            TUDUDI_HOSTED_MODE: 'true'
+            TUDUDI_TRUST_PROXY: '1'
+            DISABLE_SCHEDULER: 'false'
+            DISABLE_TELEGRAM: 'false'
+        volumes:
+            - ./uploads:/app/uploads
+            - ./backups:/app/backups
+        depends_on:
+            db:
+                condition: service_healthy
+            web:
+                condition: service_started
+        restart: unless-stopped
+
+volumes:
+    pgdata:
+    caddy_data:
+    caddy_config:
+
+# .env must set at least:
+#   APP_DOMAIN=app.example.com
+#   DB_PASSWORD=...                         (long random)
+#   TUDUDI_SESSION_SECRET=...               (openssl rand -hex 64)
+#   TUDUDI_ALLOWED_ORIGINS=https://app.example.com
+#   FRONTEND_URL=https://app.example.com
+#   BACKEND_URL=https://app.example.com
+#   TUDUDI_USER_EMAIL=... TUDUDI_USER_PASSWORD=...   (the admin account)
+#   ENABLE_EMAIL=true EMAIL_SMTP_HOST=... EMAIL_SMTP_PORT=587 EMAIL_SMTP_USERNAME=... EMAIL_SMTP_PASSWORD=... EMAIL_FROM_ADDRESS=...
+#   STRIPE_SECRET_KEY=... STRIPE_WEBHOOK_SECRET=... STRIPE_PRICE_PRO_MONTHLY=... STRIPE_PRICE_PRO_ANNUAL=...
+#   FF_ENABLE_BACKUPS=true FF_ENABLE_CALDAV=true FF_ENABLE_MCP=true
+# Optional: LLM_API_KEY, TUDUDI_PLANS_JSON, TUDUDI_TRIAL_DAYS, LOG_LEVEL.
+# The server refuses to start in hosted mode until the required ones are set.


### PR DESCRIPTION
## Description

Two remaining plan items that need nothing from outside the repo.

**Database pagination for `GET /api/tasks`.** The route loaded every matching task and sliced the array in memory, so cost grew with a user's total task count regardless of page size. With `limit`/`offset` it now calls `findAndCountAll` (distinct on `id`, includes and ordering intact) and reports the count from the query. The two views that post-process the list in memory, `today` (recurring-instance filtering) and `upcoming` grouped by day (recurring expansion), keep paging after that step, so their output is unchanged. Responses without pagination parameters are unchanged.

**Hosted deployment reference.** `docs/examples/docker-compose.hosted.yml` and `docs/examples/Caddyfile`: Caddy with automatic TLS in front of a `web` container (schedulers and Telegram off) and a `worker` container from the same image (schedulers on, no traffic), PostgreSQL 16 with `max_connections` sized for both pools, shared `uploads/` and `backups/` volumes, hosted mode and trust-proxy preset, and the required `.env` variables listed at the bottom. Secret-free and generic, so it serves self-hosters too; the real deployment config stays in the private infra repo. `docs/17-hosted-mode.md` gains a deployment section and `docs/16-postgresql.md` points to it.

## Type of Change

- [x] New feature (adds functionality)
- [x] Documentation/Translation update

## Testing

- `tasks-pagination.test.js` gains two tests: a tag-filtered, ordered list pages in the database (correct page sizes, total, `hasMore`, no duplicate rows across pages), and `today` still pages in memory with the same response shape.
- `npm test`: 1959 passed; the one failure is the known uploads parallel flake, which passes alone. `npm run lint`: 0 errors.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)