### PR TITLE
fix(telegram): leave summary message escaped and check API call result

### DIFF
--- a/backend/modules/tasks/taskSummaryService.js
+++ b/backend/modules/tasks/taskSummaryService.js
@@ -294,16 +294,10 @@ const sendSummaryToUser = async (userId) => {
         const summary = await generateSummaryForUser(userId);
         if (!summary) return false;
 
-        // Strip MarkdownV2 escape sequences and send as plain text to avoid
-        // double-send if Telegram accepts the message but the HTTP response is lost
-        const plainSummary = summary.replace(
-            /\\([_*\[\]()~`>#+\-=|{}.!\\])/g,
-            '$1'
-        );
         await sendTelegramMessage(
             user.telegram_bot_token,
             user.telegram_chat_id,
-            plainSummary
+            summary
         );
 
         // Update tracking fields

--- a/backend/modules/telegram/telegramPoller.js
+++ b/backend/modules/telegram/telegramPoller.js
@@ -152,7 +152,15 @@ const makeHttpGetRequest = (url, timeout = 5000) => {
                 res.on('end', () => {
                     try {
                         const response = JSON.parse(data);
-                        resolve(response);
+                        if (response.ok) {
+                            resolve(response);
+                        } else {
+                            reject(
+                                new Error(
+                                    `Telegram error ${response.error_code}: ${response.description}`
+                                )
+                            );
+                        }
                     } catch (error) {
                         reject(error);
                     }
@@ -176,7 +184,15 @@ const makeHttpPostRequest = (url, postData, options) => {
             res.on('end', () => {
                 try {
                     const response = JSON.parse(data);
-                    resolve(response);
+                    if (response.ok) {
+                        resolve(response);
+                    } else {
+                        reject(
+                            new Error(
+                                `Telegram error ${response.error_code}: ${response.description}`
+                            )
+                        );
+                    }
                 } catch (error) {
                     reject(error);
                 }

--- a/backend/tests/unit/services/telegramPoller.test.js
+++ b/backend/tests/unit/services/telegramPoller.test.js
@@ -215,7 +215,7 @@ describe('Multiple Telegram Allowed Users', () => {
             // Simulate successful response
             const mockResponse = {
                 on: jest.fn((event, handler) => {
-                    if (event === 'data') handler(JSON.stringify({}));
+                    if (event === 'data') handler(JSON.stringify({ ok: true }));
                     if (event === 'end') handler();
                     return mockResponse;
                 }),


### PR DESCRIPTION
<!--
Thank you for contributing to tududi!

Before submitting:
1. Read the Contributing Guide: https://github.com/chrisvel/tududi/blob/main/.github/CONTRIBUTING.md
2. Run: npm run pre-push (linting, formatting, tests)
3. Fill out the sections below and check all applicable boxes (replace [ ] with [x])
4. Delete sections that don't apply
-->

## Description

- Don't strip escape sequences from the task summary message before sending it to Telegram API, else the call fails.

- Inspect JSON object returned by Telegram API and fail the call if an error is returned. Previously the object was ignored and failing calls were incorrectly treated as successful.

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Breaking change (breaks existing functionality)
- [ ] Documentation/Translation update

## Related Issues

Fixes #1524

## Testing

**How did you test this?**

Ran `npm test`, manually tested on my Tududi instance.

- [x] `npm run pre-push` passes

## Checklist

- [x] This is not an AI slop crap, I know what I am doing
- [x] Self-reviewed my own code, follows project style guidelines
- [x] Tests, ~docs~, ~migrations~, and ~translations~ updated (if applicable)

## Additional Notes


