### PR TITLE
fix(demo): the sandbox cannot mint API tokens

### DIFF
--- a/backend/modules/demo/service.js
+++ b/backend/modules/demo/service.js
@@ -118,6 +118,7 @@ async function resetDemo({ force = false } = {}) {
             Goal,
             View,
             Person,
+            ApiToken,
         } = models;
         const where = { where: { user_id: user.id } };
         // Tasks first: notes and projects are referenced by them.
@@ -130,6 +131,8 @@ async function resetDemo({ force = false } = {}) {
         await Tag.destroy({ ...where, force: true });
         if (View) await View.destroy({ ...where, force: true });
         if (Person) await Person.destroy({ ...where, force: true });
+        // Any token minted before the route guard existed dies here too.
+        if (ApiToken) await ApiToken.destroy({ ...where, force: true });
 
         await seedDemoData(user.id, models);
         await user.update({

--- a/backend/modules/users/routes.js
+++ b/backend/modules/users/routes.js
@@ -89,9 +89,12 @@ router.get(
     apiKeyManagementLimiter,
     usersController.listApiKeys
 );
+// Closed to the demo account: a token would keep working after the sandbox
+// is wiped, which is the one thing the reset exists to prevent.
 router.post(
     '/profile/api-keys',
     apiKeyManagementLimiter,
+    blockDemoUser,
     usersController.createApiKey
 );
 router.post(

--- a/backend/tests/integration/demo.test.js
+++ b/backend/tests/integration/demo.test.js
@@ -109,6 +109,30 @@ describe('Public demo sandbox', () => {
         ).not.toBeNull();
     });
 
+    it('cannot mint an API token, and any old one dies at the reset', async () => {
+        const { ApiToken } = require('../../models');
+        const agent = request.agent(app);
+        await agent.post('/api/demo/login');
+        const user = await User.findOne({ where: { email: DEMO_EMAIL } });
+
+        // A token would outlive the wipe, which is the one kind of access
+        // the reset exists to remove.
+        const minted = await agent
+            .post('/api/profile/api-keys')
+            .send({ name: 'persistence' });
+        expect(minted.status).toBe(403);
+
+        // One created before the guard existed is cleared by the reset
+        await ApiToken.create({
+            user_id: user.id,
+            name: 'legacy',
+            token_hash: 'x'.repeat(60),
+            token_prefix: 'tt_test',
+        });
+        await demoService.resetDemo();
+        expect(await ApiToken.count({ where: { user_id: user.id } })).toBe(0);
+    });
+
     it('wipes what a visitor did and seeds it again on reset', async () => {
         const agent = request.agent(app);
         await agent.post('/api/demo/login');


### PR DESCRIPTION
## Description

The demo account could create an API token, and that token would keep working after the sandbox was wiped. Persistent access to a shared public account is exactly what the reset exists to prevent.

- `POST /api/profile/api-keys` is now closed to the demo account (403).
- `resetDemo()` destroys the account's tokens, so anything minted before this guard is cleared on the next cycle.
- Listing and revoking stay open, so a visitor can still see what the sandbox holds.

Found by the automated security review of `52566258`.

## Type of Change

- [x] Bug fix (fixes an issue)

## Testing

**How did you test this?**

- `demo.test.js` gains a case: minting is refused with 403, and a token inserted directly (as one created before the guard would have been) is gone after a reset. 7 passing.
- `demo`, `api-tokens` and `users` suites together: 76 passing. `npm run lint` zero errors.

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)