### PR TITLE
feat(release): cut the GitHub Release from the tag, and pick versions by channel

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -27,6 +27,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
 
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      latest: ${{ steps.version.outputs.latest }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -49,12 +54,17 @@ jobs:
             echo "Refusing to publish: '$VERSION' is not a version" >&2
             exit 1
           fi
+          # One rule for both: anything with a hyphen (1.5.0-rc.1,
+          # 1.5.0-dev.3) is a pre-release. It never moves the :latest image
+          # tag and it is flagged as a pre-release on GitHub.
+          PRERELEASE="false"
           case "$VERSION" in
-            *-*) LATEST="false" ;;   # pre-releases never move latest
+            *-*) LATEST="false"; PRERELEASE="true" ;;
           esac
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "latest=$LATEST" >> "$GITHUB_OUTPUT"
-          echo "Publishing $VERSION (latest: $LATEST)"
+          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
+          echo "Publishing $VERSION (latest: $LATEST, prerelease: $PRERELEASE)"
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -84,3 +94,79 @@ jobs:
       - name: Print digest
         run: |
           echo "chrisvel/tududi:${{ steps.version.outputs.version }}@${{ steps.build.outputs.digest }}" | tee -a "$GITHUB_STEP_SUMMARY"
+
+  # The GitHub Release is cut only from a real tag push, and only after the
+  # image it describes is on Docker Hub, so a release never points at
+  # something nobody can pull. workflow_dispatch republishes an image for a
+  # tag that already has its release, so it is skipped here.
+  release:
+    needs: publish
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build release notes
+        id: notes
+        env:
+          VERSION: ${{ needs.publish.outputs.version }}
+          PRERELEASE: ${{ needs.publish.outputs.prerelease }}
+        run: |
+          # A stable release documents itself: CHANGELOG.md carries a section
+          # written by hand, and that is the release body. Pre-releases are
+          # cut too often to justify that, so they get generated notes.
+          NOTES_FILE="release-notes.md"
+          if [ "$PRERELEASE" = "false" ] && [ -f CHANGELOG.md ]; then
+            awk -v v="$VERSION" '
+              $0 == "## " v { found = 1; next }
+              found && /^## / { exit }
+              found { print }
+            ' CHANGELOG.md > "$NOTES_FILE"
+          fi
+          if [ -s "$NOTES_FILE" ]; then
+            echo "Using the CHANGELOG.md section for $VERSION"
+            echo "generate=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "No CHANGELOG.md section for $VERSION; generating notes"
+            printf '' > "$NOTES_FILE"
+            echo "generate=true" >> "$GITHUB_OUTPUT"
+          fi
+          {
+            echo ""
+            echo "Docker image: \`docker pull chrisvel/tududi:$VERSION\`"
+          } >> "$NOTES_FILE"
+
+      - name: Create the GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          PRERELEASE: ${{ needs.publish.outputs.prerelease }}
+          GENERATE: ${{ steps.notes.outputs.generate }}
+        run: |
+          # Re-running the workflow on a tag that already has a release must
+          # update it rather than fail the run.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG exists, updating it"
+            ACTION=edit
+          else
+            ACTION=create
+          fi
+          set -- "$TAG" --title "$TAG" --notes-file release-notes.md
+          if [ "$PRERELEASE" = "true" ]; then
+            set -- "$@" --prerelease
+          else
+            set -- "$@" --latest
+          fi
+          if [ "$ACTION" = "create" ] && [ "$GENERATE" = "true" ]; then
+            set -- "$@" --generate-notes
+          fi
+          gh release "$ACTION" "$@"
+          gh release view "$TAG" --json tagName,isPrerelease,url \
+            | tee -a "$GITHUB_STEP_SUMMARY"

--- a/scripts/create-version.sh
+++ b/scripts/create-version.sh
@@ -1,12 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
-  echo "Usage: $0 <version>" >&2
+# Cuts a release: bumps package.json, rolls the changelog for a stable
+# release, commits and tags. Pushing the tag is what publishes the image and
+# creates the GitHub Release (.github/workflows/docker-publish.yml).
+#
+#   ./scripts/create-version.sh              ask which kind, propose the number
+#   ./scripts/create-version.sh v1.5.0       take that version, no questions
+#
+# The version decides everything downstream: anything with a hyphen
+# (v1.5.0-rc.1, v1.5.0-dev.3) is a pre-release, which never moves the :latest
+# image tag and is flagged as a pre-release on GitHub. A plain v1.5.0 does
+# both.
+
+if [[ $# -gt 1 ]]; then
+  echo "Usage: $0 [version]" >&2
   exit 1
 fi
-
-VERSION=$1
 
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "Error: This script must be run inside a git repository." >&2
@@ -21,13 +31,63 @@ if [[ ! -f package.json ]]; then
   exit 1
 fi
 
-if git show-ref --tags --verify --quiet "refs/tags/$VERSION"; then
-  echo "Error: Tag $VERSION already exists." >&2
+if [[ -n $(git status --porcelain) ]]; then
+  echo "Error: Working tree has uncommitted changes. Please commit or stash them before continuing." >&2
   exit 1
 fi
 
-if [[ -n $(git status --porcelain) ]]; then
-  echo "Error: Working tree has uncommitted changes. Please commit or stash them before continuing." >&2
+VERSION="${1:-}"
+
+if [[ -z "$VERSION" ]]; then
+  if [[ ! -t 0 ]]; then
+    echo "Error: no version given and no terminal to ask on." >&2
+    exit 1
+  fi
+
+  # Shell assignments: LATEST_STABLE/RC/DEV and NEXT_STABLE/RC/DEV.
+  eval "$(node scripts/version-plan.js)"
+
+  printf '\nLatest release on each channel\n\n'
+  printf '  stable  %s\n' "${LATEST_STABLE:-(none yet)}"
+  printf '  rc      %s\n' "${LATEST_RC:-(none yet)}"
+  printf '  dev     %s\n\n' "${LATEST_DEV:-(none yet)}"
+
+  printf 'What kind of release is this?\n\n'
+  printf '  1) stable             %-18s moves :latest\n' "$NEXT_STABLE"
+  printf '  2) release candidate  %-18s pre-release\n' "$NEXT_RC"
+  printf '  3) development        %-18s pre-release\n\n' "$NEXT_DEV"
+
+  # A bare `read` failing on Ctrl-D would exit silently under `set -e`.
+  read -r -p 'Choice [1-3]: ' CHOICE || { printf '\nCancelled.\n'; exit 1; }
+  case "$CHOICE" in
+    1) SUGGESTED="$NEXT_STABLE" ;;
+    2) SUGGESTED="$NEXT_RC" ;;
+    3) SUGGESTED="$NEXT_DEV" ;;
+    *) echo "Error: pick 1, 2 or 3." >&2; exit 1 ;;
+  esac
+
+  printf '\n'
+  read -r -p "Create ${SUGGESTED}? [Y/n, or type another version]: " ANSWER || { printf '\nCancelled.\n'; exit 1; }
+  case "$ANSWER" in
+    ''|y|Y|yes|YES) VERSION="$SUGGESTED" ;;
+    n|N|no|NO) echo "Nothing done."; exit 0 ;;
+    *) VERSION="$ANSWER" ;;
+  esac
+fi
+
+if [[ "$VERSION" != v* ]]; then
+  echo "Error: Version must start with 'v'" >&2
+  exit 1
+fi
+
+# Matches what the publish workflow will accept once the leading v is dropped.
+if ! printf '%s' "${VERSION#v}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$'; then
+  echo "Error: '$VERSION' is not a version like v1.5.0 or v1.5.0-rc.1" >&2
+  exit 1
+fi
+
+if git show-ref --tags --verify --quiet "refs/tags/$VERSION"; then
+  echo "Error: Tag $VERSION already exists." >&2
   exit 1
 fi
 
@@ -55,6 +115,46 @@ NODE
 
 git add package.json
 
+# Only a stable release closes the changelog. Pre-releases are cut too often
+# to justify a section each, and the release workflow gives them generated
+# notes instead; whatever is under Unreleased keeps accumulating until the
+# stable release that ships it.
+case "${VERSION#v}" in
+  *-*) : ;;
+  *)
+    node - "${VERSION#v}" <<'NODE'
+const fs = require('fs');
+
+const version = process.argv[2];
+const file = 'CHANGELOG.md';
+if (!fs.existsSync(file)) process.exit(0);
+
+const text = fs.readFileSync(file, 'utf8');
+const heading = '## Unreleased';
+const at = text.indexOf(heading);
+if (at === -1) {
+  console.error(`No "${heading}" section in ${file}; leaving it alone.`);
+  process.exit(0);
+}
+
+const body = text.slice(at + heading.length).replace(/^\s*/, '');
+const nextHeading = body.indexOf('\n## ');
+const unreleased = (nextHeading === -1 ? body : body.slice(0, nextHeading)).trim();
+if (!unreleased) {
+  console.error(`"${heading}" is empty; leaving ${file} alone.`);
+  process.exit(0);
+}
+
+fs.writeFileSync(
+  file,
+  text.slice(0, at) + `${heading}\n\n## ${version}` + text.slice(at + heading.length)
+);
+console.error(`Rolled ${heading} into ## ${version} in ${file}.`);
+NODE
+    git add CHANGELOG.md
+    ;;
+esac
+
 if git diff --cached --quiet; then
   echo "Error: No changes to commit after updating package.json." >&2
   exit 1
@@ -68,3 +168,5 @@ git tag -a "$VERSION" -m "Release $VERSION"
 echo "Version updated to $VERSION."
 echo "Created commit: $COMMIT_MESSAGE"
 echo "Created annotated tag: $VERSION"
+echo
+echo "Publish it with:  git push origin main --follow-tags"

--- a/scripts/version-plan.js
+++ b/scripts/version-plan.js
@@ -1,0 +1,109 @@
+'use strict';
+
+// Reads the tag history and works out what the next version would be on each
+// channel. Prints shell assignments so create-version.sh can `eval` it.
+//
+// Ordering lives here rather than in the shell because `sort -V` gets
+// pre-releases wrong: 1.5.0-rc.7 has to sort *below* 1.5.0, and rc.10 above
+// rc.9. Both are ordinary comparisons once the tag is parsed.
+
+const { execFileSync } = require('child_process');
+
+const TAG = /^v(\d+)\.(\d+)\.(\d+)(?:-(rc|dev)\.(\d+))?$/;
+
+function parse(tag) {
+    const m = TAG.exec(tag);
+    if (!m) return null;
+    return {
+        tag,
+        major: Number(m[1]),
+        minor: Number(m[2]),
+        patch: Number(m[3]),
+        channel: m[4] || 'stable',
+        number: m[5] ? Number(m[5]) : 0,
+    };
+}
+
+function compareRelease(a, b) {
+    return (
+        a.major - b.major ||
+        a.minor - b.minor ||
+        a.patch - b.patch ||
+        a.number - b.number
+    );
+}
+
+// Is this release for a version that has not shipped as stable yet?
+function isAhead(pre, stable) {
+    if (!pre) return false;
+    if (!stable) return true;
+    return (
+        (pre.major - stable.major ||
+            pre.minor - stable.minor ||
+            pre.patch - stable.patch) > 0
+    );
+}
+
+function base(v) {
+    return `${v.major}.${v.minor}.${v.patch}`;
+}
+
+function nextPatch(v) {
+    return v ? `${v.major}.${v.minor}.${v.patch + 1}` : '0.1.0';
+}
+
+const tags = execFileSync('git', ['tag', '--list', 'v*'], {
+    encoding: 'utf8',
+})
+    .split('\n')
+    .map((t) => t.trim())
+    .filter(Boolean)
+    .map(parse)
+    .filter(Boolean);
+
+const newest = (channel) => {
+    const of = tags.filter((t) => t.channel === channel);
+    return of.length ? of.sort(compareRelease)[of.length - 1] : null;
+};
+
+const stable = newest('stable');
+const rc = newest('rc');
+const dev = newest('dev');
+
+// The version currently in flight: the highest base that has pre-releases but
+// has not shipped as stable. While 1.5.0 is in RC, a first dev build belongs
+// on 1.5.0 too, not on an invented 1.4.3 line.
+const inFlight = [rc, dev]
+    .filter((v) => isAhead(v, stable))
+    .sort(compareRelease)
+    .pop();
+
+// A pre-release channel continues the line it is already on when that line is
+// ahead of the last stable release; otherwise it joins the version in flight,
+// and failing that opens a new patch line.
+function nextPre(channel, latest) {
+    if (isAhead(latest, stable)) {
+        return `v${base(latest)}-${channel}.${latest.number + 1}`;
+    }
+    if (inFlight) {
+        return `v${base(inFlight)}-${channel}.1`;
+    }
+    return `v${nextPatch(stable)}-${channel}.1`;
+}
+
+// Going stable promotes whichever pre-release line is furthest along, so
+// 1.5.0-rc.7 becomes 1.5.0 rather than inventing a number.
+const promote = inFlight || null;
+
+const out = {
+    LATEST_STABLE: stable ? stable.tag : '',
+    LATEST_RC: rc ? rc.tag : '',
+    LATEST_DEV: dev ? dev.tag : '',
+    NEXT_STABLE: promote ? `v${base(promote)}` : `v${nextPatch(stable)}`,
+    NEXT_RC: nextPre('rc', rc),
+    NEXT_DEV: nextPre('dev', dev),
+};
+
+for (const [key, value] of Object.entries(out)) {
+    process.stdout.write(`${key}='${value}'\n`);
+}


### PR DESCRIPTION
## Description

Publishing stopped at Docker Hub. The GitHub Release was made by hand afterwards, or not at all: `v1.5.0-rc.6` and `v1.5.0-rc.7` have no release, and everything since 1.4.2 is still sitting under `## Unreleased` in the changelog.

**The publish workflow now cuts the release itself**, in a `release` job that runs after the image is on Docker Hub, so a release never points at something nobody can pull. One rule decides both halves: a hyphen in the version (`1.5.0-rc.1`, `1.5.0-dev.3`) means a pre-release, which never moves the `:latest` image tag and is flagged as a pre-release on GitHub. A plain `1.5.0` moves `:latest` and is marked as the latest release. Re-running on a tag that already has a release updates it rather than failing the run, and `workflow_dispatch` is skipped since it republishes an image for a tag whose release already exists.

**A stable release documents itself from `CHANGELOG.md`**, so `create-version.sh` rolls `## Unreleased` into a version section as part of the bump, and the workflow uses that section as the release body. Pre-releases are cut too often to justify a section each, so they get generated notes and leave `Unreleased` to accumulate until the stable release that ships it.

**`create-version.sh` now asks when run with no argument.** It prints the latest release on each channel and proposes the next number:

```
Latest release on each channel

  stable  v1.4.2
  rc      v1.5.0-rc.7
  dev     v1.4.0-dev.1

What kind of release is this?

  1) stable             v1.5.0             moves :latest
  2) release candidate  v1.5.0-rc.8        pre-release
  3) development        v1.5.0-dev.1       pre-release

Choice [1-3]: 2

Create v1.5.0-rc.8? [Y/n, or type another version]:
```

Choosing stable while `1.5.0-rc.7` exists promotes that line to `1.5.0` rather than inventing a number. Choosing dev opens `1.5.0-dev.1` on the version already in flight rather than an unrelated `1.4.3` line. Passing a version explicitly skips every question, so scripted use is unchanged.

The ordering lives in `scripts/version-plan.js` rather than the shell because `sort -V` gets it wrong: `1.5.0-rc.7` has to sort below `1.5.0`, and `rc.10` above `rc.9`.

## Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [x] Documentation/Translation update

## Testing

Tested against throwaway clones of this repo so no real tag was burned:

- `scripts/version-plan.js` against the real tag history returns `NEXT_STABLE=v1.5.0`, `NEXT_RC=v1.5.0-rc.8`, `NEXT_DEV=v1.5.0-dev.1`
- Stable path (`create-version.sh v1.5.0`): rolls `## Unreleased` into `## 1.5.0`, commits `package.json` **and** `CHANGELOG.md`, tags. Verified the heading spacing and that the workflow's `awk` extraction returns exactly that section
- Pre-release path (`create-version.sh v1.5.0-rc.8`): commits `package.json` only, changelog untouched
- Interactive path with the prompts stubbed: choice 2 resolves to `v1.5.0-rc.8` and tags it
- `bash -n` on the script, YAML parsed and the job graph checked (`release` needs `publish`, `contents: write`, `if: github.event_name == 'push'`), `prettier --check` clean
- Guarded the two `read` calls: a bare `read` failing on Ctrl-D would have exited silently under `set -e`

The release job itself has not run yet, since that needs a real tag push. First live exercise should be `v1.5.0-rc.8` rather than `v1.5.0`, so a mistake costs a pre-release rather than the stable one.

- [ ] `npm run pre-push` passes

`pre-push` is `lint-staged` and reports no staged files once committed. `prettier --check` and `bash -n` were run directly; no backend or frontend source changed.

## Checklist

- [ ] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)

## Additional Notes

Deploying from Actions was considered and left out. It needs an SSH key in repository secrets that can reach production as root, which widens the blast radius of a compromised workflow or action for something run a few times a year. Deploy stays the one deliberate manual step: `./deploy.sh 1.5.0` from `tududi-ci` once CI is green.
