### PR TITLE
fix(ai-assistant): retry with max_completion_tokens on current OpenAI models

### DIFF
--- a/backend/modules/ai-assistant/service.js
+++ b/backend/modules/ai-assistant/service.js
@@ -122,22 +122,59 @@ async function recordTokenUsage(userId, response) {
     }
 }
 
+function isResponseFormatRejection(err) {
+    const is400 = err?.status === 400;
+    const mentionsFormat =
+        err?.message?.includes('response_format') ||
+        err?.error?.message?.includes('response_format');
+    return is400 && mentionsFormat;
+}
+
+// Current OpenAI models (o-series, GPT-5 and newer) reject the legacy
+// max_tokens parameter with a 400 and require max_completion_tokens instead.
+// We still send max_tokens first so OpenAI-compatible servers that predate
+// the rename (Ollama, LM Studio, vLLM) keep working, then swap the name and
+// retry once for the providers that demand the new one.
+function isMaxTokensRejection(err) {
+    const code = err?.code || err?.error?.code;
+    const param = err?.param || err?.error?.param;
+    return code === 'unsupported_parameter' && param === 'max_tokens';
+}
+
+function swapToMaxCompletionTokens(params) {
+    if (!('max_tokens' in params)) return params;
+    const { max_tokens: value, ...rest } = params;
+    return { ...rest, max_completion_tokens: value };
+}
+
+// A single request can hit both fallbacks (drop response_format and swap
+// max_tokens), so retry in a loop and apply each fallback at most once.
 async function callWithFallback(client, userId, params) {
+    let attempt = { ...params };
+    let triedFormatFallback = false;
+    let triedMaxTokensFallback = false;
     let response;
-    try {
-        response = await client.chat.completions.create(params);
-    } catch (err) {
-        const is400 = err?.status === 400;
-        const mentionsFormat =
-            err?.message?.includes('response_format') ||
-            err?.error?.message?.includes('response_format');
-        if (is400 && mentionsFormat) {
-            const { response_format: _dropped, ...fallbackParams } = params;
-            response = await client.chat.completions.create(fallbackParams);
-        } else {
+
+    for (;;) {
+        try {
+            response = await client.chat.completions.create(attempt);
+            break;
+        } catch (err) {
+            if (!triedMaxTokensFallback && isMaxTokensRejection(err)) {
+                triedMaxTokensFallback = true;
+                attempt = swapToMaxCompletionTokens(attempt);
+                continue;
+            }
+            if (!triedFormatFallback && isResponseFormatRejection(err)) {
+                triedFormatFallback = true;
+                const { response_format: _dropped, ...rest } = attempt;
+                attempt = rest;
+                continue;
+            }
             throw err;
         }
     }
+
     await recordTokenUsage(userId, response);
     return response;
 }

--- a/backend/tests/unit/modules/ai-assistant/callWithFallback.test.js
+++ b/backend/tests/unit/modules/ai-assistant/callWithFallback.test.js
@@ -1,0 +1,156 @@
+const mockCreate = jest.fn();
+
+jest.mock('openai', () => jest.fn());
+
+const OpenAI = require('openai');
+const aiAssistantService = require('../../../../modules/ai-assistant/service');
+
+function makeError(props) {
+    const err = new Error(props.message || 'Bad Request');
+    Object.assign(err, props);
+    return err;
+}
+
+const OK_RESPONSE = {
+    choices: [{ message: { content: '{}' } }],
+    model: 'test-model',
+    usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+};
+
+describe('AI Assistant - callWithFallback max_completion_tokens retry', () => {
+    const savedApiKey = process.env.LLM_API_KEY;
+
+    beforeEach(() => {
+        process.env.LLM_API_KEY = 'test-key';
+        mockCreate.mockReset();
+        OpenAI.mockImplementation(() => ({
+            chat: { completions: { create: (...args) => mockCreate(...args) } },
+        }));
+    });
+
+    afterEach(() => {
+        if (savedApiKey === undefined) {
+            delete process.env.LLM_API_KEY;
+        } else {
+            process.env.LLM_API_KEY = savedApiKey;
+        }
+    });
+
+    it('swaps max_tokens for max_completion_tokens and retries once when the provider rejects max_tokens', async () => {
+        mockCreate
+            .mockRejectedValueOnce(
+                makeError({
+                    status: 400,
+                    code: 'unsupported_parameter',
+                    param: 'max_tokens',
+                    type: 'invalid_request_error',
+                    message:
+                        "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.",
+                })
+            )
+            .mockResolvedValueOnce(OK_RESPONSE);
+
+        await aiAssistantService.generateProjectInsights(
+            { projectName: 'Website redesign' },
+            null
+        );
+
+        expect(mockCreate).toHaveBeenCalledTimes(2);
+        expect(mockCreate.mock.calls[0][0]).toEqual(
+            expect.objectContaining({ max_tokens: 600 })
+        );
+        const retry = mockCreate.mock.calls[1][0];
+        expect(retry.max_tokens).toBeUndefined();
+        expect(retry.max_completion_tokens).toBe(600);
+    });
+
+    it('reads the rejection details from a nested error body', async () => {
+        mockCreate
+            .mockRejectedValueOnce(
+                makeError({
+                    status: 400,
+                    error: {
+                        code: 'unsupported_parameter',
+                        param: 'max_tokens',
+                        message: "Unsupported parameter: 'max_tokens'",
+                    },
+                })
+            )
+            .mockResolvedValueOnce(OK_RESPONSE);
+
+        await aiAssistantService.generateTaskInsights(
+            { taskName: 'Write the report', taskStatus: 0, taskPriority: 1 },
+            null
+        );
+
+        expect(mockCreate).toHaveBeenCalledTimes(2);
+        expect(mockCreate.mock.calls[1][0].max_completion_tokens).toBe(1000);
+    });
+
+    it('does not retry when a 400 is unrelated to max_tokens', async () => {
+        mockCreate.mockRejectedValueOnce(
+            makeError({
+                status: 400,
+                code: 'invalid_api_key',
+                message: 'Incorrect API key provided',
+            })
+        );
+
+        await expect(
+            aiAssistantService.generateProjectInsights(
+                { projectName: 'Website redesign' },
+                null
+            )
+        ).rejects.toThrow('Incorrect API key provided');
+        expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('gives up if the swapped retry is rejected again', async () => {
+        mockCreate.mockRejectedValue(
+            makeError({
+                status: 400,
+                code: 'unsupported_parameter',
+                param: 'max_tokens',
+                message: "Unsupported parameter: 'max_tokens'",
+            })
+        );
+
+        await expect(
+            aiAssistantService.generateProjectInsights(
+                { projectName: 'Website redesign' },
+                null
+            )
+        ).rejects.toThrow();
+        expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('composes the max_tokens swap with the response_format drop', async () => {
+        mockCreate
+            .mockRejectedValueOnce(
+                makeError({
+                    status: 400,
+                    code: 'unsupported_parameter',
+                    param: 'max_tokens',
+                    message: "Unsupported parameter: 'max_tokens'",
+                })
+            )
+            .mockRejectedValueOnce(
+                makeError({
+                    status: 400,
+                    message: "Unsupported value: 'response_format'",
+                })
+            )
+            .mockResolvedValueOnce(OK_RESPONSE);
+
+        await aiAssistantService.generateProjectInsights(
+            { projectName: 'Website redesign' },
+            null
+        );
+
+        expect(mockCreate).toHaveBeenCalledTimes(3);
+        const finalCall = mockCreate.mock.calls[2][0];
+        expect(finalCall.max_tokens).toBeUndefined();
+        expect(finalCall.max_completion_tokens).toBe(600);
+        expect(finalCall.response_format).toBeUndefined();
+    });
+});

--- a/docs/13-ai-assistant.md
+++ b/docs/13-ai-assistant.md
@@ -60,6 +60,8 @@ LLM_MAX_TOKENS_PROJECT_INSIGHTS=600   # default 600
 
 Non-numeric or non-positive values are ignored and fall back to the default.
 
+Requests are sent with `max_tokens`. Current OpenAI models (o-series, GPT-5 and newer) reject that name with an HTTP 400 (`code: unsupported_parameter`, `param: max_tokens`) and require `max_completion_tokens` instead. `callWithFallback()` catches that specific rejection, swaps the parameter name, and retries once. Sending `max_tokens` first keeps older OpenAI-compatible servers (Ollama, LM Studio, vLLM) working, since some do not recognize the newer name.
+
 ### Optional: skip the thinking phase
 
 Some reasoning models keep spending tokens on hidden reasoning no matter how high `max_tokens` is raised. If your provider supports it (e.g. Qwen3 served via vLLM), set:
@@ -79,6 +81,8 @@ The fallback only trusts a field if it actually parses as JSON. Most reasoning-p
 ### `LLM_DISABLE_THINKING` failure mode
 
 If your provider doesn't support `chat_template_kwargs` and rejects it with an HTTP 400, the request fails loudly rather than silently retrying without the flag — `callWithFallback()` only auto-retries by dropping `response_format`, not `chat_template_kwargs`. This is intentional for an explicitly opt-in flag, but if you enable `LLM_DISABLE_THINKING` and start seeing errors instead of empty results, check that your provider actually documents support for it.
+
+The `max_tokens` -> `max_completion_tokens` retry and the `response_format` drop compose: a request that needs both (a current OpenAI reasoning model plus a schema it will not honour) applies each fallback once in the same `callWithFallback()` call.
 
 ---
 


### PR DESCRIPTION
## Description

The AI Assistant returned a 500 for all three features (daily brief, task insights, project insights) whenever `LLM_MODEL` was set to a current OpenAI reasoning-family / GPT-5+ model. Those models reject the legacy `max_tokens` parameter with an HTTP 400 (`code: unsupported_parameter`, `param: max_tokens`, `type: invalid_request_error`) and require `max_completion_tokens` instead. Older models (`gpt-4o-mini` etc.) still accept `max_tokens`, which is why the default config worked.

`callWithFallback()` now catches that specific rejection, swaps `max_tokens` for `max_completion_tokens`, and retries once. Requests still send `max_tokens` first so OpenAI-compatible servers that predate the rename (Ollama, LM Studio, vLLM) keep working. The retry logic was reshaped into a small loop so the two fallbacks (this one and the existing `response_format` drop) each apply at most once and compose: a request that needs both still succeeds.

Files changed:
- `backend/modules/ai-assistant/service.js` - the retry loop and the two rejection predicates
- `backend/tests/unit/modules/ai-assistant/callWithFallback.test.js` - new coverage (swap and retry, nested error body, no retry on unrelated 400, give up after a second rejection, compose with the response_format drop)
- `docs/13-ai-assistant.md` - documents the fallback and how it composes with the response_format drop

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issues

Fixes #1506

## Testing

**How did you test this?**

- `npm run lint:fix && npm run lint` - zero errors (frontend + backend)
- `cd backend && npx jest tests/unit/modules/ai-assistant/` - 19 passed (5 new)
- `cd backend && npx jest tests/ -t "ai"` - 182 passed, 0 failed

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)
