### PR TITLE
fix(csp): allow 'self' in frame-src so the PDF attachment preview renders

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -57,7 +57,10 @@ app.use(
                 fontSrc: ["'self'"],
                 objectSrc: ["'none'"],
                 mediaSrc: ["'self'"],
-                frameSrc: ['https://challenges.cloudflare.com'],
+                // 'self' is needed for AttachmentPreview, which renders PDF
+                // attachments in a same-origin <iframe>; without it the
+                // browser refuses the frame ("This content is blocked").
+                frameSrc: ["'self'", 'https://challenges.cloudflare.com'],
                 upgradeInsecureRequests:
                     process.env.UPGRADE_INSECURE_REQUESTS === 'true'
                         ? []

--- a/backend/tests/integration/securityHeaders.test.js
+++ b/backend/tests/integration/securityHeaders.test.js
@@ -1,0 +1,16 @@
+const request = require('supertest');
+const app = require('../../app');
+
+describe('Security headers', () => {
+    it('CSP frame-src allows same-origin frames for the PDF attachment preview', async () => {
+        const res = await request(app).get('/api/health');
+        const csp = res.headers['content-security-policy'];
+        expect(csp).toBeDefined();
+        const frameSrc = csp
+            .split(';')
+            .map((d) => d.trim())
+            .find((d) => d.startsWith('frame-src '));
+        expect(frameSrc).toBeDefined();
+        expect(frameSrc.split(/\s+/)).toContain("'self'");
+    });
+});


### PR DESCRIPTION
## Description

`AttachmentPreview` renders PDF attachments in a same-origin `<iframe>`, but the helmet CSP in `backend/app.js` only allows `https://challenges.cloudflare.com` in `frame-src` (`'none'` on v1.4.2). Browsers therefore refuse the app's own frame and show "This content is blocked. Contact the site owner to fix the issue." instead of the PDF.

This adds `'self'` to `frameSrc` (Turnstile stays allowed) and an integration test that asserts the directive contains `'self'`, so it can't regress silently.

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1497

## Testing

- `cd backend && NODE_ENV=test jest tests/integration/securityHeaders.test.js` passes with the change and fails without it (`Received array: ["frame-src", "https://challenges.cloudflare.com"]`).
- Ran the same CSP with `frame-src 'self'` against a v1.4.2 deployment (via a reverse-proxy header override): the PDF preview renders.
- [x] `eslint --config backend/eslint.config.js` and `prettier --check` clean on both files (`npm run pre-push` equivalent for these paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
