### PR TITLE
fix(task): keep area selector available after assigning a project

### DIFF
--- a/frontend/components/Task/TaskDetails/TaskAreaCard.tsx
+++ b/frontend/components/Task/TaskDetails/TaskAreaCard.tsx
@@ -63,8 +63,11 @@ const TaskAreaCard: React.FC<TaskAreaCardProps> = ({
         setSearchQuery('');
     };
 
-    if (task.Project) {
-        if (!effectiveArea) return null;
+    // Show a read-only card only when the area is genuinely inherited from the
+    // task's project. A task keeps its own independent area_id, so in every
+    // other case (project without an area, or the task carrying its own area)
+    // the selector below stays editable.
+    if (isInherited && effectiveArea) {
         return (
             <div className="rounded-lg shadow-sm bg-white dark:bg-gray-900 p-4">
                 <div className="flex items-center justify-between gap-2">

--- a/frontend/components/Task/TaskDetails/__tests__/TaskAreaCard.test.tsx
+++ b/frontend/components/Task/TaskDetails/__tests__/TaskAreaCard.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import TaskAreaCard from '../TaskAreaCard';
+import { Task } from '../../../../entities/Task';
+import { Area } from '../../../../entities/Area';
+
+jest.mock('react-i18next', () => ({
+    useTranslation: () => ({
+        t: (_key: string, fallback: string) => fallback,
+    }),
+}));
+
+jest.mock('react-router-dom', () => ({
+    Link: ({ children, to }: any) => <a href={to}>{children}</a>,
+}));
+
+const areas: Area[] = [
+    { id: 1, name: 'Work', uid: 'area-work' } as Area,
+    { id: 2, name: 'Home', uid: 'area-home' } as Area,
+];
+
+const baseProps = {
+    areas,
+    onAreaSelect: jest.fn().mockResolvedValue(undefined),
+    onAreaClear: jest.fn().mockResolvedValue(undefined),
+    getAreaLink: (area: Area) => `/area/${area.uid}`,
+};
+
+describe('TaskAreaCard - area selection with a project', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('keeps the area selector visible when a project without an area is assigned', () => {
+        const task = {
+            id: 10,
+            name: 'Task',
+            Project: { id: 5, name: 'Some Project', uid: 'proj-5' },
+        } as unknown as Task;
+
+        render(<TaskAreaCard task={task} {...baseProps} />);
+
+        expect(screen.getByText('Assign to an area')).toBeInTheDocument();
+    });
+
+    it('lets the user pick an area after assigning a project', async () => {
+        const task = {
+            id: 10,
+            name: 'Task',
+            Project: { id: 5, name: 'Some Project', uid: 'proj-5' },
+        } as unknown as Task;
+
+        render(<TaskAreaCard task={task} {...baseProps} />);
+
+        fireEvent.click(screen.getByText('Assign to an area'));
+        await act(async () => {
+            fireEvent.click(screen.getByText('Work'));
+        });
+
+        expect(baseProps.onAreaSelect).toHaveBeenCalledWith(
+            expect.objectContaining({ id: 1, name: 'Work' })
+        );
+    });
+
+    it('shows the task own area (editable) even when a project is assigned', () => {
+        const task = {
+            id: 10,
+            name: 'Task',
+            Area: { id: 2, name: 'Home', uid: 'area-home' },
+            Project: { id: 5, name: 'Some Project', uid: 'proj-5' },
+        } as unknown as Task;
+
+        render(<TaskAreaCard task={task} {...baseProps} />);
+
+        expect(screen.getByText('Home')).toBeInTheDocument();
+        expect(screen.queryByText('via project')).not.toBeInTheDocument();
+    });
+
+    it('shows a read-only via-project card when the area is inherited from the project', () => {
+        const task = {
+            id: 10,
+            name: 'Task',
+            Project: {
+                id: 5,
+                name: 'Some Project',
+                uid: 'proj-5',
+                area_id: 1,
+                Area: { id: 1, name: 'Work', uid: 'area-work' },
+            },
+        } as unknown as Task;
+
+        render(<TaskAreaCard task={task} {...baseProps} />);
+
+        expect(screen.getByText('Work')).toBeInTheDocument();
+        expect(screen.getByText('via project')).toBeInTheDocument();
+    });
+});


### PR DESCRIPTION
## Description

In the task detail page, the Area card disappeared as soon as a project was assigned to a task. If the project had an area, the card showed a read-only "via project" summary; if the project had no area, `TaskAreaCard` returned `null` and the selector vanished entirely. Users could no longer see or pick an area for a task once it had a project (issue #1500).

### Data model finding

A `Task` has its own `area_id` column (`backend/models/task.js`), with a real `Task.belongsTo(Area)` / `Area.hasMany(Task)` association (`backend/models/index.js`). It is set and cleared independently of `project_id` in the update route (`backend/modules/tasks/routes.js`), exactly like `goal_id`. The docs back this up: a task can be "directly assigned to an area" and the Area detail page lists "all tasks directly assigned to this area (not inside projects)". So a task's area is not derived purely from its project, it is an independent field.

On top of that, the task detail endpoint (`GET /task/:uid`) uses `TASK_INCLUDES_WITH_SUBTASKS`, which loads the `Project` with only `id, name, uid, image_url, color`, no nested `Area` and no `area_id`. So the "via project" inheritance branch could effectively never fire on this page anyway, it only ever hid the card.

### Fix approach chosen

Since the area is an independent field, the selector should stay editable when a project is assigned. The read-only "via project" card now renders only when the area is genuinely inherited (`isInherited && effectiveArea`, i.e. the task has no own area and the project carries one). In every other case the normal editable selector renders:

- project assigned, no area anywhere: editable "Assign to an area" empty state (the bug from #1500)
- project assigned, task has its own area: editable card with the task's area, no misleading "via project" label
- no project: unchanged
- inherited area (project's `Area` loaded): unchanged read-only "via project" card

This is the minimal change that matches the data model and is not misleading. Selecting an area calls the existing `handleAreaSelection` which already does `updateTask(task.uid, { area_id: area.id })`, and the backend already accepts `area_id` alongside `project_id`, so no backend change is needed.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1500

## Testing

**How did you test this?**

- Added `frontend/components/Task/TaskDetails/__tests__/TaskAreaCard.test.tsx` covering: selector stays visible with a project and no area, user can pick an area after assigning a project, the task's own area shows editable (no "via project"), and inherited area still shows the read-only card.
- `npm run frontend:test -- TaskAreaCard` and the existing `TaskDetails` suite pass.
- `npm run lint:fix && npm run lint`: zero errors (2 pre-existing warnings in an unrelated CalDAV test file).

- [x] `npm run pre-push` passes

## Screenshots

No screenshot captured (headless environment, Playwright not run per task constraints). Behavior change: with a project assigned and no area, the Area card now shows the "Assign to an area" selector instead of being hidden.

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (if applicable)

