### PR TITLE
feat: shareable areas/goals, real task assignment, member invite email

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -43,6 +43,8 @@ EMAIL_FROM_NAME=Tududi
 REGISTRATION_TOKEN_EXPIRY_HOURS=24
 # Password reset links stay valid this long
 PASSWORD_RESET_TOKEN_EXPIRY_MINUTES=60
+# Admin member-invite set-password links stay valid this long
+INVITE_TOKEN_EXPIRY_HOURS=168
 
 # Logging: LOG_LEVEL=trace|debug|info|warn|error|silent (default info),
 # LOG_FORMAT=json|pretty (default: pretty in development, json otherwise)

--- a/backend/config/config.js
+++ b/backend/config/config.js
@@ -100,6 +100,10 @@ const passwordResetConfig = {
         : 60,
 };
 
+const inviteTokenExpiryHours = process.env.INVITE_TOKEN_EXPIRY_HOURS
+    ? parseInt(process.env.INVITE_TOKEN_EXPIRY_HOURS, 10)
+    : 168;
+
 const config = {
     allowedOrigins: process.env.TUDUDI_ALLOWED_ORIGINS
         ? process.env.TUDUDI_ALLOWED_ORIGINS.split(',').map((origin) =>
@@ -246,6 +250,8 @@ const config = {
     registrationConfig,
 
     passwordResetConfig,
+
+    inviteTokenExpiryHours,
 
     uploadPath:
         process.env.TUDUDI_UPLOAD_PATH || path.join(projectRootPath, 'uploads'),

--- a/backend/middleware/authorize.js
+++ b/backend/middleware/authorize.js
@@ -1,7 +1,7 @@
 const permissionsService = require('../services/permissionsService');
 
 // requiredAccess: 'ro' | 'rw' | 'admin'
-// resourceType: 'project' | 'task' | 'note'
+// resourceType: 'project' | 'task' | 'note' | 'area' | 'goal'
 // getResourceUid: function(req) => string | Promise<string>
 function hasAccess(requiredAccess, resourceType, getResourceUid, options = {}) {
     const notFoundMessage = options.notFoundMessage || 'Not found';

--- a/backend/migrations/20260910000001-add-task-assigned-notification-preference.js
+++ b/backend/migrations/20260910000001-add-task-assigned-notification-preference.js
@@ -1,0 +1,56 @@
+'use strict';
+
+// Backfill the `taskAssigned` key into every user's notification_preferences.
+// New rows get it from the Sequelize model default and every app write path
+// passes a full preferences object, so no DB-level column default change is
+// needed (and a SQLite column rebuild on the wide users table is best avoided).
+
+const CHANNELS = { inApp: true, email: false, push: false, telegram: false };
+
+function parsePrefs(raw) {
+    let prefs = raw;
+    for (let i = 0; i < 2 && typeof prefs === 'string'; i++) {
+        try {
+            prefs = JSON.parse(prefs);
+        } catch {
+            return null;
+        }
+    }
+    return prefs && typeof prefs === 'object' ? prefs : null;
+}
+
+module.exports = {
+    async up(queryInterface) {
+        const [users] = await queryInterface.sequelize.query(
+            'SELECT id, notification_preferences FROM users WHERE notification_preferences IS NOT NULL'
+        );
+
+        for (const user of users) {
+            const prefs = parsePrefs(user.notification_preferences);
+            if (!prefs || prefs.taskAssigned) continue;
+
+            prefs.taskAssigned = { ...CHANNELS };
+            await queryInterface.sequelize.query(
+                'UPDATE users SET notification_preferences = :prefs WHERE id = :id',
+                { replacements: { prefs: JSON.stringify(prefs), id: user.id } }
+            );
+        }
+    },
+
+    async down(queryInterface) {
+        const [users] = await queryInterface.sequelize.query(
+            'SELECT id, notification_preferences FROM users WHERE notification_preferences IS NOT NULL'
+        );
+
+        for (const user of users) {
+            const prefs = parsePrefs(user.notification_preferences);
+            if (!prefs || !prefs.taskAssigned) continue;
+
+            delete prefs.taskAssigned;
+            await queryInterface.sequelize.query(
+                'UPDATE users SET notification_preferences = :prefs WHERE id = :id',
+                { replacements: { prefs: JSON.stringify(prefs), id: user.id } }
+            );
+        }
+    },
+};

--- a/backend/models/user.js
+++ b/backend/models/user.js
@@ -207,6 +207,12 @@ module.exports = (sequelize) => {
                         push: false,
                         telegram: false,
                     },
+                    taskAssigned: {
+                        inApp: true,
+                        email: false,
+                        push: false,
+                        telegram: false,
+                    },
                 },
             },
             keyboard_shortcuts: {

--- a/backend/modules/admin/service.js
+++ b/backend/modules/admin/service.js
@@ -131,12 +131,19 @@ class AdminService {
         const { email, password, name, surname, role } =
             validateCreateUser(body);
         const { linked_person_uid } = body || {};
+        const invite = !password;
 
         const userData = {
             email,
-            password,
             notification_preferences: getDefaultNotificationPreferences(),
         };
+        if (password) {
+            userData.password = password;
+        } else {
+            // No password yet: the account is inert until the invite link is
+            // used, which also verifies the email.
+            userData.email_verified = false;
+        }
         if (name) userData.name = name;
         if (surname) userData.surname = surname;
 
@@ -180,6 +187,20 @@ class AdminService {
             );
         }
 
+        let emailSent = false;
+        if (invite) {
+            const {
+                sendMemberInviteEmail,
+            } = require('../auth/passwordResetService');
+            try {
+                const result = await sendMemberInviteEmail(user);
+                emailSent = result.sent;
+            } catch (err) {
+                // The account stays; the admin can resend or set a password.
+                logError(err, 'Failed to send member invite email');
+            }
+        }
+
         return {
             id: user.id,
             email: user.email,
@@ -187,6 +208,8 @@ class AdminService {
             surname: user.surname,
             created_at: user.created_at,
             role: makeAdmin ? 'admin' : 'user',
+            invited: invite,
+            email_sent: emailSent,
         };
     }
 

--- a/backend/modules/admin/validation.js
+++ b/backend/modules/admin/validation.js
@@ -49,16 +49,20 @@ function validateSetAdminRole(body) {
 }
 
 /**
- * Validate create user request body.
+ * Validate create user request body. Password is optional: when it is omitted
+ * the account is created without one and an invite email is sent so the member
+ * can set their own.
  */
 function validateCreateUser(body) {
     const { email, password, name, surname, role } = body || {};
-    if (!email || !password) {
-        throw new ValidationError('Email and password are required');
+    if (!email) {
+        throw new ValidationError('Email is required');
     }
     validateEmail(email);
-    validatePassword(password);
-    return { email, password, name, surname, role };
+    if (password) {
+        validatePassword(password);
+    }
+    return { email, password: password || null, name, surname, role };
 }
 
 /**

--- a/backend/modules/auth/passwordResetService.js
+++ b/backend/modules/auth/passwordResetService.js
@@ -22,6 +22,83 @@ const tokenExpiry = () => {
     return new Date(Date.now() + minutes * 60 * 1000);
 };
 
+// Store a fresh set-password token (SHA-256 hashed) on the account and return
+// the raw token for the emailed link. Shared by the password-reset flow and the
+// admin member-invite flow.
+async function issueResetToken(user, expiresAt = tokenExpiry()) {
+    const token = crypto.randomBytes(32).toString('hex');
+    await user.update({
+        password_reset_token_hash: hashToken(token),
+        password_reset_token_expires_at: expiresAt,
+    });
+    return token;
+}
+
+const buildInviteEmail = (setPasswordUrl, expiryHours) => {
+    const subject = 'You have been added to a Tududi workspace';
+    const text = `You have been added to a Tududi workspace.
+
+Choose a password to activate your account and sign in:
+
+${setPasswordUrl}
+
+The link expires in ${expiryHours} hours. If you were not expecting this, you can ignore this email.
+
+Best regards,
+The Tududi Team`;
+
+    const html = `
+<p>You have been added to a Tududi workspace.</p>
+
+<p>Choose a password to activate your account and sign in:</p>
+
+<p style="text-align: center; margin: 30px 0;">
+    <a href="${setPasswordUrl}" style="background-color: #3b82f6; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; display: inline-block;">Set your password</a>
+</p>
+
+<p>Or copy and paste this link into your browser:</p>
+<p style="word-break: break-all; color: #666;">${setPasswordUrl}</p>
+
+<p><strong>The link expires in ${expiryHours} hours.</strong> If you were not expecting this, you can ignore this email.</p>
+
+<p>Best regards,<br>The Tududi Team</p>
+`;
+    return { subject, text, html };
+};
+
+// Creates a set-password token for an admin-created account and emails the
+// activation link. Returns whether the email was actually sent so the caller
+// can report it; unlike registration, the account is kept either way.
+async function sendMemberInviteEmail(user) {
+    const config = getConfig();
+    const hours = config.inviteTokenExpiryHours;
+    const expiresAt = new Date(Date.now() + hours * 60 * 60 * 1000);
+    const token = await issueResetToken(user, expiresAt);
+
+    if (!isEmailEnabled()) {
+        logInfo(
+            `Email service is disabled. Invite link for ${user.email} not sent.`
+        );
+        return { sent: false };
+    }
+
+    const setPasswordUrl = `${config.frontendUrl}/reset-password?token=${token}`;
+    const result = await sendEmail({
+        to: user.email,
+        ...buildInviteEmail(setPasswordUrl, hours),
+    });
+
+    if (result.success) {
+        logInfo(`Member invite email sent to ${user.email}`);
+    } else {
+        logError(
+            new Error(result.reason),
+            `Failed to send member invite email to ${user.email}`
+        );
+    }
+    return { sent: !!result.success };
+}
+
 const buildResetEmail = (resetUrl, minutes) => {
     const subject = 'Reset your Tududi password';
     const text = `Someone asked to reset the password for your Tududi account.
@@ -62,11 +139,7 @@ async function requestPasswordReset(email) {
         return;
     }
 
-    const token = crypto.randomBytes(32).toString('hex');
-    await user.update({
-        password_reset_token_hash: hashToken(token),
-        password_reset_token_expires_at: tokenExpiry(),
-    });
+    const token = await issueResetToken(user);
 
     if (!isEmailEnabled()) {
         logInfo(
@@ -126,5 +199,7 @@ async function resetPasswordWithToken(token, password) {
 module.exports = {
     requestPasswordReset,
     resetPasswordWithToken,
+    sendMemberInviteEmail,
+    issueResetToken,
     hashToken,
 };

--- a/backend/modules/auth/service.js
+++ b/backend/modules/auth/service.js
@@ -37,9 +37,11 @@ class AuthService {
         // True only while hosted Cloud is shut, so a self-hosted instance
         // with registration off keeps the generic "closed" message instead
         // of the Cloud-specific "opening soon" copy and its email capture.
+        const { isEmailEnabled } = require('../../services/emailService');
         return {
             enabled: await isRegistrationEnabled(),
             waitlist: isCloudClosed(),
+            email_enabled: isEmailEnabled(),
         };
     }
 

--- a/backend/modules/projects/service.js
+++ b/backend/modules/projects/service.js
@@ -15,6 +15,9 @@ const {
 const { uid: generateUid } = require('../../utils/uid');
 const { extractUidFromSlug } = require('../../utils/slug-utils');
 const { logError } = require('../../services/logService');
+const {
+    syncProjectSharesFromContainer,
+} = require('../../services/containerShareSync');
 const { Project } = require('../../models');
 
 const PROJECT_STATUSES = Project.rawAttributes.status.values;
@@ -342,6 +345,10 @@ class ProjectsService {
             );
         }
 
+        if (projectData.area_id || projectData.goal_id) {
+            await syncProjectSharesFromContainer(project.id);
+        }
+
         return {
             ...project.toJSON(),
             uid: projectUid,
@@ -419,6 +426,16 @@ class ProjectsService {
 
         await projectsRepository.update(project, updateData);
         await updateProjectTags(project, tagsData, userId);
+
+        // Moving the project into a (possibly shared) area or goal mirrors that
+        // container's collaborators onto the project.
+        if (
+            isOwner &&
+            (updateData.area_id !== undefined ||
+                updateData.goal_id !== undefined)
+        ) {
+            await syncProjectSharesFromContainer(project.id);
+        }
 
         const projectWithAssociations =
             await projectsRepository.findByUidWithTagsAndArea(validatedUid);

--- a/backend/modules/shares/repository.js
+++ b/backend/modules/shares/repository.js
@@ -1,10 +1,30 @@
 'use strict';
 
 const { Op } = require('sequelize');
-const { User, Permission, Project, Task, Note } = require('../../models');
+const {
+    User,
+    Permission,
+    Project,
+    Task,
+    Note,
+    Area,
+    Goal,
+} = require('../../models');
 
-const RESOURCE_MODELS = { project: Project, task: Task, note: Note };
-const RESOURCE_NAME_FIELDS = { project: 'name', task: 'name', note: 'title' };
+const RESOURCE_MODELS = {
+    project: Project,
+    task: Task,
+    note: Note,
+    area: Area,
+    goal: Goal,
+};
+const RESOURCE_NAME_FIELDS = {
+    project: 'name',
+    task: 'name',
+    note: 'title',
+    area: 'name',
+    goal: 'title',
+};
 
 class SharesRepository {
     async findResourceOwner(resourceType, resourceUid) {

--- a/backend/modules/shares/service.js
+++ b/backend/modules/shares/service.js
@@ -11,7 +11,7 @@ const {
     ForbiddenError,
 } = require('../../shared/errors');
 
-const SHAREABLE_TYPES = new Set(['project', 'task', 'note']);
+const SHAREABLE_TYPES = new Set(['project', 'task', 'note', 'area', 'goal']);
 const ACCESS_LEVELS = new Set(['ro', 'rw']);
 
 class SharesService {

--- a/backend/modules/tasks/operations/assignment.js
+++ b/backend/modules/tasks/operations/assignment.js
@@ -1,0 +1,72 @@
+'use strict';
+
+const { Person, User, Notification } = require('../../../models');
+const {
+    shouldSendInAppNotification,
+    shouldSendTelegramNotification,
+} = require('../../../utils/notificationPreferences');
+const { logError } = require('../../../services/logService');
+
+// Resolve a people.uid to the user account it is linked to, if any.
+async function resolveAssigneeUser(personUid) {
+    if (!personUid) return null;
+    const person = await Person.findOne({
+        where: { uid: personUid },
+        attributes: ['linked_user_id'],
+        raw: true,
+    });
+    if (!person || !person.linked_user_id) return null;
+    return User.findByPk(person.linked_user_id, {
+        attributes: [
+            'id',
+            'email',
+            'name',
+            'notification_preferences',
+            'telegram_bot_token',
+            'telegram_chat_id',
+        ],
+    });
+}
+
+// Notify the person a task was just assigned to, when they have an account and
+// aren't the one doing the assigning. Best-effort: a failure here never fails
+// the task write.
+async function notifyAssignee(task, previousAssignedTo, actingUserId) {
+    try {
+        const newAssignedTo = task.assigned_to || null;
+        if (!newAssignedTo || newAssignedTo === previousAssignedTo) return;
+
+        const assignee = await resolveAssigneeUser(newAssignedTo);
+        if (!assignee || assignee.id === actingUserId) return;
+
+        if (!shouldSendInAppNotification(assignee, 'task_assigned')) return;
+
+        const actor = await User.findByPk(actingUserId, {
+            attributes: ['id', 'name', 'email'],
+        });
+        const actorLabel = actor?.name || actor?.email || 'Someone';
+
+        const sources = [];
+        if (shouldSendTelegramNotification(assignee, 'task_assigned')) {
+            sources.push('telegram');
+        }
+
+        await Notification.createNotification({
+            userId: assignee.id,
+            type: 'task_assigned',
+            title: `${actorLabel} assigned you a task`,
+            message: `"${task.name}" was assigned to you.`,
+            data: {
+                taskUid: task.uid,
+                taskName: task.name,
+                assignedByUserId: actingUserId,
+                projectUid: task.Project ? task.Project.uid : null,
+            },
+            sources,
+        });
+    } catch (error) {
+        logError(error, `Failed to notify assignee for task ${task?.uid}`);
+    }
+}
+
+module.exports = { notifyAssignee, resolveAssigneeUser };

--- a/backend/modules/tasks/operations/recurring.js
+++ b/backend/modules/tasks/operations/recurring.js
@@ -23,6 +23,8 @@ async function handleRecurrenceUpdate(task, recurrenceFields, reqBody) {
         'project_id',
         'priority',
         'note',
+        'assigned_to',
+        'involves',
     ].some((field) => {
         const newValue = reqBody[field];
         return newValue !== undefined && newValue !== task[field];

--- a/backend/modules/tasks/queries/query-builders.js
+++ b/backend/modules/tasks/queries/query-builders.js
@@ -418,7 +418,15 @@ async function filterTasksByParams(
     }
 
     if (params.assigned_to) {
-        whereClause.assigned_to = params.assigned_to;
+        if (params.assigned_to === 'me') {
+            const myPersonUids =
+                await permissionsService.getMyPersonUids(userId);
+            whereClause.assigned_to = myPersonUids.length
+                ? { [Op.in]: myPersonUids }
+                : null;
+        } else {
+            whereClause.assigned_to = params.assigned_to;
+        }
     }
 
     const finalWhereClause = {

--- a/backend/modules/tasks/routes.js
+++ b/backend/modules/tasks/routes.js
@@ -57,6 +57,7 @@ const { createSubtasks, updateSubtasks } = require('./operations/subtasks');
 const { requireQuota } = require('../../middleware/entitlements');
 const { handleCompletionStatus } = require('./operations/completion');
 const { captureOldValues, logTaskChanges } = require('./utils/logging');
+const { notifyAssignee } = require('./operations/assignment');
 const {
     handleParentChildOnStatusChange,
 } = require('./operations/parent-child');
@@ -497,6 +498,12 @@ router.post(
                 return res.status(201).json(fallbackTask);
             }
 
+            await notifyAssignee(
+                taskWithAssociations,
+                null,
+                req.currentUser.id
+            );
+
             const serializedTask = await serializeTask(
                 taskWithAssociations,
                 req.currentUser.timezone,
@@ -901,6 +908,12 @@ router.patch('/task/:uid', requireTaskWriteAccess, async (req, res) => {
         const taskWithAssociations = await taskRepository.findById(task.id, {
             include: TASK_INCLUDES_WITH_SUBTASKS,
         });
+
+        await notifyAssignee(
+            taskWithAssociations,
+            oldValues.assigned_to,
+            req.currentUser.id
+        );
 
         const serializedTask = await serializeTask(
             taskWithAssociations,

--- a/backend/modules/tasks/utils/logging.js
+++ b/backend/modules/tasks/utils/logging.js
@@ -9,6 +9,7 @@ function captureOldValues(task) {
         due_date: task.due_date,
         defer_until: task.defer_until,
         project_id: task.project_id,
+        assigned_to: task.assigned_to,
         note: task.note,
         recurrence_type: task.recurrence_type,
         recurrence_interval: task.recurrence_interval,

--- a/backend/services/containerShareSync.js
+++ b/backend/services/containerShareSync.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const { sequelize, Permission, Area, Goal, Project } = require('../models');
+const { applyPerms } = require('./applyPerms');
+const { projectSubtreeChanges } = require('./permissionsCalculators');
+const { logError } = require('./logService');
+
+// When a project is created in (or moved into) a shared area or goal, mirror
+// that container's shares onto the project and its task/note subtree, so a
+// collaborator does not have to be re-invited for every new project. Rows are
+// written with the same status and source_action_id as the container grant, so
+// a still-pending invite does not leak the new project early and accepting or
+// declining still moves the whole set together.
+async function syncProjectSharesFromContainer(projectId) {
+    try {
+        await sequelize.transaction(async (tx) => {
+            const project = await Project.findByPk(projectId, {
+                attributes: ['id', 'uid', 'user_id', 'area_id', 'goal_id'],
+                transaction: tx,
+            });
+            if (!project) return;
+
+            const containerPerms = [];
+
+            if (project.area_id) {
+                const area = await Area.findByPk(project.area_id, {
+                    attributes: ['uid'],
+                    transaction: tx,
+                });
+                if (area) {
+                    containerPerms.push(
+                        ...(await Permission.findAll({
+                            where: {
+                                resource_type: 'area',
+                                resource_uid: area.uid,
+                            },
+                            transaction: tx,
+                            raw: true,
+                        }))
+                    );
+                }
+            }
+
+            if (project.goal_id) {
+                const goal = await Goal.findByPk(project.goal_id, {
+                    attributes: ['uid'],
+                    transaction: tx,
+                });
+                if (goal) {
+                    containerPerms.push(
+                        ...(await Permission.findAll({
+                            where: {
+                                resource_type: 'goal',
+                                resource_uid: goal.uid,
+                            },
+                            transaction: tx,
+                            raw: true,
+                        }))
+                    );
+                }
+            }
+
+            if (containerPerms.length === 0) return;
+
+            // One grant per target user: highest access wins, an accepted grant
+            // beats a pending one.
+            const byUser = new Map();
+            for (const perm of containerPerms) {
+                if (perm.user_id === project.user_id) continue;
+                const current = byUser.get(perm.user_id);
+                if (!current) {
+                    byUser.set(perm.user_id, perm);
+                    continue;
+                }
+                const better =
+                    (perm.access_level === 'rw' &&
+                        current.access_level !== 'rw') ||
+                    (perm.status === 'accepted' &&
+                        current.status !== 'accepted');
+                if (better) byUser.set(perm.user_id, perm);
+            }
+
+            const changes = { upserts: [], deletes: [] };
+            for (const perm of byUser.values()) {
+                const before = changes.upserts.length;
+                await projectSubtreeChanges(
+                    changes,
+                    {
+                        id: project.id,
+                        uid: project.uid,
+                        user_id: project.user_id,
+                    },
+                    {
+                        verb: 'share_grant',
+                        targetUserId: perm.user_id,
+                        actorUserId: perm.granted_by_user_id || project.user_id,
+                        accessLevel: perm.access_level,
+                    },
+                    'inherited'
+                );
+                for (let i = before; i < changes.upserts.length; i++) {
+                    changes.upserts[i].status = perm.status;
+                    changes.upserts[i].sourceActionId = perm.source_action_id;
+                }
+            }
+
+            await applyPerms(tx, changes);
+        });
+    } catch (error) {
+        // A failed mirror must not fail the project write; the owner can
+        // re-share the container to reconcile.
+        logError(error, `Failed to sync project shares (project ${projectId})`);
+    }
+}
+
+module.exports = { syncProjectSharesFromContainer };

--- a/backend/services/execAction.js
+++ b/backend/services/execAction.js
@@ -6,6 +6,7 @@ const {
     calculateTaskPerms,
     calculateNotePerms,
     calculateAreaPerms,
+    calculateGoalPerms,
     calculateTagPerms,
 } = require('./permissionsCalculators');
 
@@ -21,8 +22,14 @@ async function assertActorCanShare(actorUserId, resourceType, resourceOwnerId) {
 async function execAction(action) {
     // action: { verb, actorUserId, targetUserId, resourceType, resourceUid, accessLevel?, status? }
     return await sequelize.transaction(async (tx) => {
-        const { Project, Task, Note } = require('../models');
-        const ownerModels = { project: Project, task: Task, note: Note };
+        const { Project, Task, Note, Area, Goal } = require('../models');
+        const ownerModels = {
+            project: Project,
+            task: Task,
+            note: Note,
+            area: Area,
+            goal: Goal,
+        };
         const ownerModel = ownerModels[action.resourceType];
 
         let ownerUserId = null;
@@ -71,6 +78,8 @@ async function execAction(action) {
             changes = await calculateNotePerms(ctx, action);
         } else if (action.resourceType === 'area') {
             changes = await calculateAreaPerms(ctx, action);
+        } else if (action.resourceType === 'goal') {
+            changes = await calculateGoalPerms(ctx, action);
         } else if (action.resourceType === 'tag') {
             changes = await calculateTagPerms(ctx, action);
         }

--- a/backend/services/permissionsCalculators.js
+++ b/backend/services/permissionsCalculators.js
@@ -1,4 +1,4 @@
-const { Project, Task, Note } = require('../models');
+const { Project, Task, Note, Area, Goal } = require('../models');
 
 function emptyChanges() {
     return { upserts: [], deletes: [] };
@@ -47,28 +47,46 @@ async function collectProjectDescendants(projectId) {
     };
 }
 
-async function calculateProjectPerms(ctx, action) {
-    const changes = emptyChanges();
-    // find project id
-    const project = await Project.findOne({
-        where: { uid: action.resourceUid },
-        attributes: ['id', 'user_id'],
-        transaction: ctx.tx,
-    });
-    if (!project) return changes;
+async function collectTaskSubtree(taskId, seedUid) {
+    const taskUids = new Set(seedUid ? [seedUid] : []);
+    const queue = [{ id: taskId }];
+    while (queue.length) {
+        const node = queue.shift();
+        const children = await Task.findAll({
+            where: { parent_task_id: node.id },
+            attributes: ['id', 'uid'],
+            raw: true,
+        });
+        for (const c of children) {
+            if (!taskUids.has(c.uid)) {
+                taskUids.add(c.uid);
+                queue.push({ id: c.id });
+            }
+        }
+    }
+    return Array.from(taskUids);
+}
 
+// Emit the permission changes for one project and everything under it (tasks at
+// all depths, notes). `projectPropagation` is 'direct' for a plain project share
+// and 'inherited' when the project is being cascaded from an area or goal grant.
+async function projectSubtreeChanges(
+    changes,
+    project,
+    action,
+    projectPropagation
+) {
     const { taskUids, noteUids } = await collectProjectDescendants(project.id);
 
     if (action.verb === 'share_grant') {
-        const direct = {
+        pushUpsert(changes, {
             userId: action.targetUserId,
             resourceType: 'project',
-            resourceUid: action.resourceUid,
+            resourceUid: project.uid,
             accessLevel: action.accessLevel,
-            propagation: 'direct',
+            propagation: projectPropagation,
             grantedByUserId: action.actorUserId,
-        };
-        pushUpsert(changes, direct);
+        });
         for (const tuid of taskUids)
             pushUpsert(changes, {
                 userId: action.targetUserId,
@@ -91,7 +109,7 @@ async function calculateProjectPerms(ctx, action) {
         pushDelete(changes, {
             userId: action.targetUserId,
             resourceType: 'project',
-            resourceUid: action.resourceUid,
+            resourceUid: project.uid,
         });
         for (const tuid of taskUids)
             pushDelete(changes, {
@@ -106,7 +124,37 @@ async function calculateProjectPerms(ctx, action) {
                 resourceUid: nuid,
             });
     }
+}
 
+function taskUidChange(changes, action, taskUid, propagation) {
+    if (action.verb === 'share_grant') {
+        pushUpsert(changes, {
+            userId: action.targetUserId,
+            resourceType: 'task',
+            resourceUid: taskUid,
+            accessLevel: action.accessLevel,
+            propagation,
+            grantedByUserId: action.actorUserId,
+        });
+    } else if (action.verb === 'share_revoke') {
+        pushDelete(changes, {
+            userId: action.targetUserId,
+            resourceType: 'task',
+            resourceUid: taskUid,
+        });
+    }
+}
+
+async function calculateProjectPerms(ctx, action) {
+    const changes = emptyChanges();
+    const project = await Project.findOne({
+        where: { uid: action.resourceUid },
+        attributes: ['id', 'uid', 'user_id'],
+        transaction: ctx.tx,
+    });
+    if (!project) return changes;
+
+    await projectSubtreeChanges(changes, project, action, 'direct');
     return changes;
 }
 
@@ -120,42 +168,14 @@ async function calculateTaskPerms(ctx, action) {
     });
     if (!task) return changes;
 
-    const taskUids = new Set([action.resourceUid]);
-    const queue = [{ id: task.id }];
-    while (queue.length) {
-        const node = queue.shift();
-        const children = await Task.findAll({
-            where: { parent_task_id: node.id },
-            attributes: ['id', 'uid'],
-            transaction: ctx.tx,
-            raw: true,
-        });
-        for (const c of children) {
-            if (!taskUids.has(c.uid)) {
-                taskUids.add(c.uid);
-                queue.push({ id: c.id });
-            }
-        }
-    }
-
-    if (action.verb === 'share_grant') {
-        for (const tuid of taskUids)
-            pushUpsert(changes, {
-                userId: action.targetUserId,
-                resourceType: 'task',
-                resourceUid: tuid,
-                accessLevel: action.accessLevel,
-                propagation:
-                    tuid === action.resourceUid ? 'direct' : 'inherited',
-                grantedByUserId: action.actorUserId,
-            });
-    } else if (action.verb === 'share_revoke') {
-        for (const tuid of taskUids)
-            pushDelete(changes, {
-                userId: action.targetUserId,
-                resourceType: 'task',
-                resourceUid: tuid,
-            });
+    const taskUids = await collectTaskSubtree(task.id, action.resourceUid);
+    for (const tuid of taskUids) {
+        taskUidChange(
+            changes,
+            action,
+            tuid,
+            tuid === action.resourceUid ? 'direct' : 'inherited'
+        );
     }
 
     return changes;
@@ -182,16 +202,98 @@ async function calculateNotePerms(ctx, action) {
     return changes;
 }
 
+function containerRowChange(changes, action, resourceType, resourceUid) {
+    if (action.verb === 'share_grant') {
+        pushUpsert(changes, {
+            userId: action.targetUserId,
+            resourceType,
+            resourceUid,
+            accessLevel: action.accessLevel,
+            propagation: 'direct',
+            grantedByUserId: action.actorUserId,
+        });
+    } else if (action.verb === 'share_revoke') {
+        pushDelete(changes, {
+            userId: action.targetUserId,
+            resourceType,
+            resourceUid,
+        });
+    }
+}
+
+// Sharing an area cascades to every project the area owner keeps in it, and each
+// project's own task/note subtree. The area row itself is 'direct' so the share
+// list, revoke and accept/decline set-move can find it; the projects and their
+// children are 'inherited'. Projects added to the area later are covered by
+// containerShareSync.syncProjectSharesFromContainer, not here.
 async function calculateAreaPerms(ctx, action) {
     const changes = emptyChanges();
-    // TODO: implement area→projects→tasks/notes cascade later
+    const area = await Area.findOne({
+        where: { uid: action.resourceUid },
+        attributes: ['id', 'uid', 'user_id'],
+        transaction: ctx.tx,
+    });
+    if (!area) return changes;
+
+    containerRowChange(changes, action, 'area', area.uid);
+
+    const projects = await Project.findAll({
+        where: { area_id: area.id, user_id: area.user_id },
+        attributes: ['id', 'uid', 'user_id'],
+        transaction: ctx.tx,
+        raw: true,
+    });
+    for (const project of projects) {
+        await projectSubtreeChanges(changes, project, action, 'inherited');
+    }
+
     return changes;
 }
 
-async function calculateTagPerms(ctx, action) {
+// Sharing a goal cascades to its linked projects (and their subtrees) and to
+// tasks assigned directly to the goal (plus their subtasks). Same 'direct' goal
+// row + 'inherited' children shape as area sharing.
+async function calculateGoalPerms(ctx, action) {
     const changes = emptyChanges();
-    // No-op for now (tags excluded from project cascade)
+    const goal = await Goal.findOne({
+        where: { uid: action.resourceUid },
+        attributes: ['id', 'uid', 'user_id'],
+        transaction: ctx.tx,
+    });
+    if (!goal) return changes;
+
+    containerRowChange(changes, action, 'goal', goal.uid);
+
+    const projects = await Project.findAll({
+        where: { goal_id: goal.id, user_id: goal.user_id },
+        attributes: ['id', 'uid', 'user_id'],
+        transaction: ctx.tx,
+        raw: true,
+    });
+    for (const project of projects) {
+        await projectSubtreeChanges(changes, project, action, 'inherited');
+    }
+
+    // Tasks attached straight to the goal (no project). Walk each subtask tree.
+    const goalTasks = await Task.findAll({
+        where: { goal_id: goal.id, parent_task_id: null },
+        attributes: ['id', 'uid'],
+        transaction: ctx.tx,
+        raw: true,
+    });
+    for (const gt of goalTasks) {
+        const taskUids = await collectTaskSubtree(gt.id, gt.uid);
+        for (const tuid of taskUids) {
+            taskUidChange(changes, action, tuid, 'inherited');
+        }
+    }
+
     return changes;
+}
+
+async function calculateTagPerms() {
+    // No-op for now (tags excluded from project cascade)
+    return emptyChanges();
 }
 
 module.exports = {
@@ -199,5 +301,8 @@ module.exports = {
     calculateTaskPerms,
     calculateNotePerms,
     calculateAreaPerms,
+    calculateGoalPerms,
     calculateTagPerms,
+    collectProjectDescendants,
+    projectSubtreeChanges,
 };

--- a/backend/services/permissionsService.js
+++ b/backend/services/permissionsService.js
@@ -1,5 +1,13 @@
 const { Op } = require('sequelize');
-const { Project, Task, Note, Permission } = require('../models');
+const {
+    Project,
+    Task,
+    Note,
+    Area,
+    Goal,
+    Person,
+    Permission,
+} = require('../models');
 const { isAdmin } = require('./rolesService');
 
 const ACCESS = { NONE: 'none', RO: 'ro', RW: 'rw', ADMIN: 'admin' };
@@ -18,7 +26,24 @@ async function getSharedUidsForUser(resourceType, userId) {
     return Array.from(set);
 }
 
-const RESOURCE_MODELS = { project: Project, task: Task, note: Note };
+const RESOURCE_MODELS = {
+    project: Project,
+    task: Task,
+    note: Note,
+    area: Area,
+    goal: Goal,
+};
+
+// The uids of every Person record that points at this user's account (normally
+// just their self-person). A task assigned to any of these is "assigned to me".
+async function getMyPersonUids(userId) {
+    const rows = await Person.findAll({
+        where: { linked_user_id: userId },
+        attributes: ['uid'],
+        raw: true,
+    });
+    return rows.map((r) => r.uid);
+}
 
 // Whether the resource row still exists, regardless of who may read it.
 // Used to tell "gone" apart from "not yours" when access is denied.
@@ -51,11 +76,22 @@ async function getAccess(userId, resourceType, resourceUid) {
     } else if (resourceType === 'task') {
         const t = await Task.findOne({
             where: { uid: resourceUid },
-            attributes: ['user_id', 'project_id', 'parent_task_id'],
+            attributes: [
+                'user_id',
+                'project_id',
+                'parent_task_id',
+                'assigned_to',
+            ],
             raw: true,
         });
         if (!t) return ACCESS.NONE;
         if (t.user_id === userId) return ACCESS.RW;
+
+        // A task assigned to the caller is theirs to act on, wherever it lives.
+        if (t.assigned_to) {
+            const myPersonUids = await getMyPersonUids(userId);
+            if (myPersonUids.includes(t.assigned_to)) return ACCESS.RW;
+        }
 
         // Subtasks don't always carry their own project_id, so walk up the
         // parent chain to find the project (or an owning ancestor) they
@@ -118,6 +154,22 @@ async function getAccess(userId, resourceType, resourceUid) {
                 }
             }
         }
+    } else if (resourceType === 'area') {
+        const area = await Area.findOne({
+            where: { uid: resourceUid },
+            attributes: ['user_id'],
+            raw: true,
+        });
+        if (!area) return ACCESS.NONE;
+        if (area.user_id === userId) return ACCESS.RW;
+    } else if (resourceType === 'goal') {
+        const goal = await Goal.findOne({
+            where: { uid: resourceUid },
+            attributes: ['user_id'],
+            raw: true,
+        });
+        if (!goal) return ACCESS.NONE;
+        if (goal.user_id === userId) return ACCESS.RW;
     }
 
     // shared
@@ -190,6 +242,15 @@ async function ownershipOrPermissionWhere(resourceType, userId, cache = null) {
             conditions.push({ project_id: { [Op.in]: sharedProjectIds } }); // Items in shared projects
         }
 
+        // Tasks assigned to the caller show up even when they own nothing else
+        // in the task's project.
+        if (resourceType === 'task') {
+            const myPersonUids = await getMyPersonUids(userId);
+            if (myPersonUids.length > 0) {
+                conditions.push({ assigned_to: { [Op.in]: myPersonUids } });
+            }
+        }
+
         const result = { [Op.or]: conditions };
         if (cache) cache.set(cacheKey, result);
         return result;
@@ -214,4 +275,5 @@ module.exports = {
     resourceExists,
     ownershipOrPermissionWhere,
     getSharedUidsForUser,
+    getMyPersonUids,
 };

--- a/backend/tests/integration/admin-user-invite.test.js
+++ b/backend/tests/integration/admin-user-invite.test.js
@@ -1,0 +1,99 @@
+const request = require('supertest');
+
+const sentEmails = [];
+jest.mock('../../services/emailService', () => ({
+    isEmailEnabled: () => true,
+    initializeEmailService: () => {},
+    verifyEmailConnection: async () => ({ success: true }),
+    sendEmail: async (message) => {
+        sentEmails.push(message);
+        return { success: true, messageId: 'test' };
+    },
+}));
+
+const app = require('../../app');
+const { User, Role } = require('../../models');
+const { createTestUser } = require('../helpers/testUtils');
+
+const loginAgent = async (email, password = 'password123') => {
+    const agent = request.agent(app);
+    await agent.post('/api/login').send({ email, password });
+    return agent;
+};
+
+const tokenFromLastEmail = () => {
+    const last = sentEmails[sentEmails.length - 1];
+    const match = last.text.match(/token=([a-f0-9]+)/);
+    return match ? match[1] : null;
+};
+
+describe('Admin member invite', () => {
+    let adminAgent;
+
+    beforeEach(async () => {
+        sentEmails.length = 0;
+        const admin = await createTestUser({
+            email: `admin_${Date.now()}@example.com`,
+        });
+        await Role.destroy({ where: {} });
+        await Role.findOrCreate({
+            where: { user_id: admin.id },
+            defaults: { user_id: admin.id, is_admin: true },
+        });
+        adminAgent = await loginAgent(admin.email);
+    });
+
+    it('creates an inert account and emails a set-password link when no password is given', async () => {
+        const email = `member_${Date.now()}@example.com`;
+        const res = await adminAgent
+            .post('/api/admin/users')
+            .send({ email, name: 'Member' });
+
+        expect(res.status).toBe(201);
+        expect(res.body.invited).toBe(true);
+        expect(res.body.email_sent).toBe(true);
+
+        const created = await User.findOne({ where: { email } });
+        expect(created.email_verified).toBe(false);
+        expect(created.password_digest).toBeNull();
+
+        expect(sentEmails).toHaveLength(1);
+        expect(sentEmails[0].to).toBe(email);
+        expect(tokenFromLastEmail()).toBeTruthy();
+    });
+
+    it('lets the invited member set a password with the emailed token and then log in', async () => {
+        const email = `member2_${Date.now()}@example.com`;
+        await adminAgent.post('/api/admin/users').send({ email });
+
+        const token = tokenFromLastEmail();
+        const reset = await request(app)
+            .post('/api/reset-password')
+            .send({ token, password: 'newpassword123' });
+        expect(reset.status).toBe(200);
+
+        const login = await request(app)
+            .post('/api/login')
+            .send({ email, password: 'newpassword123' });
+        expect(login.status).toBe(200);
+
+        const user = await User.findOne({ where: { email } });
+        expect(user.email_verified).toBe(true);
+    });
+
+    it('still creates the account normally when a password is supplied', async () => {
+        const email = `member3_${Date.now()}@example.com`;
+        const res = await adminAgent
+            .post('/api/admin/users')
+            .send({ email, password: 'password123' });
+
+        expect(res.status).toBe(201);
+        expect(res.body.invited).toBe(false);
+        expect(sentEmails).toHaveLength(0);
+
+        const login = await request(app)
+            .post('/api/login')
+            .send({ email, password: 'password123' });
+        expect(login.status).toBe(200);
+    });
+});

--- a/backend/tests/integration/notification-preferences.test.js
+++ b/backend/tests/integration/notification-preferences.test.js
@@ -62,6 +62,12 @@ describe('Notification Preferences', () => {
                     push: false,
                     telegram: false,
                 },
+                taskAssigned: {
+                    inApp: true,
+                    email: false,
+                    push: false,
+                    telegram: false,
+                },
             });
         });
 

--- a/backend/tests/integration/shares-consent.test.js
+++ b/backend/tests/integration/shares-consent.test.js
@@ -4,6 +4,8 @@ const {
     Project,
     Task,
     Note,
+    Area,
+    Goal,
     Permission,
     Role,
     Notification,
@@ -257,6 +259,170 @@ describe('Share invitations (consent + no user enumeration)', () => {
             access_level: 'ro',
         });
         expect(res.status).toBe(403);
+    });
+});
+
+describe('Sharing an area cascades to its projects and tasks', () => {
+    let owner, invitee, ownerAgent, inviteeAgent, area, areaProject;
+
+    beforeEach(async () => {
+        owner = await createTestUser({
+            email: `areaowner_${Date.now()}@example.com`,
+        });
+        invitee = await createTestUser({
+            email: `areainvitee_${Date.now()}@example.com`,
+        });
+        ownerAgent = await login(owner);
+        inviteeAgent = await login(invitee);
+
+        area = await Area.create({ name: 'Home', user_id: owner.id });
+        areaProject = await Project.create({
+            name: 'Renovation',
+            user_id: owner.id,
+            area_id: area.id,
+        });
+        await Task.create({
+            name: 'Plaster the hallway',
+            user_id: owner.id,
+            project_id: areaProject.id,
+        });
+    });
+
+    const shareArea = (access = 'ro') =>
+        ownerAgent.post('/api/shares').send({
+            resource_type: 'area',
+            resource_uid: area.uid,
+            target_user_email: invitee.email,
+            access_level: access,
+        });
+
+    const acceptFirstInvitation = async () => {
+        const list = await inviteeAgent.get('/api/shares/invitations');
+        const inv = list.body.invitations[0];
+        return inviteeAgent.post(`/api/shares/invitations/${inv.id}/accept`);
+    };
+
+    it('hides the projects until the invitation is accepted', async () => {
+        expect((await shareArea()).status).toBe(204);
+
+        const before = await inviteeAgent.get('/api/projects');
+        expect(
+            before.body.projects.find((p) => p.uid === areaProject.uid)
+        ).toBeUndefined();
+
+        await acceptFirstInvitation();
+
+        const after = await inviteeAgent.get('/api/projects');
+        expect(
+            after.body.projects.find((p) => p.uid === areaProject.uid)
+        ).toBeDefined();
+
+        const tasks = await inviteeAgent.get('/api/tasks');
+        expect(
+            tasks.body.tasks.find((t) => t.name === 'Plaster the hallway')
+        ).toBeDefined();
+    });
+
+    it('removes the whole cascade when declined', async () => {
+        await shareArea();
+        const list = await inviteeAgent.get('/api/shares/invitations');
+        await inviteeAgent.post(
+            `/api/shares/invitations/${list.body.invitations[0].id}/decline`
+        );
+
+        const count = await Permission.count({
+            where: { user_id: invitee.id },
+        });
+        expect(count).toBe(0);
+    });
+
+    it('auto-shares a project added to the area after the grant', async () => {
+        await shareArea('rw');
+        await acceptFirstInvitation();
+
+        const created = await ownerAgent.post('/api/project').send({
+            name: 'Bathroom',
+            area_id: area.id,
+        });
+        expect(created.status).toBe(201);
+
+        const projects = await inviteeAgent.get('/api/projects');
+        expect(
+            projects.body.projects.find((p) => p.name === 'Bathroom')
+        ).toBeDefined();
+    });
+
+    it('does not leak a new project while the area invite is still pending', async () => {
+        await shareArea('rw');
+
+        const created = await ownerAgent.post('/api/project').send({
+            name: 'Garden',
+            area_id: area.id,
+        });
+        expect(created.status).toBe(201);
+
+        const projects = await inviteeAgent.get('/api/projects');
+        expect(
+            projects.body.projects.find((p) => p.name === 'Garden')
+        ).toBeUndefined();
+
+        await acceptFirstInvitation();
+        const after = await inviteeAgent.get('/api/projects');
+        expect(
+            after.body.projects.find((p) => p.name === 'Garden')
+        ).toBeDefined();
+    });
+});
+
+describe('Sharing a goal cascades to its projects and direct tasks', () => {
+    let owner, invitee, ownerAgent, inviteeAgent, goal, goalProject;
+
+    beforeEach(async () => {
+        owner = await createTestUser({
+            email: `goalowner_${Date.now()}@example.com`,
+        });
+        invitee = await createTestUser({
+            email: `goalinvitee_${Date.now()}@example.com`,
+        });
+        ownerAgent = await login(owner);
+        inviteeAgent = await login(invitee);
+
+        goal = await Goal.create({ title: 'Get closer', user_id: owner.id });
+        goalProject = await Project.create({
+            name: 'Date nights',
+            user_id: owner.id,
+            goal_id: goal.id,
+        });
+        await Task.create({
+            name: 'Buy a gift',
+            user_id: owner.id,
+            goal_id: goal.id,
+        });
+    });
+
+    it('shares linked projects and direct goal tasks once accepted', async () => {
+        const res = await ownerAgent.post('/api/shares').send({
+            resource_type: 'goal',
+            resource_uid: goal.uid,
+            target_user_email: invitee.email,
+            access_level: 'rw',
+        });
+        expect(res.status).toBe(204);
+
+        const list = await inviteeAgent.get('/api/shares/invitations');
+        await inviteeAgent.post(
+            `/api/shares/invitations/${list.body.invitations[0].id}/accept`
+        );
+
+        const projects = await inviteeAgent.get('/api/projects');
+        expect(
+            projects.body.projects.find((p) => p.uid === goalProject.uid)
+        ).toBeDefined();
+
+        const tasks = await inviteeAgent.get('/api/tasks');
+        expect(
+            tasks.body.tasks.find((t) => t.name === 'Buy a gift')
+        ).toBeDefined();
     });
 });
 

--- a/backend/tests/integration/task-assignment.test.js
+++ b/backend/tests/integration/task-assignment.test.js
@@ -1,0 +1,133 @@
+const request = require('supertest');
+const app = require('../../app');
+const { Task, Notification } = require('../../models');
+const {
+    createTestUser,
+    acceptAllInvitations,
+} = require('../helpers/testUtils');
+const peopleService = require('../../modules/people/service');
+
+const login = async (user) => {
+    const agent = request.agent(app);
+    await agent
+        .post('/api/login')
+        .send({ email: user.email, password: 'password123' });
+    return agent;
+};
+
+describe('Task assignment notifies and surfaces to the assignee', () => {
+    let owner, assignee, ownerAgent, assigneeAgent, assigneeSelfPerson, project;
+
+    beforeEach(async () => {
+        owner = await createTestUser({
+            email: `assignowner_${Date.now()}@example.com`,
+            name: 'Owner',
+        });
+        assignee = await createTestUser({
+            email: `assignee_${Date.now()}@example.com`,
+            name: 'Assignee',
+        });
+        await peopleService.createSelfPerson(owner);
+        assigneeSelfPerson = await peopleService.createSelfPerson(assignee);
+
+        ownerAgent = await login(owner);
+        assigneeAgent = await login(assignee);
+
+        const res = await ownerAgent
+            .post('/api/project')
+            .send({ name: 'Weekend logistics' });
+        project = res.body;
+        await ownerAgent.post('/api/shares').send({
+            resource_type: 'project',
+            resource_uid: project.uid,
+            target_user_email: assignee.email,
+            access_level: 'rw',
+        });
+        await acceptAllInvitations(assigneeAgent);
+    });
+
+    it('shows an assigned task in the assignee lists and lets them open it', async () => {
+        const created = await ownerAgent.post('/api/task').send({
+            name: 'Drive to tennis',
+            project_uid: project.uid,
+            assigned_to: assigneeSelfPerson.uid,
+        });
+        expect(created.status).toBe(201);
+
+        const list = await assigneeAgent.get(
+            '/api/tasks?assigned_to=me&status=active'
+        );
+        expect(list.status).toBe(200);
+        expect(
+            list.body.tasks.find((t) => t.name === 'Drive to tennis')
+        ).toBeDefined();
+
+        const detail = await assigneeAgent.get(`/api/task/${created.body.uid}`);
+        expect(detail.status).toBe(200);
+    });
+
+    it('creates a task_assigned notification for the assignee', async () => {
+        const task = await Task.create({
+            name: 'Buy groceries',
+            user_id: owner.id,
+            project_id: (await ownerAgent.get(`/api/project/${project.uid}`))
+                .body.id,
+        });
+
+        const res = await ownerAgent
+            .patch(`/api/task/${task.uid}`)
+            .send({ assigned_to: assigneeSelfPerson.uid });
+        expect(res.status).toBe(200);
+
+        const notification = await Notification.findOne({
+            where: { user_id: assignee.id, type: 'task_assigned' },
+        });
+        expect(notification).not.toBeNull();
+        expect(notification.data.taskUid).toBe(task.uid);
+    });
+
+    it('does not notify when the assignee prefers no task_assigned notification', async () => {
+        await assigneeAgent.patch('/api/profile').send({
+            notification_preferences: {
+                taskAssigned: {
+                    inApp: false,
+                    email: false,
+                    push: false,
+                    telegram: false,
+                },
+            },
+        });
+
+        const task = await Task.create({
+            name: 'Return library books',
+            user_id: owner.id,
+        });
+        await ownerAgent
+            .patch(`/api/task/${task.uid}`)
+            .send({ assigned_to: assigneeSelfPerson.uid });
+
+        const count = await Notification.count({
+            where: { user_id: assignee.id, type: 'task_assigned' },
+        });
+        expect(count).toBe(0);
+    });
+
+    it('does not notify the assigner when they assign a task to themselves', async () => {
+        const selfPerson = (
+            await peopleService.getAll(owner.id, { archived: false })
+        ).find((p) => p.linked_user_id === owner.id);
+
+        const task = await Task.create({
+            name: 'Self task',
+            user_id: owner.id,
+        });
+        await ownerAgent
+            .patch(`/api/task/${task.uid}`)
+            .send({ assigned_to: selfPerson.uid });
+
+        const count = await Notification.count({
+            where: { user_id: owner.id, type: 'task_assigned' },
+        });
+        expect(count).toBe(0);
+    });
+});

--- a/backend/tests/unit/services/permissionsService.test.js
+++ b/backend/tests/unit/services/permissionsService.test.js
@@ -9,6 +9,9 @@ const {
     Project,
     Task,
     Note,
+    Area,
+    Goal,
+    Person,
     Permission,
     sequelize,
 } = require('../../../models');
@@ -279,6 +282,55 @@ describe('permissionsService', () => {
             const access = await getAccess(otherUser.id, 'note', note.uid);
             expect(access).toBe('ro');
         });
+
+        // --- Areas & Goals ---
+
+        it('should return rw for area owner and none for a stranger', async () => {
+            const area = await Area.create({ name: 'Home', user_id: owner.id });
+            expect(await getAccess(owner.id, 'area', area.uid)).toBe('rw');
+            expect(await getAccess(otherUser.id, 'area', area.uid)).toBe(
+                'none'
+            );
+        });
+
+        it('should honour an accepted area share', async () => {
+            const area = await Area.create({ name: 'Home', user_id: owner.id });
+            await Permission.create({
+                user_id: otherUser.id,
+                resource_type: 'area',
+                resource_uid: area.uid,
+                access_level: 'ro',
+                propagation: 'direct',
+                status: 'accepted',
+                granted_by_user_id: owner.id,
+            });
+            expect(await getAccess(otherUser.id, 'area', area.uid)).toBe('ro');
+        });
+
+        it('should return rw for goal owner and none for a stranger', async () => {
+            const goal = await Goal.create({
+                title: 'Ship it',
+                user_id: owner.id,
+            });
+            expect(await getAccess(owner.id, 'goal', goal.uid)).toBe('rw');
+            expect(await getAccess(otherUser.id, 'goal', goal.uid)).toBe(
+                'none'
+            );
+        });
+
+        it('should grant rw to the assignee of a task they do not own', async () => {
+            const person = await Person.create({
+                user_id: owner.id,
+                linked_user_id: otherUser.id,
+                name: 'Other Person',
+            });
+            const task = await Task.create({
+                name: 'Assigned task',
+                user_id: owner.id,
+                assigned_to: person.uid,
+            });
+            expect(await getAccess(otherUser.id, 'task', task.uid)).toBe('rw');
+        });
     });
 
     describe('getSharedUidsForUser', () => {
@@ -403,6 +455,26 @@ describe('permissionsService', () => {
             // Should have a project_id IN condition
             const projectCondition = conditions.find((c) => c.project_id);
             expect(projectCondition).toBeDefined();
+        });
+
+        it('should include tasks assigned to the caller', async () => {
+            const person = await Person.create({
+                user_id: owner.id,
+                linked_user_id: otherUser.id,
+                name: 'Other Person',
+            });
+            const where = await ownershipOrPermissionWhere(
+                'task',
+                otherUser.id
+            );
+            const orKey = Object.getOwnPropertySymbols(where)[0];
+            const conditions = where[orKey];
+            const assignedCondition = conditions.find((c) => c.assigned_to);
+            expect(assignedCondition).toBeDefined();
+            const inKey = Object.getOwnPropertySymbols(
+                assignedCondition.assigned_to
+            )[0];
+            expect(assignedCondition.assigned_to[inKey]).toContain(person.uid);
         });
     });
 

--- a/backend/tests/unit/utils/notificationPreferences.test.js
+++ b/backend/tests/unit/utils/notificationPreferences.test.js
@@ -41,6 +41,12 @@ describe('notificationPreferences utils', () => {
                     push: false,
                     telegram: false,
                 },
+                taskAssigned: {
+                    inApp: true,
+                    email: false,
+                    push: false,
+                    telegram: false,
+                },
             });
         });
 
@@ -203,6 +209,7 @@ describe('notificationPreferences utils', () => {
                 task_overdue: 'overdueTasks',
                 project_due_soon: 'dueProjects',
                 project_overdue: 'overdueProjects',
+                task_assigned: 'taskAssigned',
             });
         });
     });
@@ -331,6 +338,12 @@ describe('notificationPreferences utils', () => {
                     email: true,
                     push: false,
                     telegram: true,
+                },
+                taskAssigned: {
+                    inApp: false,
+                    email: true,
+                    push: false,
+                    telegram: false,
                 },
             };
 

--- a/backend/utils/notificationPreferences.js
+++ b/backend/utils/notificationPreferences.js
@@ -13,6 +13,7 @@ const DEFAULT_PREFERENCES = {
         telegram: false,
     },
     deferUntil: { inApp: true, email: false, push: false, telegram: false },
+    taskAssigned: { inApp: true, email: false, push: false, telegram: false },
 };
 
 /**
@@ -23,6 +24,7 @@ const NOTIFICATION_TYPE_MAPPING = {
     task_overdue: 'overdueTasks',
     project_due_soon: 'dueProjects',
     project_overdue: 'overdueProjects',
+    task_assigned: 'taskAssigned',
 };
 
 /**

--- a/docs/00-tasks-behavior.md
+++ b/docs/00-tasks-behavior.md
@@ -420,7 +420,12 @@ This document explains how tasks work in tududi from a user behavior perspective
     - Task due soon (based on due date)
     - Task overdue
     - Defer Until time reached
-    - Task assigned to you (shared via project)
+    - **Task assigned to you** — when someone sets `assigned_to` to a person
+      linked to your account, you get a `task_assigned` notification (channels
+      configurable under the "Task Assigned" preference). An assigned task also
+      shows up in your task lists and the "Assigned to me" sidebar view, and you
+      can open and complete it, even if you don't otherwise have access to its
+      project.
 
 55. **Notification channels:**
     - In-app notifications (navbar indicator)

--- a/docs/07-areas.md
+++ b/docs/07-areas.md
@@ -117,8 +117,12 @@ Area: "Health"
 
 5. **User ID** (system-managed)
    - Links area to the user who created it
-   - Areas are private to each user
-   - Cannot be shared between users
+   - The area container itself stays with its owner (it is not listed for
+     collaborators), but an area **can be shared**: the share cascades to every
+     project the owner keeps in the area (and their tasks and notes), through
+     the same invite-and-accept flow as project sharing. Projects added to the
+     area later are shared automatically. See
+     [Projects](06-projects.md#project-sharing-and-collaboration).
 
 ---
 
@@ -609,7 +613,8 @@ No Area
 ### "Can't delete an area"
 
 **Possible reasons:**
-1. You're not the owner (areas can't be shared)
+1. You're not the owner (only the owner manages the area; a shared area's
+   projects appear for collaborators but the area itself does not)
 2. Network error
 3. Permission issue
 

--- a/docs/08-user-management.md
+++ b/docs/08-user-management.md
@@ -265,10 +265,15 @@ to an account, so it cannot be used to discover who has signed up - Declining re
 ### User CRUD Operations
 
 30. **Admins can create new users directly**
-    - Bypasses registration flow and email verification
-    - Created users can log in immediately
-    - Requires: email, password
-    - Optional: name, surname, role (admin or user)
+    - Bypasses the registration flow
+    - Requires: email. Optional: name, surname, role (admin or user)
+    - **With a password:** the account is verified and can log in immediately
+    - **Without a password (invite):** the account is created unverified with no
+      password, and an email is sent with a set-password link (reuses the
+      password-reset token; expiry `INVITE_TOKEN_EXPIRY_HOURS`, default 168).
+      Using the link sets the password and verifies the email. The response
+      carries `invited: true` and `email_sent`; if email is disabled the account
+      is still kept and the admin sets a password via update.
 
 31. **Admins can list all users**
     - Shows email, name, surname, role, creation date
@@ -351,7 +356,8 @@ to an account, so it cannot be used to discover who has signed up - Declining re
     Registration → Email Verification → First Login → Profile Setup → Active User
     ```
 
-    - Or: Admin creates user → Active user (no verification needed)
+    - Or: Admin creates user with a password → Active user (no verification needed)
+    - Or: Admin creates user without a password → Invite email → user sets password → Active user
 
 40. **User deletion flow:**
     ```

--- a/frontend/components/Admin/AdminUsersPage.tsx
+++ b/frontend/components/Admin/AdminUsersPage.tsx
@@ -21,6 +21,8 @@ interface AdminUserItem {
     surname?: string;
     created_at: string;
     role: 'admin' | 'user';
+    invited?: boolean;
+    email_sent?: boolean;
 }
 
 const fetchAdminUsers = async (t: any): Promise<AdminUserItem[]> => {
@@ -47,6 +49,8 @@ const createAdminUser = async (
     role?: 'admin' | 'user',
     linked_person_uid?: string
 ): Promise<AdminUserItem> => {
+    const body: any = { email, name, surname, role, linked_person_uid };
+    if (password) body.password = password;
     const res = await fetchWithCsrf(getApiPath('admin/users'), {
         method: 'POST',
         credentials: 'include',
@@ -54,7 +58,7 @@ const createAdminUser = async (
             'Content-Type': 'application/json',
             Accept: 'application/json',
         },
-        body: JSON.stringify({ email, password, name, surname, role, linked_person_uid }),
+        body: JSON.stringify(body),
     });
     if (res.status === 401)
         throw new Error(
@@ -183,7 +187,9 @@ const AddUserModal: React.FC<{
                 setSurname('');
                 setRole('user');
                 setSelectedPersonUid('');
-                fetchPeople({ unlinked: true }).then(setUnlinkedPeople).catch(() => setUnlinkedPeople([]));
+                fetchPeople({ unlinked: true })
+                    .then(setUnlinkedPeople)
+                    .catch(() => setUnlinkedPeople([]));
             }
             setError(null);
             setIsRoleDropdownOpen(false);
@@ -233,11 +239,8 @@ const AddUserModal: React.FC<{
             setError(t('errors.invalidEmail', 'Invalid email address'));
             return;
         }
-        // Password is required for new users, optional for updates
-        if (!editingUser && !password) {
-            setError(t('errors.required', 'This field is required'));
-            return;
-        }
+        // Password is optional for new users: leaving it blank sends an
+        // invitation email so the member sets their own.
         setSubmitting(true);
         try {
             if (editingUser) {
@@ -302,12 +305,15 @@ const AddUserModal: React.FC<{
                             <select
                                 className="w-full rounded border px-3 py-2 bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100 text-sm"
                                 value={selectedPersonUid}
-                                onChange={(e) => handlePersonSelect(e.target.value)}
+                                onChange={(e) =>
+                                    handlePersonSelect(e.target.value)
+                                }
                             >
                                 <option value="">— none —</option>
                                 {unlinkedPeople.map((p) => (
                                     <option key={p.uid} value={p.uid}>
-                                        {p.name}{p.email ? ` (${p.email})` : ''}
+                                        {p.name}
+                                        {p.email ? ` (${p.email})` : ''}
                                     </option>
                                 ))}
                             </select>
@@ -350,24 +356,26 @@ const AddUserModal: React.FC<{
                     <div>
                         <label className="block text-sm text-gray-700 dark:text-gray-300 mb-1">
                             {t('admin.password', 'Password')}
-                            {editingUser && (
-                                <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">
-                                    (
-                                    {t(
-                                        'admin.passwordOptional',
-                                        'Leave blank to keep current'
-                                    )}
-                                    )
-                                </span>
-                            )}
+                            <span className="text-xs text-gray-500 dark:text-gray-400 ml-2">
+                                (
+                                {editingUser
+                                    ? t(
+                                          'admin.passwordOptional',
+                                          'Leave blank to keep current'
+                                      )
+                                    : t(
+                                          'admin.passwordInviteHint',
+                                          'Leave blank to send an invitation email'
+                                      )}
+                                )
+                            </span>
                         </label>
                         <input
                             type="password"
                             className="w-full rounded border px-3 py-2 bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}
-                            required={!editingUser}
-                            minLength={6}
+                            minLength={8}
                         />
                     </div>
                     <div>
@@ -506,14 +514,17 @@ const AdminUsersPage: React.FC = () => {
     // Toggle registration
     const toggleRegistration = async () => {
         try {
-            const res = await fetchWithCsrf(getApiPath('admin/toggle-registration'), {
-                method: 'POST',
-                credentials: 'include',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-                body: JSON.stringify({ enabled: !registrationEnabled }),
-            });
+            const res = await fetchWithCsrf(
+                getApiPath('admin/toggle-registration'),
+                {
+                    method: 'POST',
+                    credentials: 'include',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ enabled: !registrationEnabled }),
+                }
+            );
             if (res.ok) {
                 const data = await res.json();
                 setRegistrationEnabled(data.enabled);
@@ -762,9 +773,25 @@ const AdminUsersPage: React.FC = () => {
                         setAddOpen(false);
                         setEditingUser(null);
                     }}
-                    onCreated={(user) =>
-                        setUsers((prev) => (prev ? [user, ...prev] : [user]))
-                    }
+                    onCreated={(user) => {
+                        setUsers((prev) => (prev ? [user, ...prev] : [user]));
+                        if (user.invited && user.email_sent) {
+                            showSuccessToast(
+                                t(
+                                    'admin.invitationSent',
+                                    'Invitation email sent to {{email}}',
+                                    { email: user.email }
+                                )
+                            );
+                        } else if (user.invited && !user.email_sent) {
+                            showErrorToast(
+                                t(
+                                    'admin.invitationNotSent',
+                                    'Account created, but email is disabled - set a password for this user manually.'
+                                )
+                            );
+                        }
+                    }}
                     onUpdated={(user) =>
                         setUsers((prev) =>
                             prev

--- a/frontend/components/Area/AreaDetails.tsx
+++ b/frontend/components/Area/AreaDetails.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import {
     PencilIcon,
     FlagIcon,
+    ShareIcon,
     XMarkIcon,
 } from '@heroicons/react/24/outline';
 import { useStore } from '../../store/useStore';
@@ -16,11 +17,13 @@ import { updateArea } from '../../utils/areasService';
 import { updateGoal } from '../../utils/goalsService';
 import AreaModal from './AreaModal';
 import TaskList from '../Task/TaskList';
+import ShareModal from '../Shared/ShareModal';
 import { createGoalUrl } from '../../utils/slugUtils';
 
 const STATUS_COLORS: Record<string, string> = {
     active: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-    achieved: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+    achieved:
+        'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
     paused: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300',
     dropped: 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400',
 };
@@ -41,6 +44,7 @@ const AreaDetails: React.FC = () => {
     const [areaTasks, setAreaTasks] = useState<Task[]>([]);
     const [loadingTasks, setLoadingTasks] = useState(false);
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+    const [isShareModalOpen, setIsShareModalOpen] = useState(false);
 
     const areaUid = uidSlug?.split('-')[0] || '';
 
@@ -82,7 +86,9 @@ const AreaDetails: React.FC = () => {
         if (!area?.uid) return;
         setLoadingTasks(true);
         try {
-            const result = await fetchTasks(`?area_uid=${area.uid}&type=all&status=all`);
+            const result = await fetchTasks(
+                `?area_uid=${area.uid}&type=all&status=all`
+            );
             setAreaTasks(result.tasks || []);
         } catch {
             setAreaTasks([]);
@@ -101,7 +107,8 @@ const AreaDetails: React.FC = () => {
     });
 
     const areaGoals: Goal[] = goalsStore.goals.filter(
-        (g: Goal) => g.Area?.uid === areaUid || (area && g.area_id === (area as any).id)
+        (g: Goal) =>
+            g.Area?.uid === areaUid || (area && g.area_id === (area as any).id)
     );
 
     const handleRemoveGoalFromArea = async (goal: Goal) => {
@@ -109,7 +116,9 @@ const AreaDetails: React.FC = () => {
         try {
             const result = await updateGoal(goal.uid, { area_id: null });
             goalsStore.setGoals(
-                goalsStore.goals.map((g: Goal) => g.uid === result.goal.uid ? result.goal : g)
+                goalsStore.goals.map((g: Goal) =>
+                    g.uid === result.goal.uid ? result.goal : g
+                )
             );
         } catch {
             // silently ignore
@@ -117,13 +126,21 @@ const AreaDetails: React.FC = () => {
     };
 
     const handleTaskUpdate = async (updatedTask: Task) => {
-        setAreaTasks((prev) => prev.map((t) => (t.uid === updatedTask.uid ? updatedTask : t)));
-        tasksStore.setTasks(tasksStore.tasks.map((t: Task) => (t.uid === updatedTask.uid ? updatedTask : t)));
+        setAreaTasks((prev) =>
+            prev.map((t) => (t.uid === updatedTask.uid ? updatedTask : t))
+        );
+        tasksStore.setTasks(
+            tasksStore.tasks.map((t: Task) =>
+                t.uid === updatedTask.uid ? updatedTask : t
+            )
+        );
     };
 
     const handleTaskDelete = (taskUid: string) => {
         setAreaTasks((prev) => prev.filter((t) => t.uid !== taskUid));
-        tasksStore.setTasks(tasksStore.tasks.filter((t: Task) => t.uid !== taskUid));
+        tasksStore.setTasks(
+            tasksStore.tasks.filter((t: Task) => t.uid !== taskUid)
+        );
     };
 
     const handleAreaSave = async (areaData: Partial<Area>) => {
@@ -133,10 +150,17 @@ const AreaDetails: React.FC = () => {
             description: areaData.description,
             color: areaData.color,
         });
-        areasStore.setAreas(areasStore.areas.map((a: Area) => (a.uid === result.uid ? result : a)));
+        areasStore.setAreas(
+            areasStore.areas.map((a: Area) =>
+                a.uid === result.uid ? result : a
+            )
+        );
         setArea(result);
         setIsEditModalOpen(false);
-        const slug = result.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+        const slug = result.name
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-|-$/g, '');
         navigate(`/area/${result.uid}-${slug}`, { replace: true });
     };
 
@@ -157,9 +181,15 @@ const AreaDetails: React.FC = () => {
     }
 
     const activeTasks = areaTasks.filter(
-        (t) => t.status !== 'done' && t.status !== 2 && t.status !== 'archived' && t.status !== 3
+        (t) =>
+            t.status !== 'done' &&
+            t.status !== 2 &&
+            t.status !== 'archived' &&
+            t.status !== 3
     );
-    const completedTasks = areaTasks.filter((t) => t.status === 'done' || t.status === 2);
+    const completedTasks = areaTasks.filter(
+        (t) => t.status === 'done' || t.status === 2
+    );
 
     return (
         <div className="w-full px-2 sm:px-4 lg:px-6 pt-4 pb-8">
@@ -168,46 +198,80 @@ const AreaDetails: React.FC = () => {
                 className="rounded-xl mb-8 overflow-hidden"
                 style={area.color ? { backgroundColor: area.color } : undefined}
             >
-                <div className={`p-6 ${area.color ? '' : 'bg-gray-50 dark:bg-gray-900 rounded-xl'}`}>
+                <div
+                    className={`p-6 ${area.color ? '' : 'bg-gray-50 dark:bg-gray-900 rounded-xl'}`}
+                >
                     <div className="flex items-start justify-between gap-4">
                         <div className="min-w-0">
-                            <p className={`text-xs font-medium uppercase tracking-widest mb-1 ${
-                                area.color ? 'text-white/60' : 'text-gray-400 dark:text-gray-500'
-                            }`}>
+                            <p
+                                className={`text-xs font-medium uppercase tracking-widest mb-1 ${
+                                    area.color
+                                        ? 'text-white/60'
+                                        : 'text-gray-400 dark:text-gray-500'
+                                }`}
+                            >
                                 Area
                             </p>
-                            <h1 className={`text-3xl font-light uppercase tracking-wide ${
-                                area.color ? 'text-white' : 'text-gray-900 dark:text-gray-100'
-                            }`}>
+                            <h1
+                                className={`text-3xl font-light uppercase tracking-wide ${
+                                    area.color
+                                        ? 'text-white'
+                                        : 'text-gray-900 dark:text-gray-100'
+                                }`}
+                            >
                                 {area.name}
                             </h1>
                             {area.description && (
-                                <p className={`mt-2 text-sm ${area.color ? 'text-white/80' : 'text-gray-600 dark:text-gray-400'}`}>
+                                <p
+                                    className={`mt-2 text-sm ${area.color ? 'text-white/80' : 'text-gray-600 dark:text-gray-400'}`}
+                                >
                                     {area.description}
                                 </p>
                             )}
-                            <div className={`mt-3 flex gap-4 text-xs ${area.color ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'}`}>
+                            <div
+                                className={`mt-3 flex gap-4 text-xs ${area.color ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'}`}
+                            >
                                 <Link
                                     to={`/projects?area=${area.uid}`}
                                     className={`hover:underline ${area.color ? 'hover:text-white' : 'hover:text-gray-700 dark:hover:text-gray-200'}`}
                                 >
-                                    {areaProjects.length} {t('areas.projects', 'projects')}
+                                    {areaProjects.length}{' '}
+                                    {t('areas.projects', 'projects')}
                                 </Link>
-                                <span>{areaGoals.length} {t('areas.goals', 'goals')}</span>
-                                <span>{areaTasks.length} {t('areas.tasks', 'tasks')}</span>
+                                <span>
+                                    {areaGoals.length}{' '}
+                                    {t('areas.goals', 'goals')}
+                                </span>
+                                <span>
+                                    {areaTasks.length}{' '}
+                                    {t('areas.tasks', 'tasks')}
+                                </span>
                             </div>
                         </div>
-                        <button
-                            onClick={() => setIsEditModalOpen(true)}
-                            className={`p-2 rounded-lg transition-colors flex-shrink-0 ${
-                                area.color
-                                    ? 'text-white/80 hover:text-white hover:bg-white/10'
-                                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
-                            }`}
-                            title={t('areas.edit', 'Edit area')}
-                        >
-                            <PencilIcon className="h-5 w-5" />
-                        </button>
+                        <div className="flex items-start gap-1 flex-shrink-0">
+                            <button
+                                onClick={() => setIsShareModalOpen(true)}
+                                className={`p-2 rounded-lg transition-colors ${
+                                    area.color
+                                        ? 'text-white/80 hover:text-white hover:bg-white/10'
+                                        : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
+                                }`}
+                                title={t('shares.shareArea', 'Share area')}
+                            >
+                                <ShareIcon className="h-5 w-5" />
+                            </button>
+                            <button
+                                onClick={() => setIsEditModalOpen(true)}
+                                className={`p-2 rounded-lg transition-colors ${
+                                    area.color
+                                        ? 'text-white/80 hover:text-white hover:bg-white/10'
+                                        : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
+                                }`}
+                                title={t('areas.edit', 'Edit area')}
+                            >
+                                <PencilIcon className="h-5 w-5" />
+                            </button>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -220,18 +284,36 @@ const AreaDetails: React.FC = () => {
 
                 {areaGoals.length === 0 ? (
                     <p className="text-sm text-gray-400 dark:text-gray-500">
-                        {t('goals.noGoalsInArea', 'No goals linked to this area.')}
+                        {t(
+                            'goals.noGoalsInArea',
+                            'No goals linked to this area.'
+                        )}
                     </p>
                 ) : (
                     <div className="flex flex-col gap-2">
                         {areaGoals.map((goal) => {
-                            const goalUrl = goal.uid ? createGoalUrl({ uid: goal.uid, title: goal.title }) : '/goals';
+                            const goalUrl = goal.uid
+                                ? createGoalUrl({
+                                      uid: goal.uid,
+                                      title: goal.title,
+                                  })
+                                : '/goals';
                             return (
-                                <div key={goal.uid} className="flex items-center gap-2 group">
+                                <div
+                                    key={goal.uid}
+                                    className="flex items-center gap-2 group"
+                                >
                                     <Link
                                         to={goalUrl}
                                         className={`flex-1 flex items-center gap-3 px-3 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 hover:bg-white dark:hover:bg-gray-800 transition-colors ${goal.color ? 'border-l-4' : ''}`}
-                                        style={goal.color ? { borderLeftColor: goal.color } : {}}
+                                        style={
+                                            goal.color
+                                                ? {
+                                                      borderLeftColor:
+                                                          goal.color,
+                                                  }
+                                                : {}
+                                        }
                                     >
                                         <FlagIcon className="h-4 w-4 text-blue-500 flex-shrink-0" />
                                         <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate flex-1">
@@ -242,14 +324,24 @@ const AreaDetails: React.FC = () => {
                                                 {goal.why}
                                             </span>
                                         )}
-                                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium flex-shrink-0 ${STATUS_COLORS[goal.status] ?? ''}`}>
-                                            {t(`goals.status.${goal.status}`, goal.status)}
+                                        <span
+                                            className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium flex-shrink-0 ${STATUS_COLORS[goal.status] ?? ''}`}
+                                        >
+                                            {t(
+                                                `goals.status.${goal.status}`,
+                                                goal.status
+                                            )}
                                         </span>
                                     </Link>
                                     <button
-                                        onClick={() => handleRemoveGoalFromArea(goal)}
+                                        onClick={() =>
+                                            handleRemoveGoalFromArea(goal)
+                                        }
                                         className="opacity-0 group-hover:opacity-100 transition-opacity p-1.5 text-gray-400 hover:text-red-500 dark:text-gray-500 dark:hover:text-red-400 rounded"
-                                        title={t('goals.removeFromArea', 'Remove from area')}
+                                        title={t(
+                                            'goals.removeFromArea',
+                                            'Remove from area'
+                                        )}
                                     >
                                         <XMarkIcon className="h-4 w-4" />
                                     </button>
@@ -286,7 +378,8 @@ const AreaDetails: React.FC = () => {
                         {completedTasks.length > 0 && (
                             <div>
                                 <h3 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">
-                                    {t('tasks.completed', 'Completed')} ({completedTasks.length})
+                                    {t('tasks.completed', 'Completed')} (
+                                    {completedTasks.length})
                                 </h3>
                                 <TaskList
                                     tasks={completedTasks}
@@ -309,6 +402,14 @@ const AreaDetails: React.FC = () => {
                     onClose={() => setIsEditModalOpen(false)}
                 />
             )}
+
+            <ShareModal
+                isOpen={isShareModalOpen}
+                onClose={() => setIsShareModalOpen(false)}
+                resourceType="area"
+                resourceUid={area.uid || null}
+                resourceName={area.name}
+            />
         </div>
     );
 };

--- a/frontend/components/Goal/GoalDetails.tsx
+++ b/frontend/components/Goal/GoalDetails.tsx
@@ -5,14 +5,21 @@ import {
     PencilSquareIcon,
     TrashIcon,
     FlagIcon,
+    ShareIcon,
     XMarkIcon,
 } from '@heroicons/react/24/outline';
 import { Goal, GoalHorizon, GoalStatus } from '../../entities/Goal';
 import { Task } from '../../entities/Task';
 import { Project } from '../../entities/Project';
-import { fetchGoalByUid, createGoal, updateGoal, deleteGoal } from '../../utils/goalsService';
+import {
+    fetchGoalByUid,
+    createGoal,
+    updateGoal,
+    deleteGoal,
+} from '../../utils/goalsService';
 import { extractUidFromSlug, createProjectUrl } from '../../utils/slugUtils';
 import ConfirmDialog from '../Shared/ConfirmDialog';
+import ShareModal from '../Shared/ShareModal';
 import TaskList from '../Task/TaskList';
 import { useStore } from '../../store/useStore';
 import { useToast } from '../Shared/ToastContext';
@@ -38,26 +45,38 @@ const GoalDetails: React.FC = () => {
     const { showSuccessToast, showErrorToast } = useToast();
 
     const isNew = uidSlug === 'new';
-    const prefilledAreaId = isNew ? ((location.state as any)?.area_id ?? null) : null;
+    const prefilledAreaId = isNew
+        ? ((location.state as any)?.area_id ?? null)
+        : null;
 
     const [goal, setGoal] = useState<Goal | null>(null);
     const [loading, setLoading] = useState(!isNew);
     const [error, setError] = useState<string | null>(null);
     const [isEditing, setIsEditing] = useState(isNew);
     const [isConfirmDeleteOpen, setIsConfirmDeleteOpen] = useState(false);
-    const [formData, setFormData] = useState<Partial<Goal>>({ ...defaultFormData(), area_id: prefilledAreaId });
+    const [isShareModalOpen, setIsShareModalOpen] = useState(false);
+    const [formData, setFormData] = useState<Partial<Goal>>({
+        ...defaultFormData(),
+        area_id: prefilledAreaId,
+    });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [formError, setFormError] = useState<string | null>(null);
 
     const loadGoals = useStore((state: any) => state.goalsStore.loadGoals);
     const areas = useStore((state: any) => state.areasStore.areas);
-    const projects: Project[] = useStore((state: any) => state.projectsStore.projects);
+    const projects: Project[] = useStore(
+        (state: any) => state.projectsStore.projects
+    );
 
     useEffect(() => {
         if (isNew) return;
 
         const uid = extractUidFromSlug(uidSlug ?? '');
-        if (!uid) { setError(t('goals.notFound', 'Goal not found')); setLoading(false); return; }
+        if (!uid) {
+            setError(t('goals.notFound', 'Goal not found'));
+            setLoading(false);
+            return;
+        }
 
         fetchGoalByUid(uid)
             .then((data) => {
@@ -72,23 +91,34 @@ const GoalDetails: React.FC = () => {
                     color: data.color ?? '',
                 });
             })
-            .catch((err) => setError(err?.message || t('goals.notFound', 'Goal not found')))
+            .catch((err) =>
+                setError(err?.message || t('goals.notFound', 'Goal not found'))
+            )
             .finally(() => setLoading(false));
     }, [uidSlug, t, isNew]);
 
     const handleChange = (
-        e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+        e: React.ChangeEvent<
+            HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+        >
     ) => {
         const { name, value } = e.target;
         setFormData((prev) => ({
             ...prev,
-            [name]: name === 'area_id' ? (value ? parseInt(value, 10) : null) : value,
+            [name]:
+                name === 'area_id'
+                    ? value
+                        ? parseInt(value, 10)
+                        : null
+                    : value,
         }));
     };
 
     const handleSubmit = async () => {
         if (!formData.title?.trim()) {
-            setFormError(t('errors.goalTitleRequired', 'Goal title is required'));
+            setFormError(
+                t('errors.goalTitleRequired', 'Goal title is required')
+            );
             return;
         }
         setIsSubmitting(true);
@@ -102,20 +132,32 @@ const GoalDetails: React.FC = () => {
             if (isNew) {
                 const result = await createGoal(payload as any);
                 const current = useStore.getState().goalsStore.goals;
-                useStore.getState().goalsStore.setGoals([...current, result.goal]);
+                useStore
+                    .getState()
+                    .goalsStore.setGoals([...current, result.goal]);
                 showSuccessToast(t('success.goalCreated', 'Goal created!'));
                 const { createGoalUrl } = await import('../../utils/slugUtils');
-                navigate(createGoalUrl({ uid: result.goal.uid!, title: result.goal.title }), { replace: true });
+                navigate(
+                    createGoalUrl({
+                        uid: result.goal.uid!,
+                        title: result.goal.title,
+                    }),
+                    { replace: true }
+                );
             } else {
                 const result = await updateGoal(goal!.uid!, payload);
-                setGoal((prev) => prev ? { ...prev, ...result.goal } : result.goal);
+                setGoal((prev) =>
+                    prev ? { ...prev, ...result.goal } : result.goal
+                );
                 setIsEditing(false);
                 loadGoals(true);
                 showSuccessToast(t('success.goalUpdated', 'Goal updated!'));
             }
         } catch (err) {
             setFormError((err as Error).message);
-            showErrorToast(t('errors.failedToSaveGoal', 'Failed to save goal.'));
+            showErrorToast(
+                t('errors.failedToSaveGoal', 'Failed to save goal.')
+            );
         } finally {
             setIsSubmitting(false);
         }
@@ -149,7 +191,9 @@ const GoalDetails: React.FC = () => {
             showSuccessToast(t('success.goalDeleted', 'Goal deleted!'));
             navigate('/goals');
         } catch {
-            showErrorToast(t('errors.failedToDeleteGoal', 'Failed to delete goal.'));
+            showErrorToast(
+                t('errors.failedToDeleteGoal', 'Failed to delete goal.')
+            );
         }
         setIsConfirmDeleteOpen(false);
     };
@@ -160,7 +204,9 @@ const GoalDetails: React.FC = () => {
             return {
                 ...prev,
                 Tasks: (prev.Tasks ?? []).map((t: any) =>
-                    (t.uid ?? t.id) === (updatedTask.uid ?? updatedTask.id) ? updatedTask : t
+                    (t.uid ?? t.id) === (updatedTask.uid ?? updatedTask.id)
+                        ? updatedTask
+                        : t
                 ),
             };
         });
@@ -185,13 +231,21 @@ const GoalDetails: React.FC = () => {
     }
 
     if (error || (!isNew && !goal)) {
-        return <div className="text-red-500 p-4">{error ?? t('goals.notFound', 'Goal not found')}</div>;
+        return (
+            <div className="text-red-500 p-4">
+                {error ?? t('goals.notFound', 'Goal not found')}
+            </div>
+        );
     }
 
     const tasks: Task[] = (goal?.Tasks ?? []) as Task[];
     const goalProjects: Project[] = (goal?.Projects ?? []) as Project[];
-    const activeTasks = tasks.filter((t) => !TASK_STATUS_DONE.includes(t.status as any));
-    const completedTasks = tasks.filter((t) => TASK_STATUS_DONE.includes(t.status as any));
+    const activeTasks = tasks.filter(
+        (t) => !TASK_STATUS_DONE.includes(t.status as any)
+    );
+    const completedTasks = tasks.filter((t) =>
+        TASK_STATUS_DONE.includes(t.status as any)
+    );
 
     const effectiveColor = goal?.color || goal?.Area?.color;
     const hasColor = !!effectiveColor;
@@ -202,16 +256,24 @@ const GoalDetails: React.FC = () => {
             {/* Header banner */}
             <div
                 className="rounded-xl mb-8 overflow-hidden"
-                style={hasColor && !showForm ? { backgroundColor: effectiveColor } : undefined}
+                style={
+                    hasColor && !showForm
+                        ? { backgroundColor: effectiveColor }
+                        : undefined
+                }
             >
-                <div className={`p-6 ${(!hasColor || showForm) ? 'bg-gray-50 dark:bg-gray-900 rounded-xl' : ''}`}>
+                <div
+                    className={`p-6 ${!hasColor || showForm ? 'bg-gray-50 dark:bg-gray-900 rounded-xl' : ''}`}
+                >
                     {showForm ? (
                         /* Edit / Create form inline */
                         <div className="flex flex-col gap-4">
                             <div className="flex items-center gap-2 mb-1">
                                 <FlagIcon className="h-4 w-4 text-blue-500" />
                                 <p className="text-xs font-medium uppercase tracking-widest text-gray-400 dark:text-gray-500">
-                                    {isNew ? t('goals.newGoal', 'New Goal') : t('goals.editGoal', 'Edit Goal')}
+                                    {isNew
+                                        ? t('goals.newGoal', 'New Goal')
+                                        : t('goals.editGoal', 'Edit Goal')}
                                 </p>
                             </div>
 
@@ -222,7 +284,10 @@ const GoalDetails: React.FC = () => {
                                 value={formData.title ?? ''}
                                 onChange={handleChange}
                                 className="w-full text-3xl font-light bg-transparent text-gray-900 dark:text-gray-100 border-b border-gray-300 dark:border-gray-600 focus:outline-none focus:border-blue-500 pb-1"
-                                placeholder={t('forms.goalTitlePlaceholder', 'Goal title')}
+                                placeholder={t(
+                                    'forms.goalTitlePlaceholder',
+                                    'Goal title'
+                                )}
                             />
 
                             <div>
@@ -235,7 +300,10 @@ const GoalDetails: React.FC = () => {
                                     onChange={handleChange}
                                     rows={3}
                                     className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500 resize-none"
-                                    placeholder={t('forms.goalWhyPlaceholder', 'What will achieving this enable?')}
+                                    placeholder={t(
+                                        'forms.goalWhyPlaceholder',
+                                        'What will achieving this enable?'
+                                    )}
                                 />
                             </div>
 
@@ -250,8 +318,15 @@ const GoalDetails: React.FC = () => {
                                         onChange={handleChange}
                                         className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
                                     >
-                                        <option value="season">{t('goals.horizon.season', 'Season')}</option>
-                                        <option value="year">{t('goals.horizon.year', 'Year')}</option>
+                                        <option value="season">
+                                            {t(
+                                                'goals.horizon.season',
+                                                'Season'
+                                            )}
+                                        </option>
+                                        <option value="year">
+                                            {t('goals.horizon.year', 'Year')}
+                                        </option>
                                     </select>
                                 </div>
                                 <div>
@@ -264,10 +339,24 @@ const GoalDetails: React.FC = () => {
                                         onChange={handleChange}
                                         className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
                                     >
-                                        <option value="active">{t('goals.status.active', 'Active')}</option>
-                                        <option value="achieved">{t('goals.status.achieved', 'Achieved')}</option>
-                                        <option value="paused">{t('goals.status.paused', 'Paused')}</option>
-                                        <option value="dropped">{t('goals.status.dropped', 'Dropped')}</option>
+                                        <option value="active">
+                                            {t('goals.status.active', 'Active')}
+                                        </option>
+                                        <option value="achieved">
+                                            {t(
+                                                'goals.status.achieved',
+                                                'Achieved'
+                                            )}
+                                        </option>
+                                        <option value="paused">
+                                            {t('goals.status.paused', 'Paused')}
+                                        </option>
+                                        <option value="dropped">
+                                            {t(
+                                                'goals.status.dropped',
+                                                'Dropped'
+                                            )}
+                                        </option>
                                     </select>
                                 </div>
                             </div>
@@ -292,14 +381,18 @@ const GoalDetails: React.FC = () => {
                                 <ColorPicker
                                     value={formData.color || ''}
                                     onChange={(color) =>
-                                        setFormData((prev) => ({ ...prev, color: color || '' }))
+                                        setFormData((prev) => ({
+                                            ...prev,
+                                            color: color || '',
+                                        }))
                                     }
                                 />
                             </div>
 
                             <div>
                                 <label className="block text-xs font-medium text-gray-500 dark:text-gray-400 mb-1 uppercase tracking-wider">
-                                    {t('forms.goalArea', 'Area')} ({t('common.optional', 'optional')})
+                                    {t('forms.goalArea', 'Area')} (
+                                    {t('common.optional', 'optional')})
                                 </label>
                                 <select
                                     name="area_id"
@@ -307,7 +400,9 @@ const GoalDetails: React.FC = () => {
                                     onChange={handleChange}
                                     className="block w-full border border-gray-300 dark:border-gray-600 rounded-md shadow-sm py-2 px-3 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
                                 >
-                                    <option value="">{t('forms.noArea', 'No area')}</option>
+                                    <option value="">
+                                        {t('forms.noArea', 'No area')}
+                                    </option>
                                     {areas.map((area: any) => (
                                         <option key={area.id} value={area.id}>
                                             {area.name}
@@ -317,7 +412,9 @@ const GoalDetails: React.FC = () => {
                             </div>
 
                             {formError && (
-                                <div className="text-red-500 text-sm">{formError}</div>
+                                <div className="text-red-500 text-sm">
+                                    {formError}
+                                </div>
                             )}
 
                             <div className="flex items-center gap-3 pt-2">
@@ -329,8 +426,14 @@ const GoalDetails: React.FC = () => {
                                     {isSubmitting
                                         ? t('modals.submitting', 'Saving...')
                                         : isNew
-                                            ? t('modals.createGoal', 'Create Goal')
-                                            : t('modals.updateGoal', 'Update Goal')}
+                                          ? t(
+                                                'modals.createGoal',
+                                                'Create Goal'
+                                            )
+                                          : t(
+                                                'modals.updateGoal',
+                                                'Update Goal'
+                                            )}
                                 </button>
                                 <button
                                     onClick={handleCancelEdit}
@@ -350,49 +453,115 @@ const GoalDetails: React.FC = () => {
                                     {goal!.Area ? (
                                         <>
                                             <Link
-                                                to={`/area/${goal!.Area.uid}-${goal!.Area.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`}
+                                                to={`/area/${goal!.Area.uid}-${goal!.Area.name
+                                                    .toLowerCase()
+                                                    .replace(/[^a-z0-9]+/g, '-')
+                                                    .replace(/^-|-$/g, '')}`}
                                                 className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium transition-opacity hover:opacity-80 ${
-                                                    hasColor ? 'bg-white/20 text-white' : ''
+                                                    hasColor
+                                                        ? 'bg-white/20 text-white'
+                                                        : ''
                                                 }`}
-                                                style={!hasColor && goal!.Area.color ? { backgroundColor: goal!.Area.color + '33', color: goal!.Area.color } : {}}
+                                                style={
+                                                    !hasColor &&
+                                                    goal!.Area.color
+                                                        ? {
+                                                              backgroundColor:
+                                                                  goal!.Area
+                                                                      .color +
+                                                                  '33',
+                                                              color: goal!.Area
+                                                                  .color,
+                                                          }
+                                                        : {}
+                                                }
                                             >
-                                                {!hasColor && !goal!.Area.color && (
-                                                    <span className="w-2 h-2 rounded-full bg-gray-400 dark:bg-gray-500" />
-                                                )}
+                                                {!hasColor &&
+                                                    !goal!.Area.color && (
+                                                        <span className="w-2 h-2 rounded-full bg-gray-400 dark:bg-gray-500" />
+                                                    )}
                                                 {goal!.Area.name}
                                             </Link>
-                                            <span className={`text-xs ${hasColor ? 'text-white/40' : 'text-gray-300 dark:text-gray-600'}`}>/</span>
+                                            <span
+                                                className={`text-xs ${hasColor ? 'text-white/40' : 'text-gray-300 dark:text-gray-600'}`}
+                                            >
+                                                /
+                                            </span>
                                         </>
                                     ) : null}
                                     <div className="flex items-center gap-1.5">
-                                        <FlagIcon className={`h-3.5 w-3.5 ${hasColor ? 'text-white/70' : 'text-blue-500'}`} />
-                                        <p className={`text-xs font-medium uppercase tracking-widest ${hasColor ? 'text-white/60' : 'text-gray-400 dark:text-gray-500'}`}>
+                                        <FlagIcon
+                                            className={`h-3.5 w-3.5 ${hasColor ? 'text-white/70' : 'text-blue-500'}`}
+                                        />
+                                        <p
+                                            className={`text-xs font-medium uppercase tracking-widest ${hasColor ? 'text-white/60' : 'text-gray-400 dark:text-gray-500'}`}
+                                        >
                                             {t('goals.singular', 'Goal')}
                                         </p>
                                     </div>
                                 </div>
 
-                                <h1 className={`text-3xl font-light ${hasColor ? 'text-white' : 'text-gray-900 dark:text-gray-100'}`}>
+                                <h1
+                                    className={`text-3xl font-light ${hasColor ? 'text-white' : 'text-gray-900 dark:text-gray-100'}`}
+                                >
                                     {goal!.title}
                                 </h1>
                                 {goal!.why && (
-                                    <p className={`mt-2 text-sm italic ${hasColor ? 'text-white/80' : 'text-gray-500 dark:text-gray-400'}`}>
+                                    <p
+                                        className={`mt-2 text-sm italic ${hasColor ? 'text-white/80' : 'text-gray-500 dark:text-gray-400'}`}
+                                    >
                                         {goal!.why}
                                     </p>
                                 )}
-                                <div className={`mt-3 flex gap-4 text-xs ${hasColor ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'}`}>
-                                    <span>{t(`goals.status.${goal!.status}`, goal!.status)}</span>
-                                    <span>{t(`goals.horizon.${goal!.horizon}`, goal!.horizon)}</span>
+                                <div
+                                    className={`mt-3 flex gap-4 text-xs ${hasColor ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'}`}
+                                >
+                                    <span>
+                                        {t(
+                                            `goals.status.${goal!.status}`,
+                                            goal!.status
+                                        )}
+                                    </span>
+                                    <span>
+                                        {t(
+                                            `goals.horizon.${goal!.horizon}`,
+                                            goal!.horizon
+                                        )}
+                                    </span>
                                     {goal!.target_date && (
-                                        <span>{t('goals.targetDate', 'Target')}: {new Date(goal!.target_date).toLocaleDateString()}</span>
+                                        <span>
+                                            {t('goals.targetDate', 'Target')}:{' '}
+                                            {new Date(
+                                                goal!.target_date
+                                            ).toLocaleDateString()}
+                                        </span>
                                     )}
                                 </div>
-                                <div className={`mt-3 flex gap-4 text-xs ${hasColor ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'}`}>
-                                    <span>{tasks.length} {t('tasks.title', 'tasks')}</span>
-                                    <span>{goalProjects.length} {t('projects.title', 'projects')}</span>
+                                <div
+                                    className={`mt-3 flex gap-4 text-xs ${hasColor ? 'text-white/70' : 'text-gray-500 dark:text-gray-400'}`}
+                                >
+                                    <span>
+                                        {tasks.length}{' '}
+                                        {t('tasks.title', 'tasks')}
+                                    </span>
+                                    <span>
+                                        {goalProjects.length}{' '}
+                                        {t('projects.title', 'projects')}
+                                    </span>
                                 </div>
                             </div>
                             <div className="flex items-center gap-1 flex-shrink-0">
+                                <button
+                                    onClick={() => setIsShareModalOpen(true)}
+                                    className={`p-2 rounded-lg transition-colors ${
+                                        hasColor
+                                            ? 'text-white/80 hover:text-white hover:bg-white/10'
+                                            : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
+                                    }`}
+                                    title={t('shares.shareGoal', 'Share goal')}
+                                >
+                                    <ShareIcon className="h-5 w-5" />
+                                </button>
                                 <button
                                     onClick={() => setIsEditing(true)}
                                     className={`p-2 rounded-lg transition-colors ${
@@ -427,27 +596,45 @@ const GoalDetails: React.FC = () => {
                     {/* Projects section */}
                     <div>
                         <h3 className="text-lg font-light text-gray-700 dark:text-gray-300 mb-4">
-                            {t('projects.title', 'Projects')} ({goalProjects.length})
+                            {t('projects.title', 'Projects')} (
+                            {goalProjects.length})
                         </h3>
                         {goalProjects.length === 0 ? (
                             <p className="text-sm text-gray-400 dark:text-gray-500">
-                                {t('goals.noProjects', 'No projects linked to this goal.')}
+                                {t(
+                                    'goals.noProjects',
+                                    'No projects linked to this goal.'
+                                )}
                             </p>
                         ) : (
                             <div className="flex flex-col gap-2">
                                 {goalProjects.map((project) => (
                                     <Link
                                         key={project.uid ?? project.id}
-                                        to={project.uid ? createProjectUrl({ uid: project.uid, name: project.name }) : '/projects'}
+                                        to={
+                                            project.uid
+                                                ? createProjectUrl({
+                                                      uid: project.uid,
+                                                      name: project.name,
+                                                  })
+                                                : '/projects'
+                                        }
                                         className="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 hover:bg-white dark:hover:bg-gray-800 transition-colors group border-l-4"
-                                        style={{ borderLeftColor: (project as any).color || '#6366f1' }}
+                                        style={{
+                                            borderLeftColor:
+                                                (project as any).color ||
+                                                '#6366f1',
+                                        }}
                                     >
                                         <span className="text-sm font-medium text-gray-800 dark:text-gray-200 truncate flex-1 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
                                             {project.name}
                                         </span>
                                         {project.status && (
                                             <span className="text-xs text-gray-400 dark:text-gray-500 flex-shrink-0">
-                                                {project.status.replace('_', ' ')}
+                                                {project.status.replace(
+                                                    '_',
+                                                    ' '
+                                                )}
                                             </span>
                                         )}
                                     </Link>
@@ -463,7 +650,10 @@ const GoalDetails: React.FC = () => {
                         </h3>
                         {tasks.length === 0 ? (
                             <p className="text-sm text-gray-400 dark:text-gray-500">
-                                {t('goals.noTasks', 'No tasks assigned to this goal.')}
+                                {t(
+                                    'goals.noTasks',
+                                    'No tasks assigned to this goal.'
+                                )}
                             </p>
                         ) : (
                             <div className="space-y-6">
@@ -478,7 +668,8 @@ const GoalDetails: React.FC = () => {
                                 {completedTasks.length > 0 && (
                                     <div>
                                         <h4 className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-3">
-                                            {t('tasks.completed', 'Completed')} ({completedTasks.length})
+                                            {t('tasks.completed', 'Completed')}{' '}
+                                            ({completedTasks.length})
                                         </h4>
                                         <TaskList
                                             tasks={completedTasks}
@@ -503,6 +694,14 @@ const GoalDetails: React.FC = () => {
                     onCancel={() => setIsConfirmDeleteOpen(false)}
                 />
             )}
+
+            <ShareModal
+                isOpen={isShareModalOpen}
+                onClose={() => setIsShareModalOpen(false)}
+                resourceType="goal"
+                resourceUid={goal?.uid || null}
+                resourceName={goal?.title}
+            />
         </div>
     );
 };

--- a/frontend/components/Notifications/NotificationsDropdown.tsx
+++ b/frontend/components/Notifications/NotificationsDropdown.tsx
@@ -209,12 +209,19 @@ const NotificationsDropdown: React.FC<NotificationsDropdownProps> = ({
             }
             if (
                 answer === 'accept' &&
-                notification.data?.resourceType === 'project' &&
+                notification.data?.resourceType &&
                 notification.data?.resourceUid
             ) {
+                const { resourceType, resourceUid } = notification.data;
                 await loadProjects();
                 setIsOpen(false);
-                navigate(`/project/${notification.data.resourceUid}`);
+                if (resourceType === 'project') {
+                    navigate(`/project/${resourceUid}`);
+                } else if (resourceType === 'area' || resourceType === 'goal') {
+                    // The area/goal container is not listed for collaborators;
+                    // its shared projects show up on the Projects page.
+                    navigate('/projects');
+                }
             }
         } catch (error) {
             console.error('Error answering share invitation:', error);

--- a/frontend/components/Profile/tabs/NotificationsTab.tsx
+++ b/frontend/components/Profile/tabs/NotificationsTab.tsx
@@ -28,6 +28,7 @@ const DEFAULT_PREFERENCES: NotificationPreferences = {
         telegram: false,
     },
     deferUntil: { inApp: true, email: false, push: false, telegram: false },
+    taskAssigned: { inApp: true, email: false, push: false, telegram: false },
 };
 
 interface NotificationTypeRowProps {
@@ -319,6 +320,22 @@ const NotificationsTab: React.FC<NotificationsTabProps> = ({
                             preferences={preferences.deferUntil}
                             onToggle={(channel, value) =>
                                 handleToggle('deferUntil', channel, value)
+                            }
+                            telegramConfigured={telegramConfigured}
+                        />
+                        <NotificationTypeRow
+                            icon={BellIcon}
+                            label={t(
+                                'notifications.types.taskAssigned',
+                                'Task Assigned'
+                            )}
+                            description={t(
+                                'notifications.descriptions.taskAssigned',
+                                'A task was assigned to you by someone else'
+                            )}
+                            preferences={preferences.taskAssigned}
+                            onToggle={(channel, value) =>
+                                handleToggle('taskAssigned', channel, value)
                             }
                             telegramConfigured={telegramConfigured}
                         />

--- a/frontend/components/Profile/types.ts
+++ b/frontend/components/Profile/types.ts
@@ -67,6 +67,12 @@ export interface NotificationPreferences {
         push: boolean;
         telegram: boolean;
     };
+    taskAssigned: {
+        inApp: boolean;
+        email: boolean;
+        push: boolean;
+        telegram: boolean;
+    };
 }
 
 export interface Profile {

--- a/frontend/components/Project/ProjectShareModal.tsx
+++ b/frontend/components/Project/ProjectShareModal.tsx
@@ -1,14 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import React, { useMemo } from 'react';
 import { Project } from '../../entities/Project';
-import {
-    AccessLevel,
-    ListSharesResponseRow,
-    grantShare,
-    listShares,
-    revokeShare,
-} from '../../utils/sharesService';
-import { getCurrentUser } from '../../utils/userUtils';
+import ShareModal from '../Shared/ShareModal';
 
 interface ProjectShareModalProps {
     isOpen: boolean;
@@ -16,262 +8,23 @@ interface ProjectShareModalProps {
     project: Project;
 }
 
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
 const ProjectShareModal: React.FC<ProjectShareModalProps> = ({
     isOpen,
     onClose,
     project,
 }) => {
-    const { t } = useTranslation();
-    const [email, setEmail] = useState('');
-    const [access, setAccess] = useState<AccessLevel>('ro');
-    const [submitting, setSubmitting] = useState(false);
-    const [error, setError] = useState<string | null>(null);
-    const [notice, setNotice] = useState<string | null>(null);
-    const [rows, setRows] = useState<ListSharesResponseRow[] | null>(null);
-    const [loadingList, setLoadingList] = useState(false);
-    const currentUser = getCurrentUser();
-
     const projectUid: string | null = useMemo(() => {
         return (project as any).uid || null;
     }, [project]);
 
-    const refreshShares = async (uid: string) => {
-        setLoadingList(true);
-        try {
-            const data = await listShares('project', uid);
-            setRows(data);
-        } catch (err: any) {
-            setError(err.message || 'Failed to load shares');
-            setRows([]);
-        } finally {
-            setLoadingList(false);
-        }
-    };
-
-    useEffect(() => {
-        if (!isOpen) return;
-        setEmail('');
-        setAccess('ro');
-        setError(null);
-        setNotice(null);
-
-        if (!projectUid) return;
-        refreshShares(projectUid);
-    }, [isOpen, projectUid]);
-
-    if (!isOpen) return null;
-
-    const onSubmit = async (e: React.FormEvent) => {
-        e.preventDefault();
-        setError(null);
-        setNotice(null);
-        if (!projectUid) {
-            setError(t('errors.generic', 'Something went wrong'));
-            return;
-        }
-
-        const trimmed = email.trim().toLowerCase();
-        if (!EMAIL_PATTERN.test(trimmed)) {
-            setError(t('shares.invalidEmail', 'Enter a valid email address'));
-            return;
-        }
-        if (currentUser && trimmed === currentUser.email?.toLowerCase()) {
-            setError(
-                t(
-                    'shares.cannotShareWithSelf',
-                    'You already have full access to this project'
-                )
-            );
-            return;
-        }
-
-        setSubmitting(true);
-        try {
-            await grantShare({
-                resource_type: 'project',
-                resource_uid: projectUid,
-                target_user_email: trimmed,
-                access_level: access,
-            });
-            setEmail('');
-            setNotice(t('shares.invitationSent', 'Invitation sent.'));
-            await refreshShares(projectUid);
-        } catch (err: any) {
-            setError(err.message || 'Failed to share');
-        } finally {
-            setSubmitting(false);
-        }
-    };
-
-    const onRevoke = async (userId: number) => {
-        if (!projectUid) return;
-        try {
-            await revokeShare('project', projectUid, userId);
-            await refreshShares(projectUid);
-        } catch (err: any) {
-            setError(err.message || 'Failed to revoke share');
-        }
-    };
-
-    const accessLabel = (al: AccessLevel | 'owner') =>
-        al === 'owner'
-            ? t('shares.owner', 'Owner')
-            : al === 'rw'
-              ? t('shares.readWrite', 'Read & write')
-              : t('shares.readOnly', 'Read only');
-
     return (
-        <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900 bg-opacity-80"
-            onClick={onClose}
-        >
-            <div
-                className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md"
-                onClick={(e) => e.stopPropagation()}
-            >
-                <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-                        {t('shares.shareProject', 'Share project')}
-                    </h3>
-                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">
-                        {project?.name}
-                    </p>
-                </div>
-                <form onSubmit={onSubmit} className="px-6 py-4 space-y-4">
-                    <div>
-                        <label
-                            htmlFor="share-email"
-                            className="block text-sm text-gray-700 dark:text-gray-300 mb-1"
-                        >
-                            {t('shares.targetUser', 'Invite by email')}
-                        </label>
-                        <input
-                            id="share-email"
-                            type="email"
-                            autoComplete="off"
-                            value={email}
-                            onChange={(e) => setEmail(e.target.value)}
-                            placeholder={t(
-                                'shares.emailPlaceholder',
-                                'name@example.com'
-                            )}
-                            className="w-full rounded border px-3 py-2 bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                        />
-                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                            {t(
-                                'shares.inviteHint',
-                                'They will get an invitation and see the project after accepting.'
-                            )}
-                        </p>
-                    </div>
-                    <div>
-                        <label className="block text-sm text-gray-700 dark:text-gray-300 mb-1">
-                            {t('shares.permission', 'Permission')}
-                        </label>
-                        <select
-                            value={access}
-                            onChange={(e) =>
-                                setAccess(e.target.value as AccessLevel)
-                            }
-                            className="w-full rounded border px-3 py-2 bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
-                        >
-                            <option value="ro">
-                                {t('shares.readOnly', 'Read only')}
-                            </option>
-                            <option value="rw">
-                                {t('shares.readWrite', 'Read & write')}
-                            </option>
-                        </select>
-                    </div>
-                    {error && (
-                        <div className="text-sm text-red-500">{error}</div>
-                    )}
-                    {notice && (
-                        <div className="text-sm text-green-600 dark:text-green-400">
-                            {notice}
-                        </div>
-                    )}
-                    <div className="flex justify-end space-x-2 pt-2">
-                        <button
-                            type="button"
-                            onClick={onClose}
-                            className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200"
-                        >
-                            {t('common.close', 'Close')}
-                        </button>
-                        <button
-                            type="submit"
-                            disabled={submitting || !email.trim()}
-                            className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-60"
-                        >
-                            {submitting
-                                ? t('common.saving', 'Saving...')
-                                : t('shares.share', 'Share')}
-                        </button>
-                    </div>
-                </form>
-                <div className="px-6 pb-5">
-                    <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                        {t('shares.currentShares', 'Users with access')}
-                    </div>
-                    <div className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-md max-h-56 overflow-auto">
-                        {loadingList ? (
-                            <div className="p-3 text-sm text-gray-500">
-                                {t('common.loading', 'Loading...')}
-                            </div>
-                        ) : !rows || rows.length === 0 ? (
-                            <div className="p-3 text-sm text-gray-500">
-                                {t('shares.noShares', 'Not shared yet')}
-                            </div>
-                        ) : (
-                            <ul className="divide-y divide-gray-200 dark:divide-gray-700">
-                                {rows.map((r) => (
-                                    <li
-                                        key={`${r.user_id}-${r.created_at || 'owner'}`}
-                                        className="flex items-center justify-between px-3 py-2"
-                                    >
-                                        <div>
-                                            <div
-                                                className={`text-sm ${r.is_owner ? 'font-semibold' : ''} text-gray-900 dark:text-gray-100`}
-                                            >
-                                                {r.email || `#${r.user_id}`}
-                                            </div>
-                                            <div className="text-xs text-gray-500">
-                                                {accessLabel(r.access_level)}
-                                                {r.status === 'pending' && (
-                                                    <span className="ml-2 px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200 dark:bg-transparent dark:text-amber-400 dark:border-amber-500">
-                                                        {t(
-                                                            'shares.pending',
-                                                            'Pending'
-                                                        )}
-                                                    </span>
-                                                )}
-                                            </div>
-                                        </div>
-                                        {r.is_owner ? (
-                                            <span className="px-2 py-1 text-xs rounded bg-blue-50 text-blue-600 border border-blue-200 dark:bg-transparent dark:text-blue-400 dark:border-blue-500">
-                                                {t('shares.owner', 'Owner')}
-                                            </span>
-                                        ) : (
-                                            <button
-                                                onClick={() =>
-                                                    onRevoke(r.user_id)
-                                                }
-                                                className="px-2 py-1 text-xs rounded bg-red-50 text-red-600 border border-red-200 hover:bg-red-100 dark:bg-transparent dark:text-red-400 dark:border-red-500"
-                                            >
-                                                {t('shares.revoke', 'Revoke')}
-                                            </button>
-                                        )}
-                                    </li>
-                                ))}
-                            </ul>
-                        )}
-                    </div>
-                </div>
-            </div>
-        </div>
+        <ShareModal
+            isOpen={isOpen}
+            onClose={onClose}
+            resourceType="project"
+            resourceUid={projectUid}
+            resourceName={project?.name}
+        />
     );
 };
 

--- a/frontend/components/Shared/ShareModal.tsx
+++ b/frontend/components/Shared/ShareModal.tsx
@@ -1,0 +1,294 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+    AccessLevel,
+    ListSharesResponseRow,
+    ShareGrantRequest,
+    grantShare,
+    listShares,
+    revokeShare,
+} from '../../utils/sharesService';
+import { getCurrentUser } from '../../utils/userUtils';
+
+export type ShareResourceType = ShareGrantRequest['resource_type'];
+
+interface ShareModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    resourceType: ShareResourceType;
+    resourceUid: string | null;
+    resourceName?: string | null;
+}
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const TITLE_KEYS: Record<string, { key: string; fallback: string }> = {
+    project: { key: 'shares.shareProject', fallback: 'Share project' },
+    area: { key: 'shares.shareArea', fallback: 'Share area' },
+    goal: { key: 'shares.shareGoal', fallback: 'Share goal' },
+    note: { key: 'shares.shareNote', fallback: 'Share note' },
+    task: { key: 'shares.shareTask', fallback: 'Share task' },
+};
+
+const ShareModal: React.FC<ShareModalProps> = ({
+    isOpen,
+    onClose,
+    resourceType,
+    resourceUid,
+    resourceName,
+}) => {
+    const { t } = useTranslation();
+    const [email, setEmail] = useState('');
+    const [access, setAccess] = useState<AccessLevel>('ro');
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [notice, setNotice] = useState<string | null>(null);
+    const [rows, setRows] = useState<ListSharesResponseRow[] | null>(null);
+    const [loadingList, setLoadingList] = useState(false);
+    const currentUser = getCurrentUser();
+
+    const refreshShares = async (uid: string) => {
+        setLoadingList(true);
+        try {
+            const data = await listShares(resourceType, uid);
+            setRows(data);
+        } catch (err: any) {
+            setError(err.message || 'Failed to load shares');
+            setRows([]);
+        } finally {
+            setLoadingList(false);
+        }
+    };
+
+    useEffect(() => {
+        if (!isOpen) return;
+        setEmail('');
+        setAccess('ro');
+        setError(null);
+        setNotice(null);
+        if (!resourceUid) return;
+        refreshShares(resourceUid);
+    }, [isOpen, resourceUid, resourceType]);
+
+    if (!isOpen) return null;
+
+    const title = TITLE_KEYS[resourceType] || {
+        key: 'shares.share',
+        fallback: 'Share',
+    };
+
+    const onSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError(null);
+        setNotice(null);
+        if (!resourceUid) {
+            setError(t('errors.generic', 'Something went wrong'));
+            return;
+        }
+
+        const trimmed = email.trim().toLowerCase();
+        if (!EMAIL_PATTERN.test(trimmed)) {
+            setError(t('shares.invalidEmail', 'Enter a valid email address'));
+            return;
+        }
+        if (currentUser && trimmed === currentUser.email?.toLowerCase()) {
+            setError(
+                t(
+                    'shares.cannotShareWithSelf',
+                    'You already have full access to this'
+                )
+            );
+            return;
+        }
+
+        setSubmitting(true);
+        try {
+            await grantShare({
+                resource_type: resourceType,
+                resource_uid: resourceUid,
+                target_user_email: trimmed,
+                access_level: access,
+            });
+            setEmail('');
+            setNotice(t('shares.invitationSent', 'Invitation sent.'));
+            await refreshShares(resourceUid);
+        } catch (err: any) {
+            setError(err.message || 'Failed to share');
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const onRevoke = async (userId: number) => {
+        if (!resourceUid) return;
+        try {
+            await revokeShare(resourceType, resourceUid, userId);
+            await refreshShares(resourceUid);
+        } catch (err: any) {
+            setError(err.message || 'Failed to revoke share');
+        }
+    };
+
+    const accessLabel = (al: AccessLevel | 'owner') =>
+        al === 'owner'
+            ? t('shares.owner', 'Owner')
+            : al === 'rw'
+              ? t('shares.readWrite', 'Read & write')
+              : t('shares.readOnly', 'Read only');
+
+    return (
+        <div
+            className="fixed inset-0 z-50 flex items-center justify-center bg-gray-900 bg-opacity-80"
+            onClick={onClose}
+        >
+            <div
+                className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-md"
+                onClick={(e) => e.stopPropagation()}
+            >
+                <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
+                        {t(title.key, title.fallback)}
+                    </h3>
+                    {resourceName && (
+                        <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">
+                            {resourceName}
+                        </p>
+                    )}
+                </div>
+                <form onSubmit={onSubmit} className="px-6 py-4 space-y-4">
+                    <div>
+                        <label
+                            htmlFor="share-email"
+                            className="block text-sm text-gray-700 dark:text-gray-300 mb-1"
+                        >
+                            {t('shares.targetUser', 'Invite by email')}
+                        </label>
+                        <input
+                            id="share-email"
+                            type="email"
+                            autoComplete="off"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            placeholder={t(
+                                'shares.emailPlaceholder',
+                                'name@example.com'
+                            )}
+                            className="w-full rounded border px-3 py-2 bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        />
+                        <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                            {t(
+                                'shares.inviteHint',
+                                'They will get an invitation and see it after accepting.'
+                            )}
+                        </p>
+                    </div>
+                    <div>
+                        <label className="block text-sm text-gray-700 dark:text-gray-300 mb-1">
+                            {t('shares.permission', 'Permission')}
+                        </label>
+                        <select
+                            value={access}
+                            onChange={(e) =>
+                                setAccess(e.target.value as AccessLevel)
+                            }
+                            className="w-full rounded border px-3 py-2 bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100"
+                        >
+                            <option value="ro">
+                                {t('shares.readOnly', 'Read only')}
+                            </option>
+                            <option value="rw">
+                                {t('shares.readWrite', 'Read & write')}
+                            </option>
+                        </select>
+                    </div>
+                    {error && (
+                        <div className="text-sm text-red-500">{error}</div>
+                    )}
+                    {notice && (
+                        <div className="text-sm text-green-600 dark:text-green-400">
+                            {notice}
+                        </div>
+                    )}
+                    <div className="flex justify-end space-x-2 pt-2">
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700 text-gray-800 dark:text-gray-200"
+                        >
+                            {t('common.close', 'Close')}
+                        </button>
+                        <button
+                            type="submit"
+                            disabled={submitting || !email.trim()}
+                            className="px-4 py-2 rounded bg-blue-600 text-white disabled:opacity-60"
+                        >
+                            {submitting
+                                ? t('common.saving', 'Saving...')
+                                : t('shares.share', 'Share')}
+                        </button>
+                    </div>
+                </form>
+                <div className="px-6 pb-5">
+                    <div className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                        {t('shares.currentShares', 'Users with access')}
+                    </div>
+                    <div className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-md max-h-56 overflow-auto">
+                        {loadingList ? (
+                            <div className="p-3 text-sm text-gray-500">
+                                {t('common.loading', 'Loading...')}
+                            </div>
+                        ) : !rows || rows.length === 0 ? (
+                            <div className="p-3 text-sm text-gray-500">
+                                {t('shares.noShares', 'Not shared yet')}
+                            </div>
+                        ) : (
+                            <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+                                {rows.map((r) => (
+                                    <li
+                                        key={`${r.user_id}-${r.created_at || 'owner'}`}
+                                        className="flex items-center justify-between px-3 py-2"
+                                    >
+                                        <div>
+                                            <div
+                                                className={`text-sm ${r.is_owner ? 'font-semibold' : ''} text-gray-900 dark:text-gray-100`}
+                                            >
+                                                {r.email || `#${r.user_id}`}
+                                            </div>
+                                            <div className="text-xs text-gray-500">
+                                                {accessLabel(r.access_level)}
+                                                {r.status === 'pending' && (
+                                                    <span className="ml-2 px-1.5 py-0.5 rounded bg-amber-50 text-amber-700 border border-amber-200 dark:bg-transparent dark:text-amber-400 dark:border-amber-500">
+                                                        {t(
+                                                            'shares.pending',
+                                                            'Pending'
+                                                        )}
+                                                    </span>
+                                                )}
+                                            </div>
+                                        </div>
+                                        {r.is_owner ? (
+                                            <span className="px-2 py-1 text-xs rounded bg-blue-50 text-blue-600 border border-blue-200 dark:bg-transparent dark:text-blue-400 dark:border-blue-500">
+                                                {t('shares.owner', 'Owner')}
+                                            </span>
+                                        ) : (
+                                            <button
+                                                onClick={() =>
+                                                    onRevoke(r.user_id)
+                                                }
+                                                className="px-2 py-1 text-xs rounded bg-red-50 text-red-600 border border-red-200 hover:bg-red-100 dark:bg-transparent dark:text-red-400 dark:border-red-500"
+                                            >
+                                                {t('shares.revoke', 'Revoke')}
+                                            </button>
+                                        )}
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ShareModal;

--- a/frontend/components/Sidebar/SidebarNav.tsx
+++ b/frontend/components/Sidebar/SidebarNav.tsx
@@ -7,6 +7,7 @@ import {
     ListBulletIcon,
     ClockIcon,
     CalendarIcon,
+    UserIcon,
 } from '@heroicons/react/24/outline';
 import { useStore } from '../../store/useStore';
 import { loadInboxItemsToStore } from '../../utils/inboxService';
@@ -24,7 +25,9 @@ const SidebarNav: React.FC<SidebarNavProps> = ({
 }) => {
     const { t } = useTranslation();
     const store = useStore();
-    const calendarEnabled = useStore((state) => state.userSettingsStore.calendarEnabled);
+    const calendarEnabled = useStore(
+        (state) => state.userSettingsStore.calendarEnabled
+    );
 
     const inboxItemsCount = store.inboxStore.pagination.total;
 
@@ -61,6 +64,12 @@ const SidebarNav: React.FC<SidebarNavProps> = ({
             icon: <ListBulletIcon className="h-[15px] w-[15px]" />,
             query: 'status=active',
         },
+        {
+            path: '/tasks?assigned_to=me&status=active',
+            title: t('sidebar.assignedToMe', 'Assigned to me'),
+            icon: <UserIcon className="h-[15px] w-[15px]" />,
+            query: 'assigned_to=me',
+        },
     ];
 
     const navLinks = allNavLinks.filter((link) => {
@@ -83,8 +92,16 @@ const SidebarNav: React.FC<SidebarNavProps> = ({
             return location.pathname === '/upcoming';
         }
         const isPathMatch = location.pathname === '/tasks';
-        const isQueryMatch = query ? location.search.includes(query) : location.search === '';
-        return isPathMatch && isQueryMatch;
+        if (!isPathMatch) return false;
+        const hasAssignedToMe = location.search.includes('assigned_to=me');
+        // "Assigned to me" and "All Tasks" both live at /tasks; disambiguate on
+        // the assigned_to marker so only one highlights.
+        if (query === 'assigned_to=me') return hasAssignedToMe;
+        if (query === 'status=active' && hasAssignedToMe) return false;
+        const isQueryMatch = query
+            ? location.search.includes(query)
+            : location.search === '';
+        return isQueryMatch;
     };
 
     const isActive = (path: string, query?: string) =>
@@ -95,14 +112,20 @@ const SidebarNav: React.FC<SidebarNavProps> = ({
             {navLinks.map((link) => (
                 <li key={link.path}>
                     <button
-                        onClick={() => handleNavClick(link.path, link.title, link.icon)}
+                        onClick={() =>
+                            handleNavClick(link.path, link.title, link.icon)
+                        }
                         data-testid={`sidebar-nav-${link.path.replace(/^\//, '').replace(/\?.*$/, '')}`}
                         className={`w-full flex items-center gap-[5px] px-[10px] py-[4px] rounded-[8px] transition-colors duration-150 ${isActive(link.path, link.query)}`}
                     >
-                        <span className={`flex-shrink-0 ${isActiveLink(link.path, link.query) ? 'text-blue-600 dark:text-[oklch(68%_0.14_250)]' : 'text-gray-400 dark:text-[oklch(55%_0.006_95)]'}`}>
+                        <span
+                            className={`flex-shrink-0 ${isActiveLink(link.path, link.query) ? 'text-blue-600 dark:text-[oklch(68%_0.14_250)]' : 'text-gray-400 dark:text-[oklch(55%_0.006_95)]'}`}
+                        >
                             {link.icon}
                         </span>
-                        <span className="flex-1 text-left text-[13.5px]">{link.title}</span>
+                        <span className="flex-1 text-left text-[13.5px]">
+                            {link.title}
+                        </span>
                         {link.path === '/inbox' && inboxItemsCount > 0 && (
                             <span className="text-[12px] text-gray-400 dark:text-[oklch(60%_0.01_250)]">
                                 {inboxItemsCount > 99 ? '99+' : inboxItemsCount}

--- a/frontend/utils/sharesService.ts
+++ b/frontend/utils/sharesService.ts
@@ -4,7 +4,7 @@ import { getCsrfToken } from './csrfService';
 export type AccessLevel = 'ro' | 'rw';
 
 export interface ShareGrantRequest {
-    resource_type: 'project' | 'task' | 'note' | 'area' | 'tag';
+    resource_type: 'project' | 'task' | 'note' | 'area' | 'goal' | 'tag';
     resource_uid: string;
     target_user_email: string;
     access_level: AccessLevel;

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -73,7 +73,8 @@
     "boards": "Boards",
     "bookmarks": "Favorites",
     "reports": "Reports",
-    "productivityAssistant": "Productivity Assistant"
+    "productivityAssistant": "Productivity Assistant",
+    "assignedToMe": "Assigned to me"
   },
   "navigation": {
     "home": "Home",
@@ -1548,7 +1549,10 @@
       "empty": "Nobody has signed up yet",
       "noMatches": "No addresses match that search",
       "showing": "{{from}}-{{to}} of {{total}}"
-    }
+    },
+    "passwordInviteHint": "Leave blank to send an invitation email",
+    "invitationSent": "Invitation email sent to {{email}}",
+    "invitationNotSent": "Account created, but email is disabled - set a password for this user manually."
   },
   "billing": {
     "title": "Plan & Billing",
@@ -1619,7 +1623,11 @@
     "noShares": "Not shared yet",
     "noAvailableUsers": "No users available to share with",
     "shared": "Shared",
-    "sharedWithTeam": "Shared with the team"
+    "sharedWithTeam": "Shared with the team",
+    "shareArea": "Share area",
+    "shareGoal": "Share goal",
+    "shareNote": "Share note",
+    "shareTask": "Share task"
   },
   "views": {
     "title": "Smart Views",
@@ -1755,14 +1763,16 @@
       "overdueTasks": "Overdue Tasks",
       "deferUntil": "Defer Until",
       "dueProjects": "Due Projects",
-      "overdueProjects": "Overdue Projects"
+      "overdueProjects": "Overdue Projects",
+      "taskAssigned": "Task Assigned"
     },
     "descriptions": {
       "dueTasks": "Tasks that are due within 24 hours",
       "overdueTasks": "Tasks that have passed their due date",
       "deferUntil": "Tasks that are now available to work on",
       "dueProjects": "Projects that are due within 24 hours",
-      "overdueProjects": "Projects that have passed their due date"
+      "overdueProjects": "Projects that have passed their due date",
+      "taskAssigned": "A task was assigned to you by someone else"
     },
     "telegram": {
       "notConfigured": {


### PR DESCRIPTION
## Description

Phase A of multi-person support for tududi. Closes three gaps that block a two-parents-plus-kids (or any small team) workflow:

1. **Areas and Goals could not be shared** - `calculateAreaPerms` was a `// TODO` no-op and Goals were not wired into sharing at all, so sharing "Home" meant sharing each project inside it one by one and re-sharing every new one.
2. **Task assignment was cosmetic** - `assigned_to` was stored but never notified the assignee, never granted access, and never surfaced the task in their lists.
3. **No member onboarding** - an admin who created an account set the password directly with no email; the member got no login link and no way to set their own password.

### Shareable Areas and Goals
- Implemented `calculateAreaPerms` + new `calculateGoalPerms`: a grant writes a `direct` row on the area/goal and `inherited` rows on its projects and their task/note subtrees, through the existing invite-and-accept `Permission` flow. Shared subtree logic factored into `projectSubtreeChanges` / `collectTaskSubtree` helpers (this is why `permissionsCalculators.js` has a large diff).
- `getAccess` gains `area`/`goal` branches; `SHAREABLE_TYPES`, `RESOURCE_MODELS` and `execAction` owner models extended.
- New `services/containerShareSync.js`: when a project is created in or moved into a shared area/goal, its collaborators are mirrored onto the project, copying the container grant's `status` and `source_action_id` so a still-pending invite does not leak new projects and accept/decline still moves the whole set.
- The Area container itself stays with its owner (not listed for collaborators); the collaborator sees the shared projects and files them under their own area via the existing `UserProjectArea`.
- Frontend: `ProjectShareModal` generalised into `Shared/ShareModal`, Share buttons on the Area and Goal detail pages, area/goal handling in the notification accept flow.

### Real task assignment
- `ownershipOrPermissionWhere('task')` and `getAccess('task')` now surface and grant `rw` on any task assigned to the caller's linked person, everywhere (Today, Upcoming, All Tasks, the task page).
- `notifyAssignee` emits a `task_assigned` notification (new `taskAssigned` preference key, backfill migration, Profile toggle) when the assignee is a linked account other than the actor.
- `assigned_to=me` query param resolves to the caller's self-person; new "Assigned to me" sidebar link. `assigned_to` added to the recurring template-fields list.

### Member invite email
- Admin user create with no password: the account is created unverified with no password and an email with a set-password link is sent (reuses the password-reset token infra, new `buildInviteEmail`, `INVITE_TOKEN_EXPIRY_HOURS` default 168). Using the link sets the password and verifies the email. The response carries `invited` and `email_sent`; unlike registration the account is kept even if email is disabled.
- Admin form: password optional for new users with an invite hint, outcome toasted.

## Type of Change

- [x] New feature (adds functionality)
- [x] Documentation/Translation update

## Related Issues

n/a

## Testing

**How did you test this?**

- New backend tests: area/goal cascade + auto-grant + pending-leak cases in `shares-consent.test.js`; new `task-assignment.test.js` (surface + notify + preference + self-assign); new `admin-user-invite.test.js` (invite creates inert account, emailed token sets password and logs in, password-supplied path unchanged); `getAccess`/`ownershipOrPermissionWhere` area/goal/assignee unit cases.
- All directly-affected suites pass serially (`--runInBand`, 14 suites / 130 tests). `npm run lint`, `npm run build` and frontend `tsc --noEmit` clean.
- Manual: admin creates a member with no password, the logged link sets a password and logs in; owner shares "Home", member accepts, the Home projects/tasks appear for the member; owner adds a project to Home and it appears with no further action; owner assigns a task to the member, who gets a notification and sees it under "Assigned to me".
- Note: `tests/integration/recurring-tasks.test.js` "weekly completion_based recurrence" fails on this branch **and on pristine `main`** - pre-existing, unrelated.

- [ ] `npm run pre-push` passes (lint-staged ran; the full pre-release suite was not run)

## Checklist

- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, docs, migrations, and translations updated (English translation keys added; other locales left for the translation pass)

## Additional Notes

- `SidebarNav.tsx`, `AreaDetails.tsx`, `GoalDetails.tsx` show larger diffs than the logic changes because `lint-staged`/prettier reformatted them whole-file (they were already drifted from the prettier config).
- The Area/Goal container is intentionally not shown to collaborators in this phase; only its projects/tasks. Full container visibility is a later phase.
