### PR TITLE
feat: Cloud waitlist and an admin dashboard

### DIFF
--- a/backend/migrations/20260909000001-create-waitlist-subscribers.js
+++ b/backend/migrations/20260909000001-create-waitlist-subscribers.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const { safeCreateTable, safeAddIndex } = require('../utils/migration-utils');
+
+module.exports = {
+    async up(queryInterface, Sequelize) {
+        await safeCreateTable(queryInterface, 'waitlist_subscribers', {
+            id: {
+                type: Sequelize.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            email: {
+                type: Sequelize.STRING(254),
+                allowNull: false,
+                unique: true,
+            },
+            source: {
+                type: Sequelize.STRING(32),
+                allowNull: false,
+                defaultValue: 'unknown',
+            },
+            locale: { type: Sequelize.STRING(8), allowNull: true },
+            referrer: { type: Sequelize.STRING(512), allowNull: true },
+            submission_count: {
+                type: Sequelize.INTEGER,
+                allowNull: false,
+                defaultValue: 1,
+            },
+            created_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+            },
+            updated_at: {
+                type: Sequelize.DATE,
+                allowNull: false,
+                defaultValue: Sequelize.literal('CURRENT_TIMESTAMP'),
+            },
+        });
+        await safeAddIndex(queryInterface, 'waitlist_subscribers', [
+            'created_at',
+        ]);
+    },
+
+    async down(queryInterface) {
+        await queryInterface.dropTable('waitlist_subscribers');
+    },
+};

--- a/backend/models/index.js
+++ b/backend/models/index.js
@@ -87,6 +87,7 @@ const UserProjectArea = require('./user_project_area')(sequelize);
 const RateLimit = require('./rate_limit')(sequelize);
 const BillingAccount = require('./billing_account')(sequelize);
 const BillingEvent = require('./billing_event')(sequelize);
+const WaitlistSubscriber = require('./waitlist_subscriber')(sequelize);
 const UsageCounter = require('./usage_counter')(sequelize);
 
 User.hasOne(BillingAccount, { foreignKey: 'user_id', as: 'BillingAccount' });
@@ -487,5 +488,6 @@ module.exports = {
     RateLimit,
     BillingAccount,
     BillingEvent,
+    WaitlistSubscriber,
     UsageCounter,
 };

--- a/backend/models/waitlist_subscriber.js
+++ b/backend/models/waitlist_subscriber.js
@@ -1,0 +1,61 @@
+const { DataTypes } = require('sequelize');
+
+// People who asked to be told when tududi Cloud opens. Captured by the
+// marketing page, which is the only thing that writes here; the app itself
+// never reads it except for the admin list.
+//
+// Deliberately not tied to `users`: nobody here has an account, that is the
+// whole point.
+module.exports = (sequelize) => {
+    const WaitlistSubscriber = sequelize.define(
+        'WaitlistSubscriber',
+        {
+            id: {
+                type: DataTypes.INTEGER,
+                primaryKey: true,
+                autoIncrement: true,
+            },
+            email: {
+                type: DataTypes.STRING(254),
+                allowNull: false,
+                unique: true,
+                set(value) {
+                    this.setDataValue(
+                        'email',
+                        String(value || '')
+                            .trim()
+                            .toLowerCase()
+                    );
+                },
+                validate: { isEmail: true },
+            },
+            // Which form it came from: hero, waitlist, footer, cloud
+            source: {
+                type: DataTypes.STRING(32),
+                allowNull: false,
+                defaultValue: 'unknown',
+            },
+            locale: {
+                type: DataTypes.STRING(8),
+                allowNull: true,
+            },
+            referrer: {
+                type: DataTypes.STRING(512),
+                allowNull: true,
+            },
+            // A second submission is not a second person; it is someone
+            // checking the form worked.
+            submission_count: {
+                type: DataTypes.INTEGER,
+                allowNull: false,
+                defaultValue: 1,
+            },
+        },
+        {
+            tableName: 'waitlist_subscribers',
+            indexes: [{ fields: ['created_at'] }],
+        }
+    );
+
+    return WaitlistSubscriber;
+};

--- a/backend/modules/admin/controller.js
+++ b/backend/modules/admin/controller.js
@@ -34,6 +34,27 @@ const adminController = {
      * GET /api/admin/users
      * List all users with roles.
      */
+    async overview(req, res, next) {
+        try {
+            res.json(await adminService.overview(getRequesterId(req)));
+        } catch (error) {
+            next(error);
+        }
+    },
+
+    async listWaitlist(req, res, next) {
+        try {
+            res.json(
+                await adminService.listWaitlist(getRequesterId(req), {
+                    limit: req.query.limit,
+                    offset: req.query.offset,
+                })
+            );
+        } catch (error) {
+            next(error);
+        }
+    },
+
     async listUsers(req, res, next) {
         try {
             const requesterId = getRequesterId(req);

--- a/backend/modules/admin/routes.js
+++ b/backend/modules/admin/routes.js
@@ -8,6 +8,8 @@ const adminController = require('./controller');
 // Admin verification is done in the service layer
 
 router.post('/admin/set-admin-role', adminController.setAdminRole);
+router.get('/admin/overview', adminController.overview);
+router.get('/admin/waitlist', adminController.listWaitlist);
 router.get('/admin/users', adminController.listUsers);
 router.post('/admin/users', adminController.createUser);
 router.put('/admin/users/:id', adminController.updateUser);

--- a/backend/modules/admin/service.js
+++ b/backend/modules/admin/service.js
@@ -278,6 +278,100 @@ class AdminService {
     /**
      * Toggle registration setting.
      */
+    // One page's worth of numbers for the admin dashboard: who is here,
+    // what is being sold, and who is waiting for it to open.
+    async overview(requesterId) {
+        await this.verifyAdmin(requesterId);
+        const {
+            User,
+            Role,
+            Task,
+            Project,
+            Note,
+            BillingAccount,
+            WaitlistSubscriber,
+            Setting,
+        } = require('../../models');
+        const { getConfig } = require('../../config/config');
+        const entitlements = require('../../services/entitlementsService');
+        const { Op } = require('sequelize');
+
+        const dayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
+        const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+        const config = getConfig();
+
+        const [
+            users,
+            admins,
+            verified,
+            newUsers,
+            tasks,
+            projects,
+            notes,
+            waitlist,
+            waitlistWeek,
+            paying,
+            registrationSetting,
+        ] = await Promise.all([
+            User.count(),
+            Role.count({ where: { is_admin: true } }),
+            User.count({ where: { email_verified: true } }),
+            User.count({ where: { created_at: { [Op.gte]: dayAgo } } }),
+            Task.count(),
+            Project.count(),
+            Note.count(),
+            WaitlistSubscriber.count(),
+            WaitlistSubscriber.count({
+                where: { created_at: { [Op.gte]: weekAgo } },
+            }),
+            BillingAccount.count({
+                where: { status: { [Op.in]: ['active', 'trialing'] } },
+            }),
+            Setting.findOne({ where: { key: 'registration_enabled' } }),
+        ]);
+
+        return {
+            users: { total: users, admins, verified, last24h: newUsers },
+            content: { tasks, projects, notes },
+            waitlist: { total: waitlist, last7d: waitlistWeek },
+            billing: {
+                paying,
+                hosted: config.hosted?.enabled === true,
+                subscription_required: entitlements.isSubscriptionRequired(),
+                provider: config.hosted?.billing?.provider || null,
+            },
+            instance: {
+                registration_enabled: registrationSetting
+                    ? registrationSetting.value === 'true'
+                    : false,
+                version: require('../../../package.json').version,
+                environment: config.environment,
+            },
+        };
+    }
+
+    // The waitlist, newest first, for the admin dashboard.
+    async listWaitlist(requesterId, { limit = 50, offset = 0 } = {}) {
+        await this.verifyAdmin(requesterId);
+        const { WaitlistSubscriber } = require('../../models');
+        const { rows, count } = await WaitlistSubscriber.findAndCountAll({
+            order: [['created_at', 'DESC']],
+            limit: Math.min(Number(limit) || 50, 500),
+            offset: Number(offset) || 0,
+        });
+        return {
+            total: count,
+            subscribers: rows.map((r) => ({
+                id: r.id,
+                email: r.email,
+                source: r.source,
+                locale: r.locale,
+                submission_count: r.submission_count,
+                created_at: r.created_at,
+            })),
+        };
+    }
+
     async toggleRegistration(requesterId, body) {
         await this.verifyAdmin(requesterId);
 

--- a/backend/modules/landing/locales/en/landing.json
+++ b/backend/modules/landing/locales/en/landing.json
@@ -33,7 +33,8 @@
     "demoNote": "A real hosted instance, seeded with sample data, shared and reset regularly",
     "screenshotAlt": "The tududi interface, showing the Today view with planned tasks",
     "ctaCloud": "tududi Cloud",
-    "ctaSelfHosted": "Self-hosted"
+    "ctaSelfHosted": "Self-hosted",
+    "ctaWaitlist": "Join the waitlist"
   },
   "proof": {
     "stars": "stars on GitHub",
@@ -404,12 +405,13 @@
     }
   },
   "waitlist": {
-    "title": "Not ready yet?",
-    "sub": "Leave your email for release notes and the occasional update. No spam, unsubscribe in one click.",
+    "title": "tududi Cloud is opening soon",
+    "sub": "Leave your email and we will tell you the day it opens. Nothing else, and one click to leave.",
     "placeholder": "you@email.com",
     "inputLabel": "Email address",
     "submit": "Notify me",
-    "note": "We store your address and the date you gave it, so we can send you release notes and nothing else. We never share it."
+    "note": "We store your address and the date you gave it, so we can tell you when Cloud opens. We never share it.",
+    "joined": "You are on the list. We will email you when tududi Cloud opens."
   },
   "langs": {
     "heading": "The tududi app is available in {{count}} languages worldwide"

--- a/backend/modules/landing/routes.js
+++ b/backend/modules/landing/routes.js
@@ -2,6 +2,7 @@ const path = require('path');
 const express = require('express');
 const ejs = require('ejs');
 const { getPlans } = require('../../config/plans');
+const { logError } = require('../../services/logService');
 const { getStats } = require('./stats');
 const {
     DEFAULT_LOCALE,
@@ -127,6 +128,7 @@ function createLandingRouter(landing) {
                 pageUrl,
                 money,
                 jsonForScript,
+                joined: req.query.joined === '1',
                 ...extra,
             },
             { cache: cacheRenders, rmWhitespace: false }
@@ -183,10 +185,12 @@ function createLandingRouter(landing) {
                 pageUrl,
                 money,
                 jsonForScript,
+                joined: req.query.joined === '1',
             },
             { cache: cacheRenders, rmWhitespace: false }
         );
-        if (cacheRenders) rendered.set(cacheKey, { html, at: Date.now() });
+        if (cacheRenders && !req.query.joined)
+            rendered.set(cacheKey, { html, at: Date.now() });
         res.type('html').send(html);
     }
 
@@ -230,6 +234,55 @@ function createLandingRouter(landing) {
 
         if (req.path.endsWith('/')) return res.redirect(301, `/${pathLocale}`);
         return renderLanding(req, res, pathLocale).catch(next);
+    });
+
+    // Waitlist capture. A plain form post on the marketing host itself, so
+    // it needs no JavaScript, no CORS and no CSRF token: there is no session
+    // here to ride on. The answer is always the same page with ?joined=1,
+    // whether the address was new, already on the list or refused, so the
+    // form cannot be used to find out who has signed up.
+    const waitlistBody = express.urlencoded({ extended: false, limit: '4kb' });
+    const WAITLIST_SOURCES = new Set(['hero', 'waitlist', 'footer', 'cloud']);
+
+    router.post('/waitlist', waitlistBody, async (req, res) => {
+        const locale = isSupportedLocale(req.body?.locale)
+            ? req.body.locale
+            : DEFAULT_LOCALE;
+        const back = `${localePath(locale)}?joined=1#waitlist`;
+        const email = String(req.body?.email || '')
+            .trim()
+            .toLowerCase();
+        const source = WAITLIST_SOURCES.has(req.body?.source)
+            ? req.body.source
+            : 'unknown';
+
+        // Cheap shape check only. Anything past this is the mail provider's
+        // problem, and telling a visitor their address looks wrong is worse
+        // than quietly keeping a dud row.
+        if (
+            !/^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(email) ||
+            email.length > 254
+        ) {
+            return res.redirect(303, back);
+        }
+
+        try {
+            const { WaitlistSubscriber } = require('../../models');
+            const [row, created] = await WaitlistSubscriber.findOrCreate({
+                where: { email },
+                defaults: {
+                    email,
+                    source,
+                    locale,
+                    referrer: (req.get('referer') || '').slice(0, 512) || null,
+                },
+            });
+            if (!created) await row.increment('submission_count');
+        } catch (error) {
+            // A capture failure must not show a stranger a stack trace.
+            logError('Waitlist signup failed:', error);
+        }
+        return res.redirect(303, back);
     });
 
     // The base language lives at the root, so /en is not a real URL.

--- a/backend/modules/landing/views/cloud.ejs
+++ b/backend/modules/landing/views/cloud.ejs
@@ -53,7 +53,7 @@
         <h1><%= t('cloud.title') %></h1>
         <p><%= t('cloud.lede') %></p>
         <div class="hero-actions" style="justify-content:center;">
-            <a href="<%= appUrl %>/register" class="btn-primary"><%= t('cloud.ctaPrimary') %></a>
+            <a href="<%= pricing.cloudOpen ? appUrl + '/register' : localePath(i18n.locale) + '#waitlist' %>" class="btn-primary"><%= pricing.cloudOpen ? t('cloud.ctaPrimary') : t('hero.ctaWaitlist') %></a>
             <a href="#cloud-pricing" class="btn-secondary"><%= t('cloud.ctaPricing') %></a>
         </div>
         <p class="hero-note" style="margin-top:16px;"><i class="fas fa-lock-open"></i><%= t('cloud.note') %></p>
@@ -111,7 +111,7 @@
                         <li><i class="fas fa-check"></i><%= feature %></li>
                         <% }); %>
                     </ul>
-                    <a href="<%= appUrl %>/register" class="plan-action plan-action-primary"><%= t('cloud.ctaPrimary') %></a>
+                    <a href="<%= pricing.cloudOpen ? appUrl + '/register' : localePath(i18n.locale) + '#waitlist' %>" class="plan-action plan-action-primary"><%= pricing.cloudOpen ? t('cloud.ctaPrimary') : t('hero.ctaWaitlist') %></a>
                 </div>
             </div>
 

--- a/backend/modules/landing/views/landing.ejs
+++ b/backend/modules/landing/views/landing.ejs
@@ -301,7 +301,7 @@
                 <%# The two ways to run tududi, side by side and equally
                     weighted: somebody arriving here is choosing between them,
                     not being sold one. %>
-                <a href="<%= localePath(i18n.locale, '/cloud') %>" class="btn-primary"><i class="fas fa-cloud"></i><%= t('hero.ctaCloud') %></a>
+                <a href="<%= pricing.cloudOpen ? localePath(i18n.locale, '/cloud') : '#waitlist' %>" class="btn-primary"><i class="fas fa-cloud"></i><%= pricing.cloudOpen ? t('hero.ctaCloud') : t('hero.ctaWaitlist') %></a>
                 <a href="#self-host" class="btn-secondary"><i class="fab fa-docker"></i><%= t('hero.ctaSelfHosted') %></a>
             </div>
             <% if (demo && demo.available) { %>
@@ -944,10 +944,13 @@
                     <i class="fab fa-reddit"></i> r/tududi
                 </a>
             </div>
-            <% if (newsletterAction) { %>
-            <form class="waitlist-form" action="<%= newsletterAction %>" method="post" target="_blank">
+            <% if (joined) { %>
+            <p class="waitlist-done" data-testid="waitlist-joined"><%= t('waitlist.joined') %></p>
+            <% } else { %>
+            <form class="waitlist-form" action="/waitlist" method="post">
                 <input type="email" name="email" placeholder="<%= t('waitlist.placeholder') %>" aria-label="<%= t('waitlist.inputLabel') %>" required>
-                <input type="hidden" name="tag" value="waitlist">
+                <input type="hidden" name="source" value="waitlist">
+                <input type="hidden" name="locale" value="<%= i18n.locale %>">
                 <button type="submit"><%= t('waitlist.submit') %></button>
             </form>
             <p class="waitlist-note">

--- a/backend/modules/landing/views/partials/footer.ejs
+++ b/backend/modules/landing/views/partials/footer.ejs
@@ -49,17 +49,16 @@
                         <a href="https://www.paypal.com/donate/?hosted_button_id=QEQCKLXPB6XAE">PayPal</a>
                     </div>
                 </div>
-                <% if (newsletterAction) { %>
                 <div class="footer-sub">
                     <h3><%= t('footer.subTitle') %></h3>
                     <p><%= t('footer.subBody') %></p>
-                    <form action="<%= newsletterAction %>" method="post" target="_blank">
+                    <form action="/waitlist" method="post">
                         <input type="email" name="email" placeholder="<%= t('waitlist.placeholder') %>" aria-label="<%= t('waitlist.inputLabel') %>" required>
-                        <input type="hidden" name="tag" value="footer">
+                        <input type="hidden" name="source" value="footer">
+                        <input type="hidden" name="locale" value="<%= i18n.locale %>">
                         <button type="submit"><%= t('footer.subSubmit') %></button>
                     </form>
                 </div>
-                <% } %>
             </div>
             <div class="footer-bottom">
                 <p>&copy; 2026 <strong>tududi</strong>. <%= t('footer.rights') %></p>

--- a/backend/tests/helpers/setup.js
+++ b/backend/tests/helpers/setup.js
@@ -46,6 +46,7 @@ const CLEANUP_TABLES = [
     'calendar_tokens',
     'rate_limits',
     'usage_counters',
+    'waitlist_subscribers',
     'billing_events',
     'billing_accounts',
     'notifications',

--- a/backend/tests/integration/admin-dashboard.test.js
+++ b/backend/tests/integration/admin-dashboard.test.js
@@ -1,0 +1,80 @@
+const request = require('supertest');
+const app = require('../../app');
+const { Role, WaitlistSubscriber } = require('../../models');
+const { createTestUser } = require('../helpers/testUtils');
+
+const login = async (user) => {
+    const agent = request.agent(app);
+    await agent
+        .post('/api/login')
+        .send({ email: user.email, password: 'password123' });
+    return agent;
+};
+
+describe('Admin dashboard', () => {
+    let admin, adminAgent, plain, plainAgent;
+
+    beforeEach(async () => {
+        admin = await createTestUser({
+            email: `adm_${Date.now()}@example.com`,
+        });
+        await Role.update({ is_admin: true }, { where: { user_id: admin.id } });
+        adminAgent = await login(admin);
+
+        plain = await createTestUser({
+            email: `usr_${Date.now()}@example.com`,
+        });
+        plainAgent = await login(plain);
+    });
+
+    it('counts users, content and the waitlist', async () => {
+        await WaitlistSubscriber.create({
+            email: `w1_${Date.now()}@example.com`,
+            source: 'hero',
+        });
+
+        const res = await adminAgent.get('/api/admin/overview');
+        expect(res.status).toBe(200);
+        expect(res.body.users.total).toBeGreaterThanOrEqual(2);
+        expect(res.body.users.admins).toBeGreaterThanOrEqual(1);
+        expect(res.body.waitlist.total).toBeGreaterThanOrEqual(1);
+        expect(res.body.billing).toHaveProperty('paying');
+        expect(res.body.instance).toHaveProperty('registration_enabled');
+        expect(typeof res.body.instance.version).toBe('string');
+    });
+
+    it('lists the waitlist newest first', async () => {
+        const older = await WaitlistSubscriber.create({
+            email: `old_${Date.now()}@example.com`,
+            source: 'footer',
+            created_at: new Date(Date.now() - 60000),
+        });
+        const newer = await WaitlistSubscriber.create({
+            email: `new_${Date.now()}@example.com`,
+            source: 'hero',
+        });
+
+        const res = await adminAgent.get('/api/admin/waitlist?limit=10');
+        expect(res.status).toBe(200);
+        const emails = res.body.subscribers.map((s) => s.email);
+        expect(emails).toContain(newer.email);
+        expect(emails).toContain(older.email);
+        expect(emails.indexOf(newer.email)).toBeLessThan(
+            emails.indexOf(older.email)
+        );
+    });
+
+    it('refuses both endpoints to a non-admin', async () => {
+        expect((await plainAgent.get('/api/admin/overview')).status).toBe(403);
+        expect((await plainAgent.get('/api/admin/waitlist')).status).toBe(403);
+    });
+
+    it('refuses both endpoints when signed out', async () => {
+        expect((await request(app).get('/api/admin/overview')).status).toBe(
+            401
+        );
+        expect((await request(app).get('/api/admin/waitlist')).status).toBe(
+            401
+        );
+    });
+});

--- a/backend/tests/integration/landing.test.js
+++ b/backend/tests/integration/landing.test.js
@@ -36,9 +36,8 @@ describe('Landing page', () => {
         expect(res.text).toContain('<html lang="en"');
         expect(res.text).toContain('https://app.tududi.com/register');
         expect(res.text).toContain('https://app.tududi.com/login');
-        expect(res.text).toContain(
-            'action="https://buttondown.com/api/emails/embed-subscribe/tududi"'
-        );
+        // The waitlist posts to the site's own endpoint, not a third party
+        expect(res.text).toContain('action="/waitlist"');
         // Every locale, itself included, plus x-default
         const hreflangs = res.text.match(/hreflang="/g) || [];
         expect(hreflangs.length).toBeGreaterThanOrEqual(LOCALES.length + 1);
@@ -166,6 +165,98 @@ describe('Landing page', () => {
             .get('/cloud')
             .set('Host', 'app.tududi.com');
         expect(res.text).toContain('<div id="root"');
+    });
+
+    describe('the Cloud waitlist', () => {
+        const { WaitlistSubscriber } = require('../../models');
+
+        it('stores an address and answers the same way twice', async () => {
+            const email = `wait_${Date.now()}@example.com`;
+            const first = await request(app)
+                .post('/waitlist')
+                .set('Host', 'tududi.com')
+                .type('form')
+                .send({ email, source: 'hero', locale: 'en' });
+            expect(first.status).toBe(303);
+            expect(first.headers.location).toBe('/?joined=1#waitlist');
+
+            const row = await WaitlistSubscriber.findOne({ where: { email } });
+            expect(row.source).toBe('hero');
+            expect(row.submission_count).toBe(1);
+
+            // A second go looks identical from outside, so the form cannot
+            // be used to test whether an address is already on the list.
+            const again = await request(app)
+                .post('/waitlist')
+                .set('Host', 'tududi.com')
+                .type('form')
+                .send({ email, source: 'footer', locale: 'en' });
+            expect(again.status).toBe(303);
+            expect(again.headers.location).toBe(first.headers.location);
+            await row.reload();
+            expect(row.submission_count).toBe(2);
+            expect(await WaitlistSubscriber.count({ where: { email } })).toBe(
+                1
+            );
+        });
+
+        it('lower-cases the address and comes back in the visitor locale', async () => {
+            const email = `MiXeD_${Date.now()}@Example.COM`;
+            const res = await request(app)
+                .post('/waitlist')
+                .set('Host', 'tududi.com')
+                .type('form')
+                .send({ email, source: 'waitlist', locale: 'fr' });
+            expect(res.headers.location).toBe('/fr?joined=1#waitlist');
+            expect(
+                await WaitlistSubscriber.findOne({
+                    where: { email: email.toLowerCase() },
+                })
+            ).not.toBeNull();
+        });
+
+        it('says the same thing for a malformed address and stores nothing', async () => {
+            const before = await WaitlistSubscriber.count();
+            const res = await request(app)
+                .post('/waitlist')
+                .set('Host', 'tududi.com')
+                .type('form')
+                .send({ email: 'not-an-email', source: 'hero' });
+            expect(res.status).toBe(303);
+            expect(res.headers.location).toBe('/?joined=1#waitlist');
+            expect(await WaitlistSubscriber.count()).toBe(before);
+        });
+
+        it('shows the confirmation instead of the form after joining', async () => {
+            const res = await request(app)
+                .get('/?joined=1')
+                .set('Host', 'tududi.com');
+            expect(res.text).toContain('data-testid="waitlist-joined"');
+            // The section's own form is replaced by the confirmation; the
+            // footer signup stays, so look for that form specifically.
+            expect(res.text).not.toContain('value="waitlist"');
+        });
+
+        it('is not reachable on the app host', async () => {
+            const res = await request(app)
+                .post('/waitlist')
+                .set('Host', 'app.tududi.com')
+                .type('form')
+                .send({ email: 'x@example.com' });
+            expect(res.status).not.toBe(303);
+        });
+    });
+
+    it('sends the hero to the waitlist while Cloud is shut', async () => {
+        const original = config.landing.pricing.cloudOpen;
+        config.landing.pricing.cloudOpen = false;
+        try {
+            const res = await request(app).get('/').set('Host', 'tududi.com');
+            expect(res.text).toContain('href="#waitlist"');
+            expect(res.text).toContain('action="/waitlist"');
+        } finally {
+            config.landing.pricing.cloudOpen = original;
+        }
     });
 
     it('serves the app on every other host', async () => {

--- a/frontend/App.tsx
+++ b/frontend/App.tsx
@@ -421,6 +421,31 @@ const App: React.FC = () => {
                                 }
                             />
                             <Route
+                                path="/admin"
+                                element={
+                                    currentUser?.is_admin === true ? (
+                                        <React.Suspense
+                                            fallback={
+                                                <div className="p-4">
+                                                    Loading...
+                                                </div>
+                                            }
+                                        >
+                                            {React.createElement(
+                                                React.lazy(
+                                                    () =>
+                                                        import(
+                                                            './components/Admin/AdminDashboardPage'
+                                                        )
+                                                )
+                                            )}
+                                        </React.Suspense>
+                                    ) : (
+                                        <Navigate to="/today" replace />
+                                    )
+                                }
+                            />
+                            <Route
                                 path="/admin/users"
                                 element={
                                     currentUser?.is_admin === true ? (

--- a/frontend/components/Admin/AdminDashboardPage.tsx
+++ b/frontend/components/Admin/AdminDashboardPage.tsx
@@ -1,0 +1,234 @@
+import React, { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import {
+    UsersIcon,
+    CreditCardIcon,
+    EnvelopeIcon,
+    RectangleStackIcon,
+} from '@heroicons/react/24/outline';
+import { getApiPath } from '../../config/paths';
+import { handleAuthResponse } from '../../utils/authUtils';
+
+interface Overview {
+    users: { total: number; admins: number; verified: number; last24h: number };
+    content: { tasks: number; projects: number; notes: number };
+    waitlist: { total: number; last7d: number };
+    billing: {
+        paying: number;
+        hosted: boolean;
+        subscription_required: boolean;
+        provider: string | null;
+    };
+    instance: {
+        registration_enabled: boolean;
+        version: string;
+        environment: string;
+    };
+}
+
+interface WaitlistEntry {
+    id: number;
+    email: string;
+    source: string;
+    locale: string | null;
+    submission_count: number;
+    created_at: string;
+}
+
+const Stat: React.FC<{
+    label: string;
+    value: React.ReactNode;
+    hint?: string;
+}> = ({ label, value, hint }) => (
+    <div className="bg-white dark:bg-gray-800 rounded-lg p-5 border border-gray-200 dark:border-gray-700">
+        <p className="text-sm text-gray-500 dark:text-gray-400">{label}</p>
+        <p className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mt-1">
+            {value}
+        </p>
+        {hint && (
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                {hint}
+            </p>
+        )}
+    </div>
+);
+
+// What an operator wants on opening the admin area: who is here, whether
+// the instance is selling anything, and who is waiting for it to open.
+const AdminDashboardPage: React.FC = () => {
+    const { t } = useTranslation();
+    const [data, setData] = useState<Overview | null>(null);
+    const [waitlist, setWaitlist] = useState<WaitlistEntry[]>([]);
+    const [error, setError] = useState<string | null>(null);
+
+    useEffect(() => {
+        const load = async () => {
+            try {
+                const res = await fetch(getApiPath('admin/overview'), {
+                    credentials: 'include',
+                });
+                await handleAuthResponse(res, 'Failed to load the overview.');
+                setData(await res.json());
+
+                const wl = await fetch(getApiPath('admin/waitlist?limit=25'), {
+                    credentials: 'include',
+                });
+                if (wl.ok) setWaitlist((await wl.json()).subscribers || []);
+            } catch (err: any) {
+                setError(err.message || 'Could not load the dashboard');
+            }
+        };
+        load();
+    }, []);
+
+    if (error) {
+        return (
+            <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+                <p className="text-red-500" data-testid="admin-dashboard-error">
+                    {error}
+                </p>
+            </div>
+        );
+    }
+
+    if (!data) {
+        return (
+            <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 text-gray-500 dark:text-gray-400">
+                {t('common.loading', 'Loading...')}
+            </div>
+        );
+    }
+
+    return (
+        <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-1">
+                {t('admin.dashboard.title', 'Admin')}
+            </h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+                {t('admin.dashboard.subtitle', 'tududi {{version}} · {{env}}', {
+                    version: data.instance.version,
+                    env: data.instance.environment,
+                })}
+            </p>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+                <Stat
+                    label={t('admin.dashboard.users', 'Users')}
+                    value={data.users.total}
+                    hint={t(
+                        'admin.dashboard.usersHint',
+                        '{{verified}} verified · {{admins}} admin · {{new}} today',
+                        {
+                            verified: data.users.verified,
+                            admins: data.users.admins,
+                            new: data.users.last24h,
+                        }
+                    )}
+                />
+                <Stat
+                    label={t('admin.dashboard.paying', 'Paying')}
+                    value={data.billing.paying}
+                    hint={
+                        data.billing.hosted
+                            ? `${data.billing.provider || '-'}${data.billing.subscription_required ? ' · gated' : ''}`
+                            : t('admin.dashboard.selfHosted', 'self-hosted')
+                    }
+                />
+                <Stat
+                    label={t('admin.dashboard.waitlist', 'Waitlist')}
+                    value={data.waitlist.total}
+                    hint={t('admin.dashboard.waitlistHint', '{{n}} in 7 days', {
+                        n: data.waitlist.last7d,
+                    })}
+                />
+                <Stat
+                    label={t('admin.dashboard.content', 'Content')}
+                    value={data.content.tasks}
+                    hint={t(
+                        'admin.dashboard.contentHint',
+                        '{{projects}} projects · {{notes}} notes',
+                        {
+                            projects: data.content.projects,
+                            notes: data.content.notes,
+                        }
+                    )}
+                />
+            </div>
+
+            <div className="flex flex-wrap gap-3 mb-8">
+                <Link
+                    to="/admin/users"
+                    className="inline-flex items-center px-4 py-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+                >
+                    <UsersIcon className="w-4 h-4 mr-2" />
+                    {t('admin.users.title', 'Users')}
+                </Link>
+                <Link
+                    to="/admin/billing"
+                    className="inline-flex items-center px-4 py-2 rounded-lg bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+                >
+                    <CreditCardIcon className="w-4 h-4 mr-2" />
+                    {t('admin.billing.title', 'Billing')}
+                </Link>
+                <span className="inline-flex items-center px-4 py-2 rounded-lg text-sm text-gray-500 dark:text-gray-400">
+                    <RectangleStackIcon className="w-4 h-4 mr-2" />
+                    {data.instance.registration_enabled
+                        ? t('admin.dashboard.regOpen', 'Registration open')
+                        : t('admin.dashboard.regClosed', 'Registration closed')}
+                </span>
+            </div>
+
+            <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-3 flex items-center">
+                <EnvelopeIcon className="w-5 h-5 mr-2" />
+                {t('admin.dashboard.waitlistLatest', 'Latest waitlist signups')}
+            </h2>
+            {waitlist.length === 0 ? (
+                <p className="text-gray-500 dark:text-gray-400 text-sm">
+                    {t('admin.dashboard.waitlistEmpty', 'Nobody yet.')}
+                </p>
+            ) : (
+                <div className="overflow-x-auto bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700">
+                    <table className="min-w-full text-sm">
+                        <thead className="text-gray-500 dark:text-gray-400 border-b border-gray-200 dark:border-gray-700">
+                            <tr>
+                                <th className="text-left px-4 py-2 font-medium">
+                                    {t('admin.dashboard.email', 'Email')}
+                                </th>
+                                <th className="text-left px-4 py-2 font-medium">
+                                    {t('admin.dashboard.source', 'Source')}
+                                </th>
+                                <th className="text-left px-4 py-2 font-medium">
+                                    {t('admin.dashboard.joined', 'Joined')}
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {waitlist.map((w) => (
+                                <tr
+                                    key={w.id}
+                                    className="border-b border-gray-100 dark:border-gray-700 last:border-0"
+                                >
+                                    <td className="px-4 py-2 text-gray-800 dark:text-gray-200">
+                                        {w.email}
+                                    </td>
+                                    <td className="px-4 py-2 text-gray-500 dark:text-gray-400">
+                                        {w.source}
+                                        {w.locale ? ` · ${w.locale}` : ''}
+                                    </td>
+                                    <td className="px-4 py-2 text-gray-500 dark:text-gray-400">
+                                        {new Date(
+                                            w.created_at
+                                        ).toLocaleDateString()}
+                                    </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default AdminDashboardPage;

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -10,6 +10,7 @@ import {
     EnvelopeIcon,
     MagnifyingGlassIcon,
     Cog6ToothIcon,
+    ShieldCheckIcon,
     CircleStackIcon,
     InformationCircleIcon,
     ArrowRightStartOnRectangleIcon,
@@ -267,6 +268,25 @@ const Navbar: React.FC<NavbarProps> = ({
                                     </div>
                                 )}
                                 {featureFlags.hosted && <PlanBadge />}
+                                {currentUser?.is_admin && (
+                                    <Link
+                                        to="/admin"
+                                        className="flex items-center justify-between px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                                        onClick={() => setIsDropdownOpen(false)}
+                                        data-testid="navbar-admin-link"
+                                    >
+                                        <span className="flex items-center">
+                                            <ShieldCheckIcon className="h-4 w-4 mr-2 shrink-0" />
+                                            {t('navigation.admin', 'Admin')}
+                                        </span>
+                                        <span className="ml-3 px-1.5 py-0.5 rounded text-[10px] font-semibold tracking-wide uppercase bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-200">
+                                            {t(
+                                                'navigation.adminBadge',
+                                                'Admin'
+                                            )}
+                                        </span>
+                                    </Link>
+                                )}
                                 <Link
                                     to="/profile"
                                     className="flex items-center px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -85,7 +85,9 @@
     "toggleSearch": "Toggle Search",
     "quickInboxCapture": "Quick Inbox Capture",
     "userMenu": "User Menu",
-    "search": "Search"
+    "search": "Search",
+    "admin": "Admin",
+    "adminBadge": "Admin"
   },
   "settings": {
     "todayPageSettings": "Today Page Settings",
@@ -1509,7 +1511,26 @@
     "failedToDeleteUser": "Failed to delete user",
     "confirmDelete": "Are you sure you want to delete this user?",
     "deleteUser": "Delete User",
-    "confirmDeleteUser": "Are you sure you want to delete {{email}}? This action cannot be undone."
+    "confirmDeleteUser": "Are you sure you want to delete {{email}}? This action cannot be undone.",
+    "dashboard": {
+      "title": "Admin",
+      "subtitle": "tududi {{version}} · {{env}}",
+      "users": "Users",
+      "usersHint": "{{verified}} verified · {{admins}} admin · {{new}} today",
+      "paying": "Paying",
+      "selfHosted": "self-hosted",
+      "waitlist": "Waitlist",
+      "waitlistHint": "{{n}} in 7 days",
+      "content": "Tasks",
+      "contentHint": "{{projects}} projects · {{notes}} notes",
+      "regOpen": "Registration open",
+      "regClosed": "Registration closed",
+      "waitlistLatest": "Latest waitlist signups",
+      "waitlistEmpty": "Nobody yet.",
+      "email": "Email",
+      "source": "Source",
+      "joined": "Joined"
+    }
   },
   "billing": {
     "title": "Plan & Billing",


### PR DESCRIPTION
## Description

Two things, both prompted by Cloud being closed while the site still advertised it.

**A waitlist that belongs to us.** The hero's Cloud button pointed at `/cloud`, whose Get started button pointed at a registration page that now refuses. Both CTAs follow the existing `cloudOpen` flag: with Cloud shut they say "Join the waitlist" and go to a single email input; with it open they behave as before. The form posts to `/waitlist` on the marketing host itself, so it needs no JavaScript, no CORS and no CSRF token, and it no longer depends on a third-party list being configured. Addresses go to a new `waitlist_subscribers` table.

The response is identical whether the address is new, already on the list, or malformed: a 303 back to `?joined=1#waitlist`. That is deliberate, it stops the form being used to test whether someone has signed up. A repeat submission bumps `submission_count` rather than creating a second row, and addresses are lower-cased on the way in.

**An admin dashboard.** `/admin` shows users (total, verified, admins, last 24h), paying accounts with the provider and whether the instance is gated, waitlist totals, content counts, the registration state, and the 25 most recent waitlist signups. `GET /api/admin/overview` and `GET /api/admin/waitlist` back it, both admin-only. The top-right menu gains an Admin entry with a badge, shown only to admins.

## Type of Change

- [x] New feature (adds functionality)

## Testing

**How did you test this?**

- `landing.test.js` grew to 19: storing an address, the identical answer on a repeat, lower-casing, the locale-aware redirect, a malformed address storing nothing, the confirmation replacing the form, the endpoint being unreachable on the app host, and the hero switching to the waitlist when `cloudOpen` is false.
- New `admin-dashboard.test.js` (4 tests): the counts, newest-first ordering, 403 for a non-admin, 401 when signed out.
- `npm run backend:test:upgrade` 64 passing, so the new table's migration applies on the legacy fixtures and schema parity holds.
- Full backend suite: 2000 passing. Five suites failed only in the parallel run and all 100 of their tests pass in isolation (the known port flake); the set differs on each run.
- `npm run frontend:test` 123 passing, `npm run lint` zero errors, `tsc --noEmit` clean.

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)